### PR TITLE
fix wrong degree in spurious currents input

### DIFF
--- a/include/meltpooldg/simulations/spurious_currents/spurious_currents.json
+++ b/include/meltpooldg/simulations/spurious_currents/spurious_currents.json
@@ -3,7 +3,7 @@
     "problem name": "two_phase_flow",
     "application name": "spurious_currents",
     "dimension": "2",
-    "degree": "2",
+    "degree": "1",
     "global refinements": "6",
     "gravity": "0.00"
   },


### PR DESCRIPTION
This PR fixes the level set degree in the input file of the spurious currents example.

@peterrum I will definitely address a "proper" choice of the degree parameter in a follow-up PR.
@JPmoep FYI