### PR TITLE
Remove template paramter comp 

### DIFF
--- a/include/meltpooldg/advection_diffusion/advection_diffusion_operation.hpp
+++ b/include/meltpooldg/advection_diffusion/advection_diffusion_operation.hpp
@@ -21,7 +21,7 @@ namespace MeltPoolDG
   {
     using namespace dealii;
 
-    template <unsigned int dim>
+    template <int dim>
     class AdvectionDiffusionOperation
     {
     private:

--- a/include/meltpooldg/advection_diffusion/advection_diffusion_operation.hpp
+++ b/include/meltpooldg/advection_diffusion/advection_diffusion_operation.hpp
@@ -46,7 +46,7 @@ namespace MeltPoolDG
       initialize(const std::shared_ptr<const ScratchData<dim>> &scratch_data_in,
                  const VectorType &                             solution_advected_field_in,
                  const Parameters<double> &                     data_in,
-                 const unsigned int                             dof_idx_in, 
+                 const unsigned int                             dof_idx_in,
                  const unsigned int                             dof_no_bc_idx_in,
                  const unsigned int                             quad_idx_in)
       {
@@ -90,12 +90,9 @@ namespace MeltPoolDG
             /*
              * apply dirichlet boundary values
              */
-            advec_diff_operator->create_rhs_and_apply_dirichlet_mf(rhs,
-                                                                   solution_advected_field,
-                                                                   *scratch_data,
-                                                                   dof_idx,
-                                                                   dof_no_bc_idx);
-            
+            advec_diff_operator->create_rhs_and_apply_dirichlet_mf(
+              rhs, solution_advected_field, *scratch_data, dof_idx, dof_no_bc_idx);
+
             iter = LinearSolve<VectorType, SolverGMRES<VectorType>, OperatorBase<double>>::solve(
               *advec_diff_operator, src, rhs);
           }
@@ -137,12 +134,8 @@ namespace MeltPoolDG
       void
       create_operator(const BlockVectorType &advection_velocity)
       {
-        advec_diff_operator =
-          std::make_unique<AdvectionDiffusionOperator<dim, double>>(*scratch_data,
-                                                                     advection_velocity,
-                                                                     advec_diff_data,
-                                                                     dof_idx,
-                                                                     quad_idx);
+        advec_diff_operator = std::make_unique<AdvectionDiffusionOperator<dim, double>>(
+          *scratch_data, advection_velocity, advec_diff_data, dof_idx, quad_idx);
         /*
          *  In case of a matrix-based simulation, setup the distributed sparsity pattern and
          *  apply it to the system matrix. This functionality is part of the OperatorBase class.
@@ -158,7 +151,7 @@ namespace MeltPoolDG
        */
       std::unique_ptr<OperatorBase<double>> advec_diff_operator;
       /*
-       *  Based on the following indices the correct DoFHandler or quadrature rule from 
+       *  Based on the following indices the correct DoFHandler or quadrature rule from
        *  ScratchData<dim> object is selected. This is important when ScratchData<dim> holds
        *  multiple DoFHandlers, quadrature rules, etc.
        */

--- a/include/meltpooldg/advection_diffusion/advection_diffusion_operator.hpp
+++ b/include/meltpooldg/advection_diffusion/advection_diffusion_operator.hpp
@@ -145,8 +145,8 @@ namespace MeltPoolDG
               // assembly
               cell->get_dof_indices(local_dof_indices);
 
-              scratch_data.get_constraint(this->dof_idx).distribute_local_to_global(
-                cell_matrix, cell_rhs, local_dof_indices, matrix, rhs);
+              scratch_data.get_constraint(this->dof_idx)
+                .distribute_local_to_global(cell_matrix, cell_rhs, local_dof_indices, matrix, rhs);
             }
 
         matrix.compress(VectorOperation::add);
@@ -166,11 +166,9 @@ namespace MeltPoolDG
         scratch_data.get_matrix_free().template cell_loop<VectorType, VectorType>(
           [&](const auto &matrix_free, auto &dst, const auto &src, auto cell_range) {
             FECellIntegrator<dim, 1, number>   advected_field(matrix_free,
-                                                            this->dof_idx, 
+                                                            this->dof_idx,
                                                             this->quad_idx);
-            FECellIntegrator<dim, dim, number> velocity(matrix_free,
-                                                        this->dof_idx,
-                                                        this->quad_idx);
+            FECellIntegrator<dim, dim, number> velocity(matrix_free, this->dof_idx, this->quad_idx);
 
             for (unsigned int cell = cell_range.first; cell < cell_range.second; ++cell)
               {
@@ -219,9 +217,7 @@ namespace MeltPoolDG
             FECellIntegrator<dim, 1, number, VectorizedArrayType> advected_field(matrix_free,
                                                                                  this->dof_idx,
                                                                                  this->quad_idx);
-            FECellIntegrator<dim, dim, number>                    velocity(matrix_free,
-                                                                           this->dof_idx,
-                                                                           this->quad_idx);
+            FECellIntegrator<dim, dim, number> velocity(matrix_free, this->dof_idx, this->quad_idx);
 
             for (unsigned int cell = macro_cells.first; cell < macro_cells.second; ++cell)
               {

--- a/include/meltpooldg/advection_diffusion/advection_diffusion_operator.hpp
+++ b/include/meltpooldg/advection_diffusion/advection_diffusion_operator.hpp
@@ -18,7 +18,7 @@ namespace MeltPoolDG
   {
     using namespace dealii;
 
-    template <int dim, int comp = 0, typename number = double>
+    template <int dim, typename number = double>
     class AdvectionDiffusionOperator
       : public OperatorBase<number,
                             LinearAlgebra::distributed::Vector<number>,
@@ -36,11 +36,14 @@ namespace MeltPoolDG
       // clang-format off
     AdvectionDiffusionOperator( const ScratchData<dim>               &scratch_data_in, 
                                 const BlockVectorType                &advection_velocity_in,
-                                const AdvectionDiffusionData<number> &data_in )
+                                const AdvectionDiffusionData<number> &data_in,
+                                const unsigned int                   dof_idx_in,
+                                const unsigned int                   quad_idx_in )
     : scratch_data        ( scratch_data_in       )
     , advection_velocity  ( advection_velocity_in )
     , data                ( data_in               )
     {
+      this->reset_indices(dof_idx_in, quad_idx_in);
     }
       // clang-format on
 
@@ -61,8 +64,8 @@ namespace MeltPoolDG
 
 
         FEValues<dim> fe_values(scratch_data.get_mapping(),
-                                scratch_data.get_dof_handler(comp).get_fe(),
-                                scratch_data.get_quadrature(comp),
+                                scratch_data.get_dof_handler(this->dof_idx).get_fe(),
+                                scratch_data.get_quadrature(this->quad_idx),
                                 update_values | update_gradients | update_quadrature_points |
                                   update_JxW_values);
 
@@ -83,7 +86,7 @@ namespace MeltPoolDG
 
         std::vector<Tensor<1, dim>> a(n_q_points, Tensor<1, dim>());
 
-        for (const auto &cell : scratch_data.get_dof_handler(comp).active_cell_iterators())
+        for (const auto &cell : scratch_data.get_dof_handler(this->dof_idx).active_cell_iterators())
           if (cell->is_locally_owned())
             {
               cell_matrix = 0;
@@ -142,7 +145,7 @@ namespace MeltPoolDG
               // assembly
               cell->get_dof_indices(local_dof_indices);
 
-              scratch_data.get_constraint(comp).distribute_local_to_global(
+              scratch_data.get_constraint(this->dof_idx).distribute_local_to_global(
                 cell_matrix, cell_rhs, local_dof_indices, matrix, rhs);
             }
 
@@ -163,11 +166,11 @@ namespace MeltPoolDG
         scratch_data.get_matrix_free().template cell_loop<VectorType, VectorType>(
           [&](const auto &matrix_free, auto &dst, const auto &src, auto cell_range) {
             FECellIntegrator<dim, 1, number>   advected_field(matrix_free,
-                                                            comp /*dof_idx*/,
-                                                            comp /*quad_idx*/);
+                                                            this->dof_idx, 
+                                                            this->quad_idx);
             FECellIntegrator<dim, dim, number> velocity(matrix_free,
-                                                        comp /*dof_idx*/,
-                                                        comp /*quad_idx*/);
+                                                        this->dof_idx,
+                                                        this->quad_idx);
 
             for (unsigned int cell = cell_range.first; cell < cell_range.second; ++cell)
               {
@@ -214,11 +217,11 @@ namespace MeltPoolDG
         scratch_data.get_matrix_free().template cell_loop<VectorType, VectorType>(
           [&](const auto &matrix_free, auto &dst, const auto &src, auto macro_cells) {
             FECellIntegrator<dim, 1, number, VectorizedArrayType> advected_field(matrix_free,
-                                                                                 comp /*dof_idx*/,
-                                                                                 comp /*quad_idx*/);
+                                                                                 this->dof_idx,
+                                                                                 this->quad_idx);
             FECellIntegrator<dim, dim, number>                    velocity(matrix_free,
-                                                        comp /*dof_idx*/,
-                                                        comp /*quad_idx*/);
+                                                                           this->dof_idx,
+                                                                           this->quad_idx);
 
             for (unsigned int cell = macro_cells.first; cell < macro_cells.second; ++cell)
               {

--- a/include/meltpooldg/advection_diffusion/advection_diffusion_problem.hpp
+++ b/include/meltpooldg/advection_diffusion/advection_diffusion_problem.hpp
@@ -137,21 +137,22 @@ namespace MeltPoolDG
           }
         constraints.close();
 
-        scratch_data->attach_constraint_matrix(constraints);
-        scratch_data->attach_constraint_matrix(hanging_node_constraints);
+        const int dof_idx       = scratch_data->attach_constraint_matrix(constraints);
+        const int dof_no_bc_idx = scratch_data->attach_constraint_matrix(hanging_node_constraints);
         /*
          *  create quadrature rule
          */
+        unsigned int quad_idx = 0;
 #ifdef DEAL_II_WITH_SIMPLEX_SUPPORT
         if (base_in->parameters.base.do_simplex)
-          scratch_data->attach_quadrature(Simplex::QGauss<dim>(
+          quad_idx = scratch_data->attach_quadrature(Simplex::QGauss<dim>(
             dim == 2 ? (base_in->parameters.base.n_q_points_1d == 1 ? 3 : 7) :
                        (base_in->parameters.base.n_q_points_1d == 1 ? 4 : 10)));
         else
 #endif
-          scratch_data->attach_quadrature(QGauss<1>(base_in->parameters.base.n_q_points_1d));
+          quad_idx = scratch_data->attach_quadrature(QGauss<1>(base_in->parameters.base.n_q_points_1d));
 
-          // TODO: only do once!
+          // @TODO: only do once!
 #ifdef DEAL_II_WITH_SIMPLEX_SUPPORT
         if (base_in->parameters.base.do_simplex)
           scratch_data->attach_quadrature(Simplex::QGauss<dim>(
@@ -198,7 +199,12 @@ namespace MeltPoolDG
             "a valid advection velocity. A shared_ptr to your advection velocity "
             "function, e.g., AdvectionFunc<dim> must be specified as follows: "
             "this->field_conditions.advection_field = std::make_shared<AdvectionFunc<dim>>();"));
-        advec_diff_operation.initialize(scratch_data, initial_solution, base_in->parameters);
+        advec_diff_operation.initialize(scratch_data, 
+                                        initial_solution, 
+                                        base_in->parameters, 
+                                        dof_idx, 
+                                        dof_no_bc_idx, 
+                                        quad_idx);
       }
 
       void

--- a/include/meltpooldg/advection_diffusion/advection_diffusion_problem.hpp
+++ b/include/meltpooldg/advection_diffusion/advection_diffusion_problem.hpp
@@ -150,7 +150,8 @@ namespace MeltPoolDG
                        (base_in->parameters.base.n_q_points_1d == 1 ? 4 : 10)));
         else
 #endif
-          quad_idx = scratch_data->attach_quadrature(QGauss<1>(base_in->parameters.base.n_q_points_1d));
+          quad_idx =
+            scratch_data->attach_quadrature(QGauss<1>(base_in->parameters.base.n_q_points_1d));
 
           // @TODO: only do once!
 #ifdef DEAL_II_WITH_SIMPLEX_SUPPORT
@@ -199,12 +200,8 @@ namespace MeltPoolDG
             "a valid advection velocity. A shared_ptr to your advection velocity "
             "function, e.g., AdvectionFunc<dim> must be specified as follows: "
             "this->field_conditions.advection_field = std::make_shared<AdvectionFunc<dim>>();"));
-        advec_diff_operation.initialize(scratch_data, 
-                                        initial_solution, 
-                                        base_in->parameters, 
-                                        dof_idx, 
-                                        dof_no_bc_idx, 
-                                        quad_idx);
+        advec_diff_operation.initialize(
+          scratch_data, initial_solution, base_in->parameters, dof_idx, dof_no_bc_idx, quad_idx);
       }
 
       void

--- a/include/meltpooldg/curvature/curvature_operation.hpp
+++ b/include/meltpooldg/curvature/curvature_operation.hpp
@@ -58,8 +58,8 @@ namespace MeltPoolDG
                  const unsigned int                             quad_idx_in)
       {
         scratch_data = scratch_data_in;
-        dof_idx       = dof_idx_in;
-        quad_idx      = quad_idx_in;
+        dof_idx      = dof_idx_in;
+        quad_idx     = quad_idx_in;
         /*
          *  initialize curvature data
          */
@@ -127,8 +127,10 @@ namespace MeltPoolDG
       {
         const double damping_parameter =
           scratch_data->get_min_cell_size(dof_idx) * curvature_data.damping_scale_factor;
-        curvature_operator =
-          std::make_unique<CurvatureOperator<dim>>(*scratch_data, damping_parameter, dof_idx, quad_idx);
+        curvature_operator = std::make_unique<CurvatureOperator<dim>>(*scratch_data,
+                                                                      damping_parameter,
+                                                                      dof_idx,
+                                                                      quad_idx);
         /*
          *  In case of a matrix-based simulation, setup the distributed sparsity pattern and
          *  apply it to the system matrix. This functionality is part of the OperatorBase class.
@@ -147,7 +149,7 @@ namespace MeltPoolDG
        */
       std::unique_ptr<OperatorBase<double, VectorType, BlockVectorType>> curvature_operator;
       /*
-       *  Based on the following indices the correct DoFHandler or quadrature rule from 
+       *  Based on the following indices the correct DoFHandler or quadrature rule from
        *  ScratchData<dim> object is selected. This is important when ScratchData<dim> holds
        *  multiple DoFHandlers, quadrature rules, etc.
        */

--- a/include/meltpooldg/curvature/curvature_operator.hpp
+++ b/include/meltpooldg/curvature/curvature_operator.hpp
@@ -20,7 +20,7 @@ namespace MeltPoolDG
 {
   namespace Curvature
   {
-    /*
+    /**
      *  This function calculates the curvature of the current level set function being
      *  the solution of an intermediate projection step
      *
@@ -31,7 +31,7 @@ namespace MeltPoolDG
      *  level set function n_ϕ.
      *
      */
-    template <int dim, unsigned int comp = 0, typename number = double>
+    template <int dim, typename number = double>
     class CurvatureOperator : public OperatorBase<number,
                                                   LinearAlgebra::distributed::Vector<number>,
                                                   LinearAlgebra::distributed::BlockVector<number>>
@@ -44,10 +44,13 @@ namespace MeltPoolDG
 
       // clang-format off
       CurvatureOperator( const ScratchData<dim>& scratch_data_in,
-                         const double            damping_in )
+                         const double            damping_in,
+                         const unsigned int      dof_idx_in,
+                         const unsigned int      quad_idx_in )
       : scratch_data( scratch_data_in )
       , damping     ( damping_in      )
       {
+        this->reset_indices(dof_idx_in, quad_idx_in);
       }
       // clang-format on
 
@@ -60,12 +63,12 @@ namespace MeltPoolDG
 
         const auto &  mapping = scratch_data.get_mapping();
         FEValues<dim> fe_values(mapping,
-                                scratch_data.get_dof_handler(comp).get_fe(),
-                                scratch_data.get_quadrature(comp),
+                                scratch_data.get_dof_handler(this->dof_idx).get_fe(),
+                                scratch_data.get_quadrature(this->quad_idx),
                                 update_values | update_gradients | update_quadrature_points |
                                   update_JxW_values);
 
-        const unsigned int dofs_per_cell = scratch_data.get_n_dofs_per_cell(comp);
+        const unsigned int dofs_per_cell = scratch_data.get_n_dofs_per_cell(this->dof_idx);
 
         FullMatrix<double>                   curvature_cell_matrix(dofs_per_cell, dofs_per_cell);
         Vector<double>                       curvature_cell_rhs(dofs_per_cell);
@@ -78,7 +81,7 @@ namespace MeltPoolDG
         matrix = 0.0;
         rhs    = 0.0;
 
-        for (const auto &cell : scratch_data.get_dof_handler(comp).active_cell_iterators())
+        for (const auto &cell : scratch_data.get_dof_handler(this->dof_idx).active_cell_iterators())
           if (cell->is_locally_owned())
             {
               fe_values.reinit(cell);
@@ -87,7 +90,7 @@ namespace MeltPoolDG
               curvature_cell_matrix = 0.0;
               curvature_cell_rhs    = 0.0;
 
-              NormalVector::NormalVectorOperator<dim, comp>::get_unit_normals_at_quadrature(
+              NormalVector::NormalVectorOperator<dim>::get_unit_normals_at_quadrature(
                 fe_values, solution_normal_vector_in, normal_at_q);
 
               for (const unsigned int q_index : fe_values.quadrature_point_indices())
@@ -113,7 +116,7 @@ namespace MeltPoolDG
 
               // assembly
               cell->get_dof_indices(local_dof_indices);
-              scratch_data.get_constraint(comp).distribute_local_to_global(
+              scratch_data.get_constraint(this->dof_idx).distribute_local_to_global(
                 curvature_cell_matrix, curvature_cell_rhs, local_dof_indices, matrix, rhs);
 
             } // end of cell loop
@@ -130,7 +133,7 @@ namespace MeltPoolDG
       {
         scratch_data.get_matrix_free().template cell_loop<VectorType, VectorType>(
           [&](const auto &matrix_free, auto &dst, const auto &src, auto cell_range) {
-            FECellIntegrator<dim, 1, number> curvature(matrix_free, comp, comp);
+            FECellIntegrator<dim, 1, number> curvature(matrix_free, this->dof_idx, this->quad_idx);
             for (unsigned int cell = cell_range.first; cell < cell_range.second; ++cell)
               {
                 curvature.reinit(cell);
@@ -155,8 +158,8 @@ namespace MeltPoolDG
       {
         scratch_data.get_matrix_free().template cell_loop<VectorType, BlockVectorType>(
           [&](const auto &matrix_free, auto &dst, const auto &src, auto macro_cells) {
-            FECellIntegrator<dim, 1, number>   curvature(matrix_free, comp, comp);
-            FECellIntegrator<dim, dim, number> normal_vector(matrix_free, comp, comp);
+            FECellIntegrator<dim, 1, number>   curvature(matrix_free, this->dof_idx, this->quad_idx);
+            FECellIntegrator<dim, dim, number> normal_vector(matrix_free, this->dof_idx, this->quad_idx);
             for (unsigned int cell = macro_cells.first; cell < macro_cells.second; ++cell)
               {
                 curvature.reinit(cell);
@@ -167,7 +170,7 @@ namespace MeltPoolDG
 
                 for (unsigned int q_index = 0; q_index < curvature.n_q_points; ++q_index)
                   {
-                    const auto n_phi = Reinitialization::OlssonOperator<dim, comp>::normalize(
+                    const auto n_phi = Reinitialization::OlssonOperator<dim>::normalize(
                       normal_vector.get_value(q_index));
                     curvature.submit_gradient(n_phi, q_index);
                   }

--- a/include/meltpooldg/curvature/curvature_operator.hpp
+++ b/include/meltpooldg/curvature/curvature_operator.hpp
@@ -116,8 +116,9 @@ namespace MeltPoolDG
 
               // assembly
               cell->get_dof_indices(local_dof_indices);
-              scratch_data.get_constraint(this->dof_idx).distribute_local_to_global(
-                curvature_cell_matrix, curvature_cell_rhs, local_dof_indices, matrix, rhs);
+              scratch_data.get_constraint(this->dof_idx)
+                .distribute_local_to_global(
+                  curvature_cell_matrix, curvature_cell_rhs, local_dof_indices, matrix, rhs);
 
             } // end of cell loop
         matrix.compress(VectorOperation::add);
@@ -158,8 +159,10 @@ namespace MeltPoolDG
       {
         scratch_data.get_matrix_free().template cell_loop<VectorType, BlockVectorType>(
           [&](const auto &matrix_free, auto &dst, const auto &src, auto macro_cells) {
-            FECellIntegrator<dim, 1, number>   curvature(matrix_free, this->dof_idx, this->quad_idx);
-            FECellIntegrator<dim, dim, number> normal_vector(matrix_free, this->dof_idx, this->quad_idx);
+            FECellIntegrator<dim, 1, number> curvature(matrix_free, this->dof_idx, this->quad_idx);
+            FECellIntegrator<dim, dim, number> normal_vector(matrix_free,
+                                                             this->dof_idx,
+                                                             this->quad_idx);
             for (unsigned int cell = macro_cells.first; cell < macro_cells.second; ++cell)
               {
                 curvature.reinit(cell);

--- a/include/meltpooldg/interface/operator_base.hpp
+++ b/include/meltpooldg/interface/operator_base.hpp
@@ -58,11 +58,11 @@ namespace MeltPoolDG
     {
       d_tau = dt;
     }
-    
-    void 
+
+    void
     reset_indices(const unsigned int dof_idx_in, const unsigned int quad_idx_in)
     {
-      this->dof_idx = dof_idx_in;
+      this->dof_idx  = dof_idx_in;
       this->quad_idx = quad_idx_in;
     }
 
@@ -125,11 +125,13 @@ namespace MeltPoolDG
     double              d_tau = 0.0;
     SparseMatrixType    system_matrix;
     SparsityPatternType dsp;
+
   protected:
-    /* 
-     * dof_idx/quad_idx can be overwritten from the derived operator class by calling the reset_indices function
+    /*
+     * dof_idx/quad_idx can be overwritten from the derived operator class by calling the
+     * reset_indices function
      * */
-    unsigned int dof_idx = 0;   
-    unsigned int quad_idx = 0;  
+    unsigned int dof_idx  = 0;
+    unsigned int quad_idx = 0;
   };
 } // namespace MeltPoolDG

--- a/include/meltpooldg/interface/operator_base.hpp
+++ b/include/meltpooldg/interface/operator_base.hpp
@@ -66,7 +66,7 @@ namespace MeltPoolDG
       this->quad_idx = quad_idx_in;
     }
 
-    template <unsigned int dim>
+    template <int dim>
     void
     initialize_matrix_based(const ScratchData<dim> &scratch_data)
     {

--- a/include/meltpooldg/interface/operator_base.hpp
+++ b/include/meltpooldg/interface/operator_base.hpp
@@ -58,20 +58,27 @@ namespace MeltPoolDG
     {
       d_tau = dt;
     }
+    
+    void 
+    reset_indices(const unsigned int dof_idx_in, const unsigned int quad_idx_in)
+    {
+      this->dof_idx = dof_idx_in;
+      this->quad_idx = quad_idx_in;
+    }
 
-    template <unsigned int dim, unsigned int comp>
+    template <unsigned int dim>
     void
     initialize_matrix_based(const ScratchData<dim> &scratch_data)
     {
-      const MPI_Comm mpi_communicator = scratch_data.get_mpi_comm(comp);
-      dsp.reinit(scratch_data.get_locally_owned_dofs(),
-                 scratch_data.get_locally_owned_dofs(),
-                 scratch_data.get_locally_relevant_dofs(),
+      const MPI_Comm mpi_communicator = scratch_data.get_mpi_comm(this->dof_idx);
+      dsp.reinit(scratch_data.get_locally_owned_dofs(this->dof_idx),
+                 scratch_data.get_locally_owned_dofs(this->dof_idx),
+                 scratch_data.get_locally_relevant_dofs(this->dof_idx),
                  mpi_communicator);
 
-      DoFTools::make_sparsity_pattern(scratch_data.get_dof_handler(comp),
+      DoFTools::make_sparsity_pattern(scratch_data.get_dof_handler(this->dof_idx),
                                       this->dsp,
-                                      scratch_data.get_constraint(comp),
+                                      scratch_data.get_constraint(this->dof_idx),
                                       true,
                                       Utilities::MPI::this_mpi_process(mpi_communicator));
       this->dsp.compress();
@@ -84,8 +91,10 @@ namespace MeltPoolDG
     create_rhs_and_apply_dirichlet_mf(DoFVectorType &         rhs,
                                       const SrcRhsVectorType &src,
                                       const ScratchData<dim> &scratch_data,
-                                      const int               dof_idx = 0)
+                                      const unsigned int      dof_idx,
+                                      const unsigned int      dof_no_bc_idx)
     {
+      this->reset_indices(dof_no_bc_idx, this->quad_idx);
       DoFVectorType bc_values;
       scratch_data.initialize_bc_vector(bc_values, dof_idx);
       /*
@@ -100,8 +109,11 @@ namespace MeltPoolDG
       rhs *= -1.0;
       this->create_rhs(rhs, src);
 
-      // clear constrainted values
+      /*
+       * Clear constrained values
+       */
       scratch_data.get_constraint(dof_idx).set_zero(rhs);
+      this->reset_indices(dof_idx, this->quad_idx);
     }
 
     const SparseMatrixType &
@@ -113,5 +125,11 @@ namespace MeltPoolDG
     double              d_tau = 0.0;
     SparseMatrixType    system_matrix;
     SparsityPatternType dsp;
+  protected:
+    /* 
+     * dof_idx/quad_idx can be overwritten from the derived operator class by calling the reset_indices function
+     * */
+    unsigned int dof_idx = 0;   
+    unsigned int quad_idx = 0;  
   };
 } // namespace MeltPoolDG

--- a/include/meltpooldg/interface/scratch_data.hpp
+++ b/include/meltpooldg/interface/scratch_data.hpp
@@ -152,10 +152,6 @@ namespace MeltPoolDG
           DoFTools::extract_locally_relevant_dofs(*dof, locally_relevant_dofs_temp);
           this->locally_relevant_dofs.push_back(locally_relevant_dofs_temp);
 
-          // const auto partitioner_ =
-          // std::make_shared<Utilities::MPI::Partitioner>(this->get_locally_owned_dofs(dof_idx),
-          // this->get_locally_relevant_dofs(dof_idx),
-          // this->get_mpi_comm(dof_idx));
           this->partitioner.push_back(
             std::make_shared<Utilities::MPI::Partitioner>(this->get_locally_owned_dofs(dof_idx),
                                                           this->get_locally_relevant_dofs(dof_idx),
@@ -342,25 +338,6 @@ namespace MeltPoolDG
       return ConditionalOStream(std::cout,
                                 Utilities::MPI::this_mpi_process(this->get_mpi_comm(dof_idx)) == 0);
     }
-    /*
-     *
-     * @todo: WIP
-
-    static
-    auto
-    get_derived_triangulation(const Triangulation<dim,spacedim>* &tria_in)
-    {
-      auto n = tria_in->n_active_cells();
-      if (dim==1)
-      {
-        return dynamic_cast<Triangulation<dim>&>(tria_in);
-      }
-      else
-      {
-        return dynamic_cast<parallel::distributed::Triangulation<dim>&>(*tria_in);
-      }
-    }
-      */
 
   private:
     bool do_matrix_free;

--- a/include/meltpooldg/level_set/level_set_operation.hpp
+++ b/include/meltpooldg/level_set/level_set_operation.hpp
@@ -44,12 +44,12 @@ namespace MeltPoolDG
       initialize(const std::shared_ptr<const ScratchData<dim>> &scratch_data_in,
                  const VectorType &                             solution_level_set_in,
                  const Parameters<double> &                     data_in,
-                 const unsigned int                             dof_idx_in, 
-                 const unsigned int                             dof_no_bc_idx_in, 
-                 const unsigned int                             quad_idx_in) 
+                 const unsigned int                             dof_idx_in,
+                 const unsigned int                             dof_no_bc_idx_in,
+                 const unsigned int                             quad_idx_in)
       {
         scratch_data = scratch_data_in;
-        dof_idx = dof_idx_in;
+        dof_idx      = dof_idx_in;
         /*
          *  set the level set data
          */
@@ -57,7 +57,8 @@ namespace MeltPoolDG
         /*
          *  initialize the advection_diffusion problem
          */
-        advec_diff_operation.initialize(scratch_data, solution_level_set_in, data_in, dof_idx, dof_no_bc_idx_in, quad_idx_in);
+        advec_diff_operation.initialize(
+          scratch_data, solution_level_set_in, data_in, dof_idx, dof_no_bc_idx_in, quad_idx_in);
         /*
          *  set the parameters for the levelset problem; already determined parameters
          *  from the initialize call of advec_diff_operation are overwritten.
@@ -66,7 +67,8 @@ namespace MeltPoolDG
         /*
          *    initialize the reinitialization operation class
          */
-        reinit_operation.initialize(scratch_data, solution_level_set_in, data_in, dof_no_bc_idx_in, quad_idx_in);
+        reinit_operation.initialize(
+          scratch_data, solution_level_set_in, data_in, dof_no_bc_idx_in, quad_idx_in);
         /*
          *  The initial solution of the level set equation will be reinitialized.
          */
@@ -142,8 +144,8 @@ namespace MeltPoolDG
           TimeIteratorData<double>{0.0,
                                    100000.,
                                    data_in.reinit.dtau > 0.0 ?
-                                   data_in.reinit.dtau :
-                                   scratch_data->get_min_cell_size(dof_idx) *
+                                     data_in.reinit.dtau :
+                                     scratch_data->get_min_cell_size(dof_idx) *
                                        data_in.reinit.scale_factor_epsilon,
                                    data_in.reinit.max_n_steps,
                                    false});
@@ -185,7 +187,6 @@ namespace MeltPoolDG
        *    accessible for output_results.
        */
       const BlockVectorType &solution_normal_vector = reinit_operation.solution_normal_vector;
-      
     };
   } // namespace LevelSet
 } // namespace MeltPoolDG

--- a/include/meltpooldg/level_set/level_set_problem.hpp
+++ b/include/meltpooldg/level_set/level_set_problem.hpp
@@ -138,12 +138,13 @@ namespace MeltPoolDG
           }
         constraints_dirichlet.close();
 
-        const unsigned int dof_no_bc_idx = scratch_data->attach_constraint_matrix(hanging_node_constraints);
+        const unsigned int dof_no_bc_idx =
+          scratch_data->attach_constraint_matrix(hanging_node_constraints);
         const unsigned int dof_idx = scratch_data->attach_constraint_matrix(constraints_dirichlet);
         /*
          *  create quadrature rule
          */
-        
+
         unsigned int quad_idx = 0;
 #ifdef DEAL_II_WITH_SIMPLEX_SUPPORT
         if (base_in->parameters.base.do_simplex)
@@ -152,7 +153,8 @@ namespace MeltPoolDG
                        (base_in->parameters.base.n_q_points_1d == 1 ? 4 : 10)));
         else
 #endif
-          quad_idx = scratch_data->attach_quadrature(QGauss<1>(base_in->parameters.base.n_q_points_1d));
+          quad_idx =
+            scratch_data->attach_quadrature(QGauss<1>(base_in->parameters.base.n_q_points_1d));
 
           // TODO: only do once!
 #ifdef DEAL_II_WITH_SIMPLEX_SUPPORT
@@ -200,7 +202,8 @@ namespace MeltPoolDG
             "function, e.g., AdvectionFunc<dim> must be specified as follows: "
             "this->field_conditions.advection_field = std::make_shared<AdvectionFunc<dim>>();"));
 
-        level_set_operation.initialize(scratch_data, initial_solution, base_in->parameters, dof_idx, dof_no_bc_idx, quad_idx);
+        level_set_operation.initialize(
+          scratch_data, initial_solution, base_in->parameters, dof_idx, dof_no_bc_idx, quad_idx);
       }
 
       void
@@ -305,8 +308,8 @@ namespace MeltPoolDG
       std::shared_ptr<ScratchData<dim>> scratch_data;
       BlockVectorType                   advection_velocity;
 
-      TimeIterator<double>         time_iterator;
-      LevelSetOperation<dim>       level_set_operation;
+      TimeIterator<double>   time_iterator;
+      LevelSetOperation<dim> level_set_operation;
     };
   } // namespace LevelSet
 } // namespace MeltPoolDG

--- a/include/meltpooldg/level_set/level_set_problem.hpp
+++ b/include/meltpooldg/level_set/level_set_problem.hpp
@@ -138,20 +138,21 @@ namespace MeltPoolDG
           }
         constraints_dirichlet.close();
 
-        scratch_data->attach_constraint_matrix(hanging_node_constraints);
-        scratch_data->attach_constraint_matrix(constraints_dirichlet);
+        const unsigned int dof_no_bc_idx = scratch_data->attach_constraint_matrix(hanging_node_constraints);
+        const unsigned int dof_idx = scratch_data->attach_constraint_matrix(constraints_dirichlet);
         /*
          *  create quadrature rule
          */
-
+        
+        unsigned int quad_idx = 0;
 #ifdef DEAL_II_WITH_SIMPLEX_SUPPORT
         if (base_in->parameters.base.do_simplex)
-          scratch_data->attach_quadrature(Simplex::QGauss<dim>(
+          quad_idx = scratch_data->attach_quadrature(Simplex::QGauss<dim>(
             dim == 2 ? (base_in->parameters.base.n_q_points_1d == 1 ? 3 : 7) :
                        (base_in->parameters.base.n_q_points_1d == 1 ? 4 : 10)));
         else
 #endif
-          scratch_data->attach_quadrature(QGauss<1>(base_in->parameters.base.n_q_points_1d));
+          quad_idx = scratch_data->attach_quadrature(QGauss<1>(base_in->parameters.base.n_q_points_1d));
 
           // TODO: only do once!
 #ifdef DEAL_II_WITH_SIMPLEX_SUPPORT
@@ -199,7 +200,7 @@ namespace MeltPoolDG
             "function, e.g., AdvectionFunc<dim> must be specified as follows: "
             "this->field_conditions.advection_field = std::make_shared<AdvectionFunc<dim>>();"));
 
-        level_set_operation.initialize(scratch_data, initial_solution, base_in->parameters);
+        level_set_operation.initialize(scratch_data, initial_solution, base_in->parameters, dof_idx, dof_no_bc_idx, quad_idx);
       }
 
       void
@@ -305,7 +306,7 @@ namespace MeltPoolDG
       BlockVectorType                   advection_velocity;
 
       TimeIterator<double>         time_iterator;
-      LevelSetOperation<dim, 1, 0> level_set_operation;
+      LevelSetOperation<dim>       level_set_operation;
     };
   } // namespace LevelSet
 } // namespace MeltPoolDG

--- a/include/meltpooldg/normal_vector/normal_vector_operation.hpp
+++ b/include/meltpooldg/normal_vector/normal_vector_operation.hpp
@@ -38,7 +38,7 @@ namespace MeltPoolDG
      *    !!!!
      */
 
-    template <int dim, unsigned int comp>
+    template <int dim>
     class NormalVectorOperation
     {
     private:
@@ -58,9 +58,13 @@ namespace MeltPoolDG
 
       void
       initialize(const std::shared_ptr<const ScratchData<dim>> &scratch_data_in,
-                 const Parameters<double> &                     data_in)
+                 const Parameters<double> &                     data_in,
+                 const unsigned int                             dof_idx_in,
+                 const unsigned int                             quad_idx_in)
       {
         scratch_data = scratch_data_in;
+        dof_idx       = dof_idx_in;
+        quad_idx      = quad_idx_in;
         /*
          *  initialize normal vector data
          */
@@ -82,8 +86,8 @@ namespace MeltPoolDG
       {
         BlockVectorType rhs;
 
-        scratch_data->initialize_dof_vector(rhs, comp);
-        scratch_data->initialize_dof_vector(solution_normal_vector, comp);
+        scratch_data->initialize_dof_vector(rhs, dof_idx);
+        scratch_data->initialize_dof_vector(solution_normal_vector, dof_idx);
 
         int iter = 0;
 
@@ -110,7 +114,7 @@ namespace MeltPoolDG
                 rhs.block(d));
           }
         for (unsigned int d = 0; d < dim; ++d)
-          scratch_data->get_constraint(comp).distribute(solution_normal_vector.block(d));
+          scratch_data->get_constraint(dof_idx).distribute(solution_normal_vector.block(d));
 
         if (normal_vector_data.do_print_l2norm)
           {
@@ -132,24 +136,30 @@ namespace MeltPoolDG
       create_operator()
       {
         const double damping_parameter =
-          scratch_data->get_min_cell_size(comp) * normal_vector_data.damping_scale_factor;
+          scratch_data->get_min_cell_size(dof_idx) * normal_vector_data.damping_scale_factor;
         normal_vector_operator =
-          std::make_unique<NormalVectorOperator<dim, comp>>(*scratch_data, damping_parameter);
+          std::make_unique<NormalVectorOperator<dim>>(*scratch_data, damping_parameter, dof_idx, quad_idx);
         /*
          *  In case of a matrix-based simulation, setup the distributed sparsity pattern and
          *  apply it to the system matrix. This functionality is part of the OperatorBase class.
          */
         if (!normal_vector_data.do_matrix_free)
-          normal_vector_operator->initialize_matrix_based<dim, comp>(*scratch_data);
+          normal_vector_operator->initialize_matrix_based<dim>(*scratch_data);
       }
 
     private:
       std::shared_ptr<const ScratchData<dim>> scratch_data;
-
       /*
        *  This pointer will point to your user-defined normal vector operator.
        */
       std::unique_ptr<OperatorBase<double, BlockVectorType, VectorType>> normal_vector_operator;
+      /*
+       *  Based on the following indices the correct DoFHandler or quadrature rule from 
+       *  ScratchData<dim> object is selected. This is important when ScratchData<dim> holds
+       *  multiple DoFHandlers, quadrature rules, etc.
+       */
+      unsigned int dof_idx;
+      unsigned int quad_idx;
     };
   } // namespace NormalVector
 } // namespace MeltPoolDG

--- a/include/meltpooldg/normal_vector/normal_vector_operation.hpp
+++ b/include/meltpooldg/normal_vector/normal_vector_operation.hpp
@@ -63,8 +63,8 @@ namespace MeltPoolDG
                  const unsigned int                             quad_idx_in)
       {
         scratch_data = scratch_data_in;
-        dof_idx       = dof_idx_in;
-        quad_idx      = quad_idx_in;
+        dof_idx      = dof_idx_in;
+        quad_idx     = quad_idx_in;
         /*
          *  initialize normal vector data
          */
@@ -137,8 +137,10 @@ namespace MeltPoolDG
       {
         const double damping_parameter =
           scratch_data->get_min_cell_size(dof_idx) * normal_vector_data.damping_scale_factor;
-        normal_vector_operator =
-          std::make_unique<NormalVectorOperator<dim>>(*scratch_data, damping_parameter, dof_idx, quad_idx);
+        normal_vector_operator = std::make_unique<NormalVectorOperator<dim>>(*scratch_data,
+                                                                             damping_parameter,
+                                                                             dof_idx,
+                                                                             quad_idx);
         /*
          *  In case of a matrix-based simulation, setup the distributed sparsity pattern and
          *  apply it to the system matrix. This functionality is part of the OperatorBase class.
@@ -154,7 +156,7 @@ namespace MeltPoolDG
        */
       std::unique_ptr<OperatorBase<double, BlockVectorType, VectorType>> normal_vector_operator;
       /*
-       *  Based on the following indices the correct DoFHandler or quadrature rule from 
+       *  Based on the following indices the correct DoFHandler or quadrature rule from
        *  ScratchData<dim> object is selected. This is important when ScratchData<dim> holds
        *  multiple DoFHandlers, quadrature rules, etc.
        */

--- a/include/meltpooldg/normal_vector/normal_vector_operator.hpp
+++ b/include/meltpooldg/normal_vector/normal_vector_operator.hpp
@@ -32,10 +32,10 @@ namespace MeltPoolDG
       using VectorizedArrayType = VectorizedArray<number>;
       using SparseMatrixType    = TrilinosWrappers::SparseMatrix;
 
-      NormalVectorOperator(const ScratchData<dim> &scratch_data_in, 
-                           const double           damping_in,
-                           const unsigned int     dof_idx_in,
-                           const unsigned int     quad_idx_in )
+      NormalVectorOperator(const ScratchData<dim> &scratch_data_in,
+                           const double            damping_in,
+                           const unsigned int      dof_idx_in,
+                           const unsigned int      quad_idx_in)
         : scratch_data(scratch_data_in)
         , damping(damping_in)
       {
@@ -113,13 +113,11 @@ namespace MeltPoolDG
               // assembly
               cell->get_dof_indices(local_dof_indices);
 
-              scratch_data.get_constraint(this->dof_idx).distribute_local_to_global(normal_cell_matrix,
-                                                                           local_dof_indices,
-                                                                           matrix);
+              scratch_data.get_constraint(this->dof_idx)
+                .distribute_local_to_global(normal_cell_matrix, local_dof_indices, matrix);
               for (unsigned int d = 0; d < dim; ++d)
-                scratch_data.get_constraint(this->dof_idx).distribute_local_to_global(normal_cell_rhs[d],
-                                                                             local_dof_indices,
-                                                                             rhs.block(d));
+                scratch_data.get_constraint(this->dof_idx)
+                  .distribute_local_to_global(normal_cell_rhs[d], local_dof_indices, rhs.block(d));
 
             } // end of cell loop
         matrix.compress(VectorOperation::add);
@@ -135,7 +133,9 @@ namespace MeltPoolDG
       {
         scratch_data.get_matrix_free().template cell_loop<BlockVectorType, BlockVectorType>(
           [&](const auto &, auto &dst, const auto &src, auto cell_range) {
-            FECellIntegrator<dim, dim, number> normal(scratch_data.get_matrix_free(), this->dof_idx, this->quad_idx);
+            FECellIntegrator<dim, dim, number> normal(scratch_data.get_matrix_free(),
+                                                      this->dof_idx,
+                                                      this->quad_idx);
             for (unsigned int cell = cell_range.first; cell < cell_range.second; ++cell)
               {
                 normal.reinit(cell);
@@ -162,8 +162,8 @@ namespace MeltPoolDG
                                                          this->dof_idx,
                                                          this->quad_idx);
         FECellIntegrator<dim, 1, number>   level_set(scratch_data.get_matrix_free(),
-                                                         this->dof_idx,
-                                                         this->quad_idx);
+                                                   this->dof_idx,
+                                                   this->quad_idx);
 
         scratch_data.get_matrix_free().template cell_loop<BlockVectorType, VectorType>(
           [&](const auto &, auto &dst, const auto &src, auto macro_cells) {

--- a/include/meltpooldg/normal_vector/normal_vector_operator.hpp
+++ b/include/meltpooldg/normal_vector/normal_vector_operator.hpp
@@ -20,7 +20,7 @@ namespace MeltPoolDG
 {
   namespace NormalVector
   {
-    template <int dim, unsigned int comp, typename number = double>
+    template <int dim, typename number = double>
     class NormalVectorOperator
       : public OperatorBase<number,
                             LinearAlgebra::distributed::BlockVector<number>,
@@ -32,10 +32,15 @@ namespace MeltPoolDG
       using VectorizedArrayType = VectorizedArray<number>;
       using SparseMatrixType    = TrilinosWrappers::SparseMatrix;
 
-      NormalVectorOperator(const ScratchData<dim> &scratch_data_in, const double damping_in)
+      NormalVectorOperator(const ScratchData<dim> &scratch_data_in, 
+                           const double           damping_in,
+                           const unsigned int     dof_idx_in,
+                           const unsigned int     quad_idx_in )
         : scratch_data(scratch_data_in)
         , damping(damping_in)
-      {}
+      {
+        this->reset_indices(dof_idx_in, quad_idx_in);
+      }
 
       void
       assemble_matrixbased(const VectorType &level_set_in,
@@ -46,12 +51,12 @@ namespace MeltPoolDG
         const auto &mapping = scratch_data.get_mapping();
 
         FEValues<dim> fe_values(mapping,
-                                scratch_data.get_dof_handler(comp).get_fe(),
-                                scratch_data.get_quadrature(comp),
+                                scratch_data.get_dof_handler(this->dof_idx).get_fe(),
+                                scratch_data.get_quadrature(this->quad_idx),
                                 update_values | update_gradients | update_quadrature_points |
                                   update_JxW_values);
 
-        const unsigned int dofs_per_cell = scratch_data.get_n_dofs_per_cell(comp);
+        const unsigned int dofs_per_cell = scratch_data.get_n_dofs_per_cell(this->dof_idx);
 
         FullMatrix<double>                   normal_cell_matrix(dofs_per_cell, dofs_per_cell);
         std::vector<Vector<double>>          normal_cell_rhs(dim, Vector<double>(dofs_per_cell));
@@ -64,7 +69,7 @@ namespace MeltPoolDG
         matrix = 0.0;
         rhs    = 0.0;
 
-        for (const auto &cell : scratch_data.get_dof_handler(comp).active_cell_iterators())
+        for (const auto &cell : scratch_data.get_dof_handler(this->dof_idx).active_cell_iterators())
           if (cell->is_locally_owned())
             {
               fe_values.reinit(cell);
@@ -108,11 +113,11 @@ namespace MeltPoolDG
               // assembly
               cell->get_dof_indices(local_dof_indices);
 
-              scratch_data.get_constraint(comp).distribute_local_to_global(normal_cell_matrix,
+              scratch_data.get_constraint(this->dof_idx).distribute_local_to_global(normal_cell_matrix,
                                                                            local_dof_indices,
                                                                            matrix);
               for (unsigned int d = 0; d < dim; ++d)
-                scratch_data.get_constraint(comp).distribute_local_to_global(normal_cell_rhs[d],
+                scratch_data.get_constraint(this->dof_idx).distribute_local_to_global(normal_cell_rhs[d],
                                                                              local_dof_indices,
                                                                              rhs.block(d));
 
@@ -130,7 +135,7 @@ namespace MeltPoolDG
       {
         scratch_data.get_matrix_free().template cell_loop<BlockVectorType, BlockVectorType>(
           [&](const auto &, auto &dst, const auto &src, auto cell_range) {
-            FECellIntegrator<dim, dim, number> normal(scratch_data.get_matrix_free(), comp, comp);
+            FECellIntegrator<dim, dim, number> normal(scratch_data.get_matrix_free(), this->dof_idx, this->quad_idx);
             for (unsigned int cell = cell_range.first; cell < cell_range.second; ++cell)
               {
                 normal.reinit(cell);
@@ -153,15 +158,12 @@ namespace MeltPoolDG
       void
       create_rhs(BlockVectorType &dst, const VectorType &src) const override
       {
-        const int                          n_comp_fe_system = 0;
         FECellIntegrator<dim, dim, number> normal_vector(scratch_data.get_matrix_free(),
-                                                         comp,
-                                                         comp,
-                                                         n_comp_fe_system);
+                                                         this->dof_idx,
+                                                         this->quad_idx);
         FECellIntegrator<dim, 1, number>   level_set(scratch_data.get_matrix_free(),
-                                                   comp,
-                                                   comp,
-                                                   n_comp_fe_system);
+                                                         this->dof_idx,
+                                                         this->quad_idx);
 
         scratch_data.get_matrix_free().template cell_loop<BlockVectorType, VectorType>(
           [&](const auto &, auto &dst, const auto &src, auto macro_cells) {

--- a/include/meltpooldg/reinitialization/olsson_operator.hpp
+++ b/include/meltpooldg/reinitialization/olsson_operator.hpp
@@ -36,7 +36,7 @@ namespace MeltPoolDG
                      const double &          constant_epsilon,
                      const double &          eps_scale_factor,
                      const unsigned int      dof_idx_in,
-                     const unsigned int      quad_idx_in )
+                     const unsigned int      quad_idx_in)
         : scratch_data(scratch_data_in)
         , eps(constant_epsilon)
         , eps_scale_factor(eps_scale_factor)
@@ -135,8 +135,8 @@ namespace MeltPoolDG
               // assembly
               cell->get_dof_indices(local_dof_indices);
 
-              scratch_data.get_constraint(this->dof_idx).distribute_local_to_global(
-                cell_matrix, cell_rhs, local_dof_indices, matrix, rhs);
+              scratch_data.get_constraint(this->dof_idx)
+                .distribute_local_to_global(cell_matrix, cell_rhs, local_dof_indices, matrix, rhs);
             }
 
         matrix.compress(VectorOperation::add);
@@ -158,7 +158,8 @@ namespace MeltPoolDG
             eps :
             eps_scale_factor *
               scratch_data.get_min_cell_size(
-                this->dof_idx); // @ todo: check how cell size can be extracted from matrix free class
+                this
+                  ->dof_idx); // @ todo: check how cell size can be extracted from matrix free class
 
         AssertThrow(eps_ > 0.0, ExcMessage("reinitialization operator: epsilon must be set"));
 
@@ -169,8 +170,8 @@ namespace MeltPoolDG
                                                       this->dof_idx,
                                                       this->quad_idx);
             FECellIntegrator<dim, dim, number> normal_vector(scratch_data.get_matrix_free(),
-                                                      this->dof_idx,
-                                                      this->quad_idx);
+                                                             this->dof_idx,
+                                                             this->quad_idx);
             for (unsigned int cell = cell_range.first; cell < cell_range.second; ++cell)
               {
                 levelset.reinit(cell);
@@ -214,7 +215,8 @@ namespace MeltPoolDG
             eps :
             eps_scale_factor *
               scratch_data.get_min_cell_size(
-                this->dof_idx); // @ todo: check how cell size can be extracted from matrix free class
+                this
+                  ->dof_idx); // @ todo: check how cell size can be extracted from matrix free class
 
         AssertThrow(eps_ > 0.0,
                     ExcMessage("reinitialization matrix-free operator: epsilon must be set"));
@@ -226,12 +228,12 @@ namespace MeltPoolDG
 
         scratch_data.get_matrix_free().template cell_loop<VectorType, VectorType>(
           [&](const auto &, auto &dst, const auto &src, auto macro_cells) {
-            FECellIntegrator<dim, 1, number>   psi(scratch_data.get_matrix_free(), 
-                                                      this->dof_idx,
-                                                      this->quad_idx);
+            FECellIntegrator<dim, 1, number>   psi(scratch_data.get_matrix_free(),
+                                                 this->dof_idx,
+                                                 this->quad_idx);
             FECellIntegrator<dim, dim, number> normal_vector(scratch_data.get_matrix_free(),
-                                                      this->dof_idx,
-                                                      this->quad_idx);
+                                                             this->dof_idx,
+                                                             this->quad_idx);
             for (unsigned int cell = macro_cells.first; cell < macro_cells.second; ++cell)
               {
                 psi.reinit(cell);

--- a/include/meltpooldg/reinitialization/reinitialization_operation.hpp
+++ b/include/meltpooldg/reinitialization/reinitialization_operation.hpp
@@ -57,8 +57,8 @@ namespace MeltPoolDG
                  const unsigned int                             quad_idx_in)
       {
         scratch_data = scratch_data_in;
-        dof_idx = dof_idx_in;
-        quad_idx = quad_idx_in;
+        dof_idx      = dof_idx_in;
+        quad_idx     = quad_idx_in;
         scratch_data->initialize_dof_vector(solution_level_set, dof_idx);
         scratch_data->initialize_dof_vector(solution_level_set, dof_idx);
         /*
@@ -196,8 +196,8 @@ namespace MeltPoolDG
              *  In case of a matrix-based simulation, setup the distributed sparsity pattern and
              *  apply it to the system matrix. This functionality is part of the OperatorBase class.
              */
-        
-        if (!reinit_data.do_matrix_free)
+
+            if (!reinit_data.do_matrix_free)
               reinit_operator->initialize_matrix_based<dim>(*scratch_data);
       }
       void
@@ -218,7 +218,7 @@ namespace MeltPoolDG
        */
       NormalVector::NormalVectorOperation<dim> normal_vector_operation;
       /*
-       *  Based on the following indices the correct DoFHandler or quadrature rule from 
+       *  Based on the following indices the correct DoFHandler or quadrature rule from
        *  ScratchData<dim> object is selected. This is important when ScratchData<dim> holds
        *  multiple DoFHandlers, quadrature rules, etc.
        */

--- a/include/meltpooldg/reinitialization/reinitialization_operation.hpp
+++ b/include/meltpooldg/reinitialization/reinitialization_operation.hpp
@@ -29,7 +29,7 @@ namespace MeltPoolDG
      *     property of the level set equation
      */
 
-    template <int dim, unsigned int comp>
+    template <int dim>
     class ReinitializationOperation
     {
     private:
@@ -52,10 +52,15 @@ namespace MeltPoolDG
       void
       initialize(const std::shared_ptr<const ScratchData<dim>> &scratch_data_in,
                  const VectorType &                             solution_level_set_in,
-                 const Parameters<double> &                     data_in)
+                 const Parameters<double> &                     data_in,
+                 const unsigned int                             dof_idx_in,
+                 const unsigned int                             quad_idx_in)
       {
         scratch_data = scratch_data_in;
-        scratch_data->initialize_dof_vector(solution_level_set, comp);
+        dof_idx = dof_idx_in;
+        quad_idx = quad_idx_in;
+        scratch_data->initialize_dof_vector(solution_level_set, dof_idx);
+        scratch_data->initialize_dof_vector(solution_level_set, dof_idx);
         /*
          *    initialize the (local) parameters of the reinitialization
          *    from the global user-defined parameters
@@ -64,7 +69,7 @@ namespace MeltPoolDG
         /*
          *    initialize normal_vector_field
          */
-        normal_vector_operation.initialize(scratch_data_in, data_in);
+        normal_vector_operation.initialize(scratch_data_in, data_in, dof_idx_in, quad_idx_in);
         /*
          *    compute the normal vector field and update the initial solution
          */
@@ -88,7 +93,7 @@ namespace MeltPoolDG
         /*
          *    copy the given solution into the member variable
          */
-        scratch_data->initialize_dof_vector(solution_level_set, comp);
+        scratch_data->initialize_dof_vector(solution_level_set, dof_idx);
         solution_level_set.copy_locally_owned_data_from(solution_level_set_in);
         solution_level_set.update_ghost_values();
         /*
@@ -105,8 +110,8 @@ namespace MeltPoolDG
       {
         VectorType src, rhs;
 
-        scratch_data->initialize_dof_vector(src, comp);
-        scratch_data->initialize_dof_vector(rhs, comp);
+        scratch_data->initialize_dof_vector(src, dof_idx);
+        scratch_data->initialize_dof_vector(rhs, dof_idx);
 
         reinit_operator->set_time_increment(d_tau);
 
@@ -115,7 +120,7 @@ namespace MeltPoolDG
         if (reinit_data.do_matrix_free)
           {
             VectorType src_rhs;
-            scratch_data->initialize_dof_vector(src_rhs, comp);
+            scratch_data->initialize_dof_vector(src_rhs, dof_idx);
             src_rhs.copy_locally_owned_data_from(solution_level_set);
             src_rhs.update_ghost_values();
             reinit_operator->create_rhs(rhs, src_rhs);
@@ -141,7 +146,7 @@ namespace MeltPoolDG
                                                                     src,
                                                                     rhs,
                                                                     preconditioner);
-            scratch_data->get_constraint(comp).distribute(src);
+            scratch_data->get_constraint(dof_idx).distribute(src);
           }
 
         solution_level_set += src;
@@ -150,7 +155,7 @@ namespace MeltPoolDG
 
         if (reinit_data.do_print_l2norm)
           {
-            const ConditionalOStream &pcout = scratch_data->get_pcout(comp);
+            const ConditionalOStream &pcout = scratch_data->get_pcout(dof_idx);
             pcout << "| CG: i=" << std::setw(5) << std::left << iter;
             pcout << "\t |ΔΨ|∞ = " << std::setw(15) << std::left << std::setprecision(10)
                   << src.linfty_norm();
@@ -171,11 +176,13 @@ namespace MeltPoolDG
       {
         if (reinit_data.modeltype == "olsson2007")
           {
-            reinit_operator = std::make_unique<OlssonOperator<dim, comp, double>>(
+            reinit_operator = std::make_unique<OlssonOperator<dim, double>>(
               *scratch_data,
               normal_vector_operation.solution_normal_vector,
               reinit_data.constant_epsilon,
-              reinit_data.scale_factor_epsilon);
+              reinit_data.scale_factor_epsilon,
+              dof_idx,
+              quad_idx);
           }
         /*
          * add your desired operators here
@@ -189,14 +196,15 @@ namespace MeltPoolDG
              *  In case of a matrix-based simulation, setup the distributed sparsity pattern and
              *  apply it to the system matrix. This functionality is part of the OperatorBase class.
              */
-            if (!reinit_data.do_matrix_free)
-              reinit_operator->initialize_matrix_based<dim, comp>(*scratch_data);
+        
+        if (!reinit_data.do_matrix_free)
+              reinit_operator->initialize_matrix_based<dim>(*scratch_data);
       }
       void
       update_operator()
       {
         if (!reinit_data.do_matrix_free)
-          reinit_operator->initialize_matrix_based<dim, comp>(*scratch_data);
+          reinit_operator->initialize_matrix_based<dim>(*scratch_data);
       }
 
     private:
@@ -208,7 +216,14 @@ namespace MeltPoolDG
       /*
        *   Computation of the normal vectors
        */
-      NormalVector::NormalVectorOperation<dim, comp> normal_vector_operation;
+      NormalVector::NormalVectorOperation<dim> normal_vector_operation;
+      /*
+       *  Based on the following indices the correct DoFHandler or quadrature rule from 
+       *  ScratchData<dim> object is selected. This is important when ScratchData<dim> holds
+       *  multiple DoFHandlers, quadrature rules, etc.
+       */
+      unsigned int dof_idx;
+      unsigned int quad_idx;
     };
   } // namespace Reinitialization
 } // namespace MeltPoolDG

--- a/include/meltpooldg/reinitialization/reinitialization_problem.hpp
+++ b/include/meltpooldg/reinitialization/reinitialization_problem.hpp
@@ -123,7 +123,8 @@ namespace MeltPoolDG
         /*
          *    initialize the reinitialization operation class
          */
-        reinit_operation.initialize(scratch_data, solution_level_set, base_in->parameters, dof_idx, quad_idx);
+        reinit_operation.initialize(
+          scratch_data, solution_level_set, base_in->parameters, dof_idx, quad_idx);
       }
 
       void
@@ -157,7 +158,8 @@ namespace MeltPoolDG
                            (base_in->parameters.base.n_q_points_1d == 1 ? 4 : 10)));
             else
 #endif
-              quad_idx = scratch_data->attach_quadrature(QGauss<1>(base_in->parameters.base.n_q_points_1d));
+              quad_idx =
+                scratch_data->attach_quadrature(QGauss<1>(base_in->parameters.base.n_q_points_1d));
           }
           /*
            *  setup DoFHandler
@@ -319,9 +321,8 @@ namespace MeltPoolDG
       std::shared_ptr<ScratchData<dim>> scratch_data;
       TimeIterator<double>              time_iterator;
       ReinitializationOperation<dim>    reinit_operation;
-      unsigned int dof_idx;
-      unsigned int quad_idx;
-
+      unsigned int                      dof_idx;
+      unsigned int                      quad_idx;
     };
   } // namespace Reinitialization
 } // namespace MeltPoolDG

--- a/include/meltpooldg/reinitialization/reinitialization_problem.hpp
+++ b/include/meltpooldg/reinitialization/reinitialization_problem.hpp
@@ -123,7 +123,7 @@ namespace MeltPoolDG
         /*
          *    initialize the reinitialization operation class
          */
-        reinit_operation.initialize(scratch_data, solution_level_set, base_in->parameters);
+        reinit_operation.initialize(scratch_data, solution_level_set, base_in->parameters, dof_idx, quad_idx);
       }
 
       void
@@ -157,7 +157,7 @@ namespace MeltPoolDG
                            (base_in->parameters.base.n_q_points_1d == 1 ? 4 : 10)));
             else
 #endif
-              scratch_data->attach_quadrature(QGauss<1>(base_in->parameters.base.n_q_points_1d));
+              quad_idx = scratch_data->attach_quadrature(QGauss<1>(base_in->parameters.base.n_q_points_1d));
           }
           /*
            *  setup DoFHandler
@@ -186,7 +186,7 @@ namespace MeltPoolDG
         constraints.close();
 
         if (do_initial_setup)
-          scratch_data->attach_constraint_matrix(constraints);
+          dof_idx = scratch_data->attach_constraint_matrix(constraints);
 
         /*
          *  create the matrix-free object
@@ -318,7 +318,10 @@ namespace MeltPoolDG
 
       std::shared_ptr<ScratchData<dim>> scratch_data;
       TimeIterator<double>              time_iterator;
-      ReinitializationOperation<dim, 0> reinit_operation;
+      ReinitializationOperation<dim>    reinit_operation;
+      unsigned int dof_idx;
+      unsigned int quad_idx;
+
     };
   } // namespace Reinitialization
 } // namespace MeltPoolDG

--- a/include/meltpooldg/simulations/reinit_circle/reinit_circle.json
+++ b/include/meltpooldg/simulations/reinit_circle/reinit_circle.json
@@ -1,22 +1,22 @@
 {
   "base" : {
-    "application name": "reinit_circle",
-    "problem name": "reinitialization",
-    "dimension": "2",
+    "application name": "  reinit_circle",
+    "problem name": "      reinitialization",
+    "dimension": "         2",
     "global refinements": "6",
-    "degree": "1"
+    "degree": "            1"
   },
-           "reinitialization" : {
-             "reinit max n steps": "30",
-             "reinit modeltype": "olsson2007",
-             "reinit dtau": "0.005",
-             "reinit do matrix free": "true",
-             "reinit do print l2norm": "true"
-           },
-                                "paraview":
+  "reinitialization" : {
+    "reinit max n steps": "    30",
+    "reinit modeltype":       "olsson2007",
+    "reinit dtau": "           0.005",
+    "reinit do matrix free":  "true",
+    "reinit do print l2norm": "true"
+  },
+  "paraview":
   {
-    "paraview filename" : "output/reinit_circle/solution_reinitialization",
-                          "paraview do output" : "true",
-                                                 "paraview print normal vector" : "true"
+    "paraview filename" :            "output/reinit_circle/solution_reinitialization",
+    "paraview do output" :           "true",
+    "paraview print normal vector" : "true"
   }
 }

--- a/include/meltpooldg/simulations/reinit_circle_amr/reinit_circle_amr.json
+++ b/include/meltpooldg/simulations/reinit_circle_amr/reinit_circle_amr.json
@@ -1,31 +1,32 @@
 {
   "base" : {
-    "application name": "reinit_circle_amr",
-    "problem name": "reinitialization",
-    "dimension": "2",
+    "application name":   "reinit_circle_amr",
+    "problem name":       "reinitialization",
+    "dimension": "         2",
     "global refinements": "6",
-    "degree": "1"
+    "degree": "            1"
   },
-           "adaptive meshing" : {
-             "do amr": "true",
-             "upper perc to refine": "0.3",
-             "lower perc to coarsen": "0.00",
-             "max grid refinement level": "8"
-           },
-                                "reinitialization" : {
-                                  "reinit max n steps": "30",
-                                  "reinit modeltype": "olsson2007",
-                                  "reinit dtau": "0.005",
-                                  "reinit do matrix free": "true",
-                                  "reinit do print l2norm": "true",
-                                  "reinit constant epsilon": "0.05"
-                                },
-                                                     "normal vector"
-    : {"normal vec do matrix free": "true"},
-      "paraview":
+  "adaptive meshing" : {
+    "do amr":                    "true",
+    "upper perc to refine": "     0.3",
+    "lower perc to coarsen": "    0.00",
+    "max grid refinement level": "8"
+  },
+  "reinitialization" : {
+    "reinit max n steps": "30",
+    "reinit modeltype": "olsson2007",
+    "reinit dtau": "0.005",
+    "reinit do matrix free": "true",
+    "reinit do print l2norm": "true",
+    "reinit constant epsilon": "0.05"
+  },
+  "normal vector" : { 
+      "normal vec do matrix free": "true"
+  },
+  "paraview":
   {
     "paraview filename" : "solution_reinitialization",
-                          "paraview do output" : "true",
-                                                 "paraview print normal vector" : "true"
+    "paraview do output" : "true",
+    "paraview print normal vector" : "true"
   }
 }

--- a/include/meltpooldg/simulations/rotating_bubble/rotating_bubble.json
+++ b/include/meltpooldg/simulations/rotating_bubble/rotating_bubble.json
@@ -6,31 +6,31 @@
     "global refinements": "6",
     "degree": "1"
   },
-           "levelset" : {
-             "ls do reinitialization": "true",
-             "ls artificial diffusivity": "0.0",
-             "ls do print l2norm": "true",
-             "ls theta": "0.5",
-             "ls start time": "0.0",
-             "ls end time": "1.5707963267948966",
-             "ls time step size": "0.01",
-             "ls do matrix free": "true"
-           },
-                        "reinitialization" : {
-                          "reinit max n steps": "5",
-                          "reinit modeltype": "olsson2007",
-                          "reinit do matrix free": "true",
-                          "reinit do print l2norm": "true",
-                          "reinit eps scale factor": "0.5"
-                        },
-                                             "normal vector"
-    : {"normal vec damping scale factor": "0.5", "normal vec do matrix free": "true"},
-      "paraview":
+  "levelset" : {
+    "ls do reinitialization": "true",
+    "ls artificial diffusivity": "0.0",
+    "ls do print l2norm": "true",
+    "ls theta": "0.5",
+    "ls start time": "0.0",
+    "ls end time": "1.5707963267948966",
+    "ls time step size": "0.01",
+    "ls do matrix free": "true"
+  },
+  "reinitialization" : {
+    "reinit max n steps": "5",
+    "reinit modeltype": "olsson2007",
+    "reinit do matrix free": "true",
+    "reinit do print l2norm": "true",
+    "reinit eps scale factor": "0.5"
+  },
+  "normal vector": { 
+    "normal vec damping scale factor": "0.5",
+    "normal vec do matrix free": "true"},
+  "paraview":
   {
     "paraview do output" : "true",
-                           "paraview print normal vector" : "true",
-                                                            "paraview print advection"
-      : "true",
-        "paraview print boundary id" : "true"
+    "paraview print normal vector" : "true",
+    "paraview print advection" : "true",
+    "paraview print boundary id" : "true"
   }
 }


### PR DESCRIPTION
This framework should replace the template parameter `comp` and should fix issue #24. In the version of this PR, the `initialize`- functions obtain the additional arguments for selecting the current `DoFHandler`, `Quadrature`, etc. (`dof_idx`, `quad_idx`). Since the `initialize` functions should be designed in a compact way, I will think about finding a more elegant solution than simply extending the function argument list.