### PR TITLE
Adaflo integration: update phases and compute gravity force

### DIFF
--- a/include/meltpooldg/flow/adaflo_wrapper.hpp
+++ b/include/meltpooldg/flow/adaflo_wrapper.hpp
@@ -94,13 +94,33 @@ namespace Flow
         VectorTools::convert_block_vector_to_fe_sytem_vector(vec, 
           dof_handler_meltpool, navier_stokes.user_rhs.block(0), navier_stokes.get_dof_handler_u());
       }
-      
-      void
-      update_phases(const LinearAlgebra::distributed::Vector<double> & vec) override
+
+      virtual 
+      VectorizedArray<double> &
+      get_density(const unsigned int cell, const unsigned int q)
       {
-          (void) vec;
-          
-          // TODO
+        return navier_stokes.get_matrix().begin_densities(cell)[q];   
+      }
+      
+      virtual 
+      const VectorizedArray<double> &
+      get_density(const unsigned int cell, const unsigned int q) const
+      {
+        return navier_stokes.get_matrix().begin_densities(cell)[q];   
+      }
+      
+      virtual 
+      VectorizedArray<double> &
+      get_viscosity(const unsigned int cell, const unsigned int q)
+      {
+        return navier_stokes.get_matrix().begin_viscosities(cell)[q];   
+      }
+      
+      virtual 
+      const VectorizedArray<double> &
+      get_viscosity(const unsigned int cell, const unsigned int q) const
+      {
+        return navier_stokes.get_matrix().begin_viscosities(cell)[q];   
       }
 
     private:
@@ -158,11 +178,48 @@ namespace Flow
         AssertThrow(false, ExcNotImplemented ());
       }
       
-      void
-      update_phases(const LinearAlgebra::distributed::Vector<double> & ) override
+      virtual 
+      VectorizedArray<double> &
+      get_density(const unsigned int cell, const unsigned int q)
       {
         AssertThrow(false, ExcNotImplemented ());
+        (void) cell;
+        (void) q;
+        return dummy;   
       }
+      
+      virtual 
+      const VectorizedArray<double> &
+      get_density(const unsigned int cell, const unsigned int q) const
+      {
+        AssertThrow(false, ExcNotImplemented ());
+        (void) cell;
+        (void) q;
+        return dummy;   
+      }
+      
+      virtual 
+      VectorizedArray<double> &
+      get_viscosity(const unsigned int cell, const unsigned int q)
+      {
+        AssertThrow(false, ExcNotImplemented ());
+        (void) cell;
+        (void) q;
+        return dummy;   
+      }
+      
+      virtual 
+      const VectorizedArray<double> &
+      get_viscosity(const unsigned int cell, const unsigned int q) const
+      {
+        AssertThrow(false, ExcNotImplemented ());
+        (void) cell;
+        (void) q;
+        return dummy;   
+      }
+      
+      private:
+          VectorizedArray<double> dummy;
     };
 
 } // namespace Flow

--- a/include/meltpooldg/flow/adaflo_wrapper_parameters.hpp
+++ b/include/meltpooldg/flow/adaflo_wrapper_parameters.hpp
@@ -21,6 +21,17 @@
         ParameterHandler prm_adaflo;
         params.declare_parameters(prm_adaflo);
         params.parse_parameters(parameter_filename, prm_adaflo);
+        
+        // note: by setting the differences to a non-zero value we force
+        //   adaflo to assume that we are running a simulation with variable
+        //   coefficients, i.e., it allocates memory for the data structures
+        //   variable_densities and variable_viscosities, which are accessed 
+        //   during NavierStokesMatrix::begin_densities() and
+        //   NavierStokesMatrix::begin_viscosity(). However, we do not actually
+        //   use these values, since we fill the density and viscosity 
+        //   differently.
+        params.density_diff   = 1.0;
+        params.viscosity_diff = 1.0;
       }
 
       const FlowParameters& get_parameters() const

--- a/include/meltpooldg/flow/flow_base.hpp
+++ b/include/meltpooldg/flow/flow_base.hpp
@@ -16,8 +16,21 @@ namespace MeltPoolDG
       virtual void
       set_surface_tension(const LinearAlgebra::distributed::BlockVector<double> &vec) = 0;
       
-      virtual void
-      update_phases(const LinearAlgebra::distributed::Vector<double> & vec) = 0;
+      virtual 
+      VectorizedArray<double> &
+      get_density(const unsigned int cell, const unsigned int q) = 0;
+      
+      virtual 
+      const VectorizedArray<double> &
+      get_density(const unsigned int cell, const unsigned int q) const = 0;
+      
+      virtual 
+      VectorizedArray<double> &
+      get_viscosity(const unsigned int cell, const unsigned int q) = 0;
+      
+      virtual 
+      const VectorizedArray<double> &
+      get_viscosity(const unsigned int cell, const unsigned int q) const = 0;
     };
 
   } // namespace Flow

--- a/include/meltpooldg/flow/two_phase_flow_problem.hpp
+++ b/include/meltpooldg/flow/two_phase_flow_problem.hpp
@@ -57,6 +57,9 @@ namespace MeltPoolDG
         BlockVectorType surface_tension_force;
         scratch_data->initialize_dof_vector(surface_tension_force, dof_idx);
 
+        // initialize phases and force(?) [TODO] 
+        update_phases(level_set_operation.solution_level_set);
+        
         // TODO: re-enable?
         // output_results(0,base_in->parameters);
         while (!time_iterator.is_finished())
@@ -64,20 +67,31 @@ namespace MeltPoolDG
             const auto dt = time_iterator.get_next_time_increment();
             const auto n  = time_iterator.get_current_time_step_number();
 
+            // solver Navier-Stokes problem
             flow_operation->solve();
 
+            // extract velocity form Navier-Stokes solver ...
             flow_operation->get_velocity(advection_velocity);
 
             // TODO: why here?
             output_results(n, base_in->parameters);
 
+            // ... solve level-set problem with the given advection field
             level_set_operation.solve(dt, advection_velocity);
+            
+            // update 
+            update_phases(level_set_operation.solution_level_set);
+            
+            // accumulate forces: a) gravity force
+            compute_gravity_force(surface_tension_force, false);
+            
+            // ... b) surface tension
             level_set_operation.compute_surface_tension(
-              surface_tension_force, base_in->parameters.flow.surface_tension_coefficient);
+              surface_tension_force, base_in->parameters.flow.surface_tension_coefficient, true);
 
+            //  ... and set forces within the Navier-Stokes solver
             flow_operation->set_surface_tension(surface_tension_force);
 
-            flow_operation->update_phases(level_set_operation.solution_level_set);
           }
       }
 
@@ -185,6 +199,86 @@ namespace MeltPoolDG
                                                               base_in->parameters.adaflo_params);
       }
 
+      /**
+       * Update material parameter of the phases.
+       * 
+       * @todo Find a better place.
+       */
+      void
+      update_phases(const VectorType & vec)
+      {
+        const double density        = 1.0;   // TODO
+        const double density_diff   = 0.0;   // TODO
+        const double viscosity      = 0.001; // TODO
+        const double viscosity_diff = 0.0;   // TODO
+        
+        double dummy;
+          
+      scratch_data->get_matrix_free().template cell_loop<double, VectorType>(
+        [&](const auto &matrix_free, auto &, const auto &src, auto macro_cells) {
+          
+          FECellIntegrator<dim, 1, double> ls_values(matrix_free, 0 /*TODO*/, 0 /*TODO*/);
+
+          for (unsigned int cell = macro_cells.first; cell < macro_cells.second; ++cell)
+            {
+              ls_values.reinit(cell);
+              ls_values.read_dof_values_plain(src);
+              ls_values.evaluate(true, false);
+              
+              for (unsigned int q = 0; q < ls_values.n_q_points; ++q)
+                {
+                  // convert level-set value to heaviside function
+                  const auto indicator = (ls_values.get_value(q) + 1.0) * 0.5;
+                  
+                  // set density
+                  flow_operation->get_density(cell, q) = density + density_diff * indicator;
+                  
+                  // set viscosity
+                  flow_operation->get_viscosity(cell, q) = viscosity + viscosity_diff * indicator;
+                }
+            }
+        },
+        dummy,
+        vec);
+      }
+
+      /**
+       * Compute gravity force.
+       * 
+       * @todo Find a better place.
+       */
+      void
+      compute_gravity_force(BlockVectorType & vec, const bool add = true) const
+      {
+          
+        const double gravity = 0.00; // TODO
+          
+        scratch_data->get_matrix_free().template cell_loop<BlockVectorType, std::nullptr_t>(
+          [&](const auto &matrix_free, auto & force_rhs, const auto &, auto macro_cells) {
+            
+            FECellIntegrator<dim, dim, double> force_values(matrix_free, 0 /*TODO*/, 0 /*TODO*/);
+  
+            for (unsigned int cell = macro_cells.first; cell < macro_cells.second; ++cell)
+              {
+                force_values.reinit(cell);
+                
+                for (unsigned int q = 0; q < force_values.n_q_points; ++q)
+                  {
+                    Tensor<1, dim, VectorizedArray<double> > force;
+                    
+                    force[dim - 1] -= gravity * flow_operation->get_density(cell, q);
+                    
+                    force_values.submit_value(force, q);
+                  }
+                
+                force_values.integrate_scatter(true, false, force_rhs);
+              }
+          },
+          vec,
+          nullptr,
+          add);
+      }
+      
       /*
        *  This function is to create paraview output
        */

--- a/include/meltpooldg/level_set/level_set_operation.hpp
+++ b/include/meltpooldg/level_set/level_set_operation.hpp
@@ -131,7 +131,7 @@ namespace MeltPoolDG
     }
 
     void
-    compute_surface_tension(BlockVectorType& force_rhs, const double surface_tension_coefficient) const
+    compute_surface_tension(BlockVectorType& force_rhs, const double surface_tension_coefficient, const bool add) const
     {
       scratch_data->get_matrix_free().template cell_loop<BlockVectorType, std::nullptr_t>(
         [&](const auto &matrix_free, auto &force_rhs, const auto &, auto macro_cells) {
@@ -169,7 +169,7 @@ namespace MeltPoolDG
         },
         force_rhs,
         nullptr,
-        true);
+        add);
     }
 
     private:


### PR DESCRIPTION
This PR adds `TwoPhaseFlowProblem::update_phases()` and `TwoPhaseFlowProblem::compute_gravity_force()`. The places for the integration is probably not optimal (and is not what we have discussed) but I was not able to come up quickly with a better way (due to annoying dependencies of the computations). 

Let's clean up these functions once we need more complicated viscosity and density definitions.