### PR TITLE
"Fix" convergence issue

### DIFF
--- a/include/meltpooldg/flow/adaflo_wrapper.hpp
+++ b/include/meltpooldg/flow/adaflo_wrapper.hpp
@@ -79,6 +79,7 @@ namespace MeltPoolDG
       void
       solve() override
       {
+        navier_stokes.get_constraints_u().set_zero(navier_stokes.user_rhs.block(0));
         navier_stokes.advance_time_step();
       }
 


### PR DESCRIPTION
This is the guilty guy:
https://github.com/MeltPoolDG/MeltPoolDG/blob/b67627f8a620232d1c92d5340aa56dda7bb7dbb9/include/meltpooldg/flow/two_phase_flow_problem.hpp#L190

We should get the constraint matrix from `NavierStokes` as proposed by #58:
https://github.com/MeltPoolDG/MeltPoolDG/blob/b33a2d67b6ef416e83419bcbf352272e925f3337/include/meltpooldg/flow/adaflo_wrapper.hpp#L82

... not yet there ;)