### PR TITLE
Reuse MatrixFree in NavierStokes and enable simplices

### DIFF
--- a/include/meltpooldg/flow/adaflo_wrapper.hpp
+++ b/include/meltpooldg/flow/adaflo_wrapper.hpp
@@ -70,7 +70,21 @@ namespace MeltPoolDG
             "a valid initial field function for the level set field. A shared_ptr to your initial field "
             "function, e.g., MyInitializeFunc<dim> must be specified as follows: "
             "  this->attach_initial_condition(std::make_shared<MyInitializeFunc<dim>>(), 'navier_stokes_u') "));
+#  if false
         navier_stokes.setup_problem(*base_in->get_initial_condition("navier_stokes_u"));
+#  else
+        navier_stokes.distribute_dofs();
+        navier_stokes.initialize_data_structures();
+        navier_stokes.initialize_matrix_free();
+
+        dealii::VectorTools::interpolate(navier_stokes.mapping,
+                                         navier_stokes.get_dof_handler_u(),
+                                         *base_in->get_initial_condition("navier_stokes_u"),
+                                         navier_stokes.solution.block(0));
+        // navier_stokes.hanging_node_constraints_u.distribute(solution.block(0)); // TODO needed?
+        navier_stokes.solution.update_ghost_values();
+        navier_stokes.solution_old.update_ghost_values();
+#  endif
       }
 
       /**

--- a/include/meltpooldg/flow/two_phase_flow_problem.hpp
+++ b/include/meltpooldg/flow/two_phase_flow_problem.hpp
@@ -140,15 +140,32 @@ namespace MeltPoolDG
         /*
          *  setup mapping
          */
-        scratch_data->set_mapping(MappingQGeneric<dim>(base_in->parameters.base.degree));
+#ifdef DEAL_II_WITH_SIMPLEX_SUPPORT
+        if (base_in->parameters.base.do_simplex)
+          scratch_data->set_mapping(
+            MappingFE<dim>(Simplex::FE_P<dim>(base_in->parameters.base.degree)));
+        else
+#endif
+          scratch_data->set_mapping(MappingQGeneric<dim>(base_in->parameters.base.degree));
         /*
          *  setup DoFHandler
          */
         dof_handler.reinit(*base_in->triangulation);
-        dof_handler.distribute_dofs(FE_Q<dim>(base_in->parameters.base.degree));
-
         flow_dof_handler.reinit(*base_in->triangulation);
-        flow_dof_handler.distribute_dofs(FE_Q<dim>(base_in->parameters.flow.velocity_degree));
+
+#ifdef DEAL_II_WITH_SIMPLEX_SUPPORT
+        if (base_in->parameters.base.do_simplex)
+          {
+            dof_handler.distribute_dofs(Simplex::FE_P<dim>(base_in->parameters.base.degree));
+            flow_dof_handler.distribute_dofs(
+              Simplex::FE_P<dim>(base_in->parameters.flow.velocity_degree));
+          }
+        else
+#endif
+          {
+            dof_handler.distribute_dofs(FE_Q<dim>(base_in->parameters.base.degree));
+            flow_dof_handler.distribute_dofs(FE_Q<dim>(base_in->parameters.flow.velocity_degree));
+          }
 
         scratch_data->attach_dof_handler(dof_handler);
         scratch_data->attach_dof_handler(dof_handler);
@@ -191,14 +208,26 @@ namespace MeltPoolDG
         /*
          *  create quadrature rule
          */
-        ls_quad_idx =
-          scratch_data->attach_quadrature(QGauss<1>(base_in->parameters.base.n_q_points_1d));
-        flow_quad_idx =
-          scratch_data->attach_quadrature(QGauss<1>(base_in->parameters.flow.velocity_degree + 1));
+#ifdef DEAL_II_WITH_SIMPLEX_SUPPORT
+        if (base_in->parameters.base.do_simplex)
+          {
+            ls_quad_idx = scratch_data->attach_quadrature(
+              Simplex::QGauss<1>(base_in->parameters.base.n_q_points_1d));
+            flow_quad_idx = scratch_data->attach_quadrature(
+              Simplex::QGauss<1>(base_in->parameters.flow.velocity_degree + 1));
+          }
+        else
+#endif
+          {
+            ls_quad_idx =
+              scratch_data->attach_quadrature(QGauss<1>(base_in->parameters.base.n_q_points_1d));
+            flow_quad_idx = scratch_data->attach_quadrature(
+              QGauss<1>(base_in->parameters.flow.velocity_degree + 1));
+          }
 
-        /*
-         *    initialize the flow operation class
-         */
+          /*
+           *    initialize the flow operation class
+           */
 #ifdef MELT_POOL_DG_WITH_ADAFLO
 
         flow_operation = std::make_shared<AdafloWrapper<dim>>(*scratch_data, flow_dof_idx, base_in);
@@ -417,7 +446,8 @@ namespace MeltPoolDG
             DataOut<dim> data_out;
 
             DataOutBase::VtkFlags flags;
-            flags.write_higher_order_cells = true;
+            if (parameters.base.do_simplex == false)
+              flags.write_higher_order_cells = true;
             data_out.set_flags(flags);
 
             data_out.attach_dof_handler(dof_handler);

--- a/include/meltpooldg/flow/two_phase_flow_problem.hpp
+++ b/include/meltpooldg/flow/two_phase_flow_problem.hpp
@@ -195,10 +195,23 @@ namespace MeltPoolDG
           scratch_data->attach_quadrature(QGauss<1>(base_in->parameters.base.n_q_points_1d));
         flow_quad_idx =
           scratch_data->attach_quadrature(QGauss<1>(base_in->parameters.flow.velocity_degree + 1));
+
+        /*
+         *    initialize the flow operation class
+         */
+#ifdef MELT_POOL_DG_WITH_ADAFLO
+
+        flow_operation = std::make_shared<AdafloWrapper<dim>>(*scratch_data, flow_dof_idx, base_in);
+#else
+        AssertThrow(false, ExcNotImplemented());
+#endif
+
         /*
          *  create the matrix-free object
          */
+#if false
         scratch_data->build();
+#endif
         /*
          *  initialize the time stepping scheme
          */
@@ -242,14 +255,6 @@ namespace MeltPoolDG
                                        dof_no_bc_idx,
                                        ls_quad_idx,
                                        flow_dof_idx);
-        /*
-         *    initialize the flow operation class
-         */
-#ifdef MELT_POOL_DG_WITH_ADAFLO
-        flow_operation = std::make_shared<AdafloWrapper<dim>>(*scratch_data, flow_dof_idx, base_in);
-#else
-        AssertThrow(false, ExcNotImplemented());
-#endif
         /*
          *    initialize the melt pool operation class
          */

--- a/include/meltpooldg/interface/parameters.hpp
+++ b/include/meltpooldg/interface/parameters.hpp
@@ -249,9 +249,9 @@ namespace MeltPoolDG
 
           flow.density   = (flow.density > 0.0) ? flow.density : adaflo_params.params.density;
           flow.viscosity = (flow.viscosity > 0.0) ? flow.viscosity : adaflo_params.params.viscosity;
-          flow.velocity_degree        = (flow.velocity_degree > 0.0) ?
-                                          flow.velocity_degree :
-                                          adaflo_params.params.velocity_degree;
+          flow.velocity_degree = (flow.velocity_degree > 0.0) ?
+                                   flow.velocity_degree :
+                                   adaflo_params.params.velocity_degree;
           flow.velocity_n_q_points_1d = (flow.velocity_n_q_points_1d < 1) ?
                                           flow.velocity_degree + 1 :
                                           flow.velocity_n_q_points_1d;

--- a/include/meltpooldg/interface/parameters.hpp
+++ b/include/meltpooldg/interface/parameters.hpp
@@ -262,6 +262,7 @@ namespace MeltPoolDG
           adaflo_params.params.time_step_size_start = flow.time_step_size;
           adaflo_params.params.time_step_size_min   = flow.time_step_size;
           adaflo_params.params.time_step_size_max   = flow.time_step_size;
+          adaflo_params.params.use_simplex_mesh     = base.do_simplex;
         }
 
 #endif

--- a/include/meltpooldg/interface/scratch_data.hpp
+++ b/include/meltpooldg/interface/scratch_data.hpp
@@ -308,6 +308,12 @@ namespace MeltPoolDG
       return this->face_quad;
     }
 
+    MatrixFree<dim, number, VectorizedArrayType> &
+    get_matrix_free()
+    {
+      return this->matrix_free;
+    }
+
     const MatrixFree<dim, number, VectorizedArrayType> &
     get_matrix_free() const
     {


### PR DESCRIPTION
This PR allows us to have direct access to `NavierStokesinitialize_matrix_free()`.