### PR TITLE
Fix spurious currents

### DIFF
--- a/include/meltpooldg/interface/parameters.hpp
+++ b/include/meltpooldg/interface/parameters.hpp
@@ -53,6 +53,7 @@ namespace MeltPoolDG
   struct LevelSetData
   {
     bool        do_reinitialization     = false;
+    int         n_initial_reinit_steps  = -1.0;
     number      artificial_diffusivity  = 0.0;
     std::string time_integration_scheme = "crank_nicolson";
     number      start_time              = 0.0;
@@ -239,6 +240,13 @@ namespace MeltPoolDG
        */
       if (amr.min_grid_refinement_level == 1)
         amr.min_grid_refinement_level = base.global_refinements;
+
+      /*
+       *  set the number of initial reinitialization steps equal to the number of reinit steps
+       *  if no value is provided
+       */
+      if (ls.do_reinitialization && ls.n_initial_reinit_steps < 0.0)
+        ls.n_initial_reinit_steps = reinit.max_n_steps;
       /*
        *  set the melt pool center if not specified
        */
@@ -453,6 +461,10 @@ namespace MeltPoolDG
         prm.add_parameter("ls do reinitialization",
                           ls.do_reinitialization,
                           "Defines if reinitialization of level set function is activated");
+        prm.add_parameter(
+          "ls n initial reinit steps",
+          ls.n_initial_reinit_steps,
+          "Defines the number of initial reinitialization steps of the level set function.");
         prm.add_parameter("ls time integration scheme",
                           ls.time_integration_scheme,
                           "Determines the time integration scheme.",

--- a/include/meltpooldg/level_set/level_set_operation.hpp
+++ b/include/meltpooldg/level_set/level_set_operation.hpp
@@ -138,6 +138,7 @@ namespace MeltPoolDG
          *    dirichlet constraints of the reinitialization.
          */
         do_reinitialization();
+        reinit_time_iterator.reset_max_n_time_steps(base_in->parameters.reinit.max_n_steps);
         /*
          * 2) From now on, the initial solution of the level set equation will be reinitialized
          *    with dirichlet constraints of the reinitialization.
@@ -486,7 +487,7 @@ namespace MeltPoolDG
                                      data_in.reinit.dtau :
                                      scratch_data->get_min_cell_size(ls_dof_idx) *
                                        data_in.reinit.scale_factor_epsilon,
-                                   data_in.reinit.max_n_steps,
+                                   (unsigned int)data_in.ls.n_initial_reinit_steps,
                                    false});
 
         reinit_constant_epsilon     = data_in.reinit.constant_epsilon;     //@todo: better solution

--- a/include/meltpooldg/reinitialization/reinitialization_operation_adaflo_wrapper.hpp
+++ b/include/meltpooldg/reinitialization/reinitialization_operation_adaflo_wrapper.hpp
@@ -62,7 +62,6 @@ namespace MeltPoolDG
                                     cell_diameters,
                                     cell_diameter_min,
                                     cell_diameter_max);
-        set_adaflo_parameters(parameters, reinit_dof_idx, reinit_quad_idx, normal_dof_idx);
 
         /*
          * initialize normal_vector_operation from adaflo

--- a/include/meltpooldg/simulations/spurious_currents/spurious_currents.hpp
+++ b/include/meltpooldg/simulations/spurious_currents/spurious_currents.hpp
@@ -26,8 +26,9 @@ namespace MeltPoolDG
       class InitializePhi : public Function<dim>
       {
       public:
-        InitializePhi()
+        InitializePhi(const double eps)
           : Function<dim>()
+          , eps(eps)
         {}
         virtual double
         value(const Point<dim> &p, const unsigned int component = 0) const
@@ -39,9 +40,16 @@ namespace MeltPoolDG
           for (unsigned int d = 0; d < dim; ++d)
             center[d] = 0.02 + 0.01 * d;
 
-          return UtilityFunctions::CharacteristicFunctions::sgn(
-            UtilityFunctions::DistanceFunctions::spherical_manifold<dim>(p, center, 0.5));
+          return UtilityFunctions::CharacteristicFunctions::tanh_characteristic_function(
+            UtilityFunctions::DistanceFunctions::spherical_manifold<dim>(p, center, 0.5), eps);
+
+          // Alternative if no signed distance function should be used in the beginning:
+          //
+          // return UtilityFunctions::CharacteristicFunctions::sgn(
+          // UtilityFunctions::DistanceFunctions::spherical_manifold<dim>(p, center, 0.5));
         }
+
+        double eps = 0.0;
       };
 
       /*
@@ -57,6 +65,7 @@ namespace MeltPoolDG
         {
           this->set_parameters();
         }
+
 
         void
         create_spatial_discretization() override
@@ -87,7 +96,22 @@ namespace MeltPoolDG
         void
         set_field_conditions() override
         {
-          this->attach_initial_condition(std::make_shared<InitializePhi<dim>>(), "level_set");
+          double eps = 0.0;
+          if (this->parameters.reinit.implementation == "adaflo" ||
+              this->parameters.ls.implementation == "adaflo")
+            eps = this->parameters.reinit.constant_epsilon > 0.0 ?
+                    this->parameters.reinit.constant_epsilon :
+                    GridTools::minimal_cell_diameter(*this->triangulation) /
+                      this->parameters.base.degree / std::sqrt(dim);
+          else
+            eps = this->parameters.reinit.constant_epsilon > 0.0 ?
+                    this->parameters.reinit.constant_epsilon :
+                    GridTools::minimal_cell_diameter(*this->triangulation) / std::sqrt(dim) *
+                      this->parameters.reinit.scale_factor_epsilon;
+
+          AssertThrow(eps > 0, ExcNotImplemented());
+
+          this->attach_initial_condition(std::make_shared<InitializePhi<dim>>(eps), "level_set");
           this->attach_initial_condition(std::make_shared<Functions::ZeroFunction<dim>>(dim),
                                          "navier_stokes_u");
         }

--- a/include/meltpooldg/utilities/postprocessor.hpp
+++ b/include/meltpooldg/utilities/postprocessor.hpp
@@ -45,7 +45,7 @@ namespace MeltPoolDG
       , mapping(mapping_in)
       , triangulation(triangulation_in)
       , pcout(std::cout, (Utilities::MPI::this_mpi_process(mpi_communicator) == 0))
-      , do_simplex(!triangulation.all_reference_cell_types_are_hyper_cube())
+      , do_simplex(!triangulation.all_reference_cells_are_hyper_cube())
     {}
 
     /*

--- a/include/meltpooldg/utilities/timeiterator.hpp
+++ b/include/meltpooldg/utilities/timeiterator.hpp
@@ -64,6 +64,12 @@ namespace MeltPoolDG
       current_time_increment *= factor;
     }
 
+    void
+    reset_max_n_time_steps(const int time_steps_in)
+    {
+      time_data.max_n_time_steps = time_steps_in;
+    }
+
     number
     get_current_time() const
     {


### PR DESCRIPTION
This PR improves the spurious currents simulation by computing the initial smooth level set field from the analytical solution of the reinitialization. An additional parameter `ls n initial reinit steps` is introduced that enables to control the number of initial reinitialization steps. 