### PR TITLE
Heat transfer: pass velocity with pointer

### DIFF
--- a/include/meltpooldg/heat/heat_transfer_operation.hpp
+++ b/include/meltpooldg/heat/heat_transfer_operation.hpp
@@ -33,7 +33,6 @@ namespace MeltPoolDG::Heat
     const unsigned int temp_dof_idx;
     const unsigned int temp_hanging_nodes_dof_idx;
     const unsigned int temp_quad_idx;
-    const unsigned int vel_dof_idx;
     /*
      *    This are the primary solution variables of this module, which will be also publically
      *    accessible for output_results.
@@ -41,7 +40,9 @@ namespace MeltPoolDG::Heat
     VectorType temperature;
     VectorType temperature_old;
     VectorType heat_source;
-    VectorType velocity;
+
+    const unsigned int vel_dof_idx;
+    VectorType *       velocity;
 
     std::shared_ptr<HeatTransferOperator<dim>> heat_operator;
 
@@ -52,13 +53,15 @@ namespace MeltPoolDG::Heat
                           const unsigned int                              temp_dof_idx_in,
                           const unsigned int temp_hanging_nodes_dof_idx_in,
                           const unsigned int temp_quad_idx_in,
-                          const unsigned int vel_dof_idx_in)
+                          const unsigned int vel_dof_idx_in = 0,
+                          VectorType *       velocity_in    = nullptr)
       : scratch_data(scratch_data_in)
       , heat_data(heat_data_in)
       , temp_dof_idx(temp_dof_idx_in)
       , temp_hanging_nodes_dof_idx(temp_hanging_nodes_dof_idx_in)
       , temp_quad_idx(temp_quad_idx_in)
       , vel_dof_idx(vel_dof_idx_in)
+      , velocity(velocity_in)
     {
       heat_operator = std::make_shared<HeatTransferOperator<dim>>(bc_data,
                                                                   scratch_data,
@@ -81,19 +84,11 @@ namespace MeltPoolDG::Heat
     }
 
     void
-    set_velocity(const VectorType &velocity_in)
-    {
-      scratch_data.initialize_dof_vector(velocity, vel_dof_idx);
-      velocity.copy_locally_owned_data_from(velocity_in);
-    }
-
-    void
     reinit()
     {
       scratch_data.initialize_dof_vector(temperature, temp_dof_idx);
       scratch_data.initialize_dof_vector(temperature_old, temp_dof_idx);
       scratch_data.initialize_dof_vector(heat_source, temp_dof_idx);
-      scratch_data.initialize_dof_vector(velocity, vel_dof_idx);
     }
 
     void
@@ -146,10 +141,10 @@ namespace MeltPoolDG::Heat
     void
     attach_output_vectors(DataOut<dim> &data_out) const
     {
-      MeltPoolDG::VectorTools::update_ghost_values(temperature,
-                                                   temperature_old,
-                                                   heat_source,
-                                                   velocity);
+      MeltPoolDG::VectorTools::update_ghost_values(temperature, temperature_old, heat_source);
+      if (velocity)
+        MeltPoolDG::VectorTools::update_ghost_values(*velocity);
+
       /**
        *  temperature
        */
@@ -169,7 +164,7 @@ namespace MeltPoolDG::Heat
                                heat_source,
                                "heat_source");
 
-      if (heat_data.with_velocity)
+      if (velocity)
         {
           std::vector<DataComponentInterpretation::DataComponentInterpretation>
             vector_component_interpretation(
@@ -178,7 +173,7 @@ namespace MeltPoolDG::Heat
            *  velocity
            */
           data_out.add_data_vector(scratch_data.get_dof_handler(vel_dof_idx),
-                                   velocity,
+                                   *velocity,
                                    std::vector<std::string>(dim, "velocity"),
                                    vector_component_interpretation);
         }

--- a/include/meltpooldg/heat/heat_transfer_operator.hpp
+++ b/include/meltpooldg/heat/heat_transfer_operator.hpp
@@ -98,8 +98,8 @@ namespace MeltPoolDG::Heat
     const VectorType &heat_source;
 
     // configuration if heat particles are transported with a given velocity field
-    const unsigned int vel_dof_idx; //@todo: fill
-    const VectorType & velocity;    //@todo: fill
+    const unsigned int vel_dof_idx;
+    const VectorType * velocity;
 
     // configuration if two phases are given
     const unsigned int ls_dof_idx;             //@todo: fill
@@ -114,10 +114,10 @@ namespace MeltPoolDG::Heat
                          const unsigned int                              temp_quad_idx_in,
                          const VectorType &                              temperature_in,
                          const VectorType &                              heat_source_in,
-                         const unsigned int                              vel_dof_idx_in,
-                         const VectorType &                              velocity_in,
-                         const unsigned int                              ls_dof_idx_in = 0,
-                         const VectorType *level_set_as_heaviside_in                   = nullptr)
+                         const unsigned int                              vel_dof_idx_in = 0,
+                         const VectorType *                              velocity_in    = nullptr,
+                         const unsigned int                              ls_dof_idx_in  = 0,
+                         const VectorType *level_set_as_heaviside_in                    = nullptr)
       // clang-format off
     : scratch_data           ( scratch_data_in           )
     , data                   ( data_in                   )
@@ -157,7 +157,9 @@ namespace MeltPoolDG::Heat
     {
       AssertThrow(this->d_tau > 0.0, ExcMessage("advection diffusion operator: d_tau must be set"));
 
-      MeltPoolDG::VectorTools::update_ghost_values(temperature, velocity);
+      MeltPoolDG::VectorTools::update_ghost_values(temperature);
+      if (velocity)
+        MeltPoolDG::VectorTools::update_ghost_values(*velocity);
 
       scratch_data.get_matrix_free().template loop<VectorType, VectorType>(
         [&](const auto &matrix_free, auto &dst, const auto &src, auto cell_range) {
@@ -173,7 +175,9 @@ namespace MeltPoolDG::Heat
         dst,
         src,
         true /*zero dst vector*/);
-      MeltPoolDG::VectorTools::zero_out_ghosts(temperature, velocity);
+      MeltPoolDG::VectorTools::zero_out_ghosts(temperature);
+      if (velocity)
+        MeltPoolDG::VectorTools::zero_out_ghosts(*velocity);
     }
 
     void
@@ -191,10 +195,10 @@ namespace MeltPoolDG::Heat
           temp_vals.reinit(cell);
           temp_vals.gather_evaluate(src, true, true);
 
-          if (data.with_velocity)
+          if (velocity)
             {
               velocity_vals.reinit(cell);
-              velocity_vals.gather_evaluate(velocity, true, false);
+              velocity_vals.gather_evaluate(*velocity, true, false);
             }
 
           for (unsigned int q_index = 0; q_index < temp_vals.n_q_points; ++q_index)
@@ -205,7 +209,7 @@ namespace MeltPoolDG::Heat
 
               auto val =
                 data.density * data.capacity * this->d_tau_inv * temp_vals.get_value(q_index);
-              if (data.with_velocity)
+              if (velocity)
                 {
                   val += data.density * data.capacity * temp_vals.get_gradient(q_index) *
                          velocity_vals.get_value(q_index);
@@ -302,10 +306,10 @@ namespace MeltPoolDG::Heat
           heat_source_vals.read_dof_values_plain(heat_source);
           heat_source_vals.evaluate(true, false);
 
-          if (data.with_velocity)
+          if (velocity)
             {
               velocity_vals.reinit(cell);
-              velocity_vals.read_dof_values_plain(velocity);
+              velocity_vals.read_dof_values_plain(*velocity);
               velocity_vals.evaluate(true, false);
             }
 
@@ -316,7 +320,7 @@ namespace MeltPoolDG::Heat
                            this->d_tau_inv -
                          heat_source_vals.get_value(q_index);
 
-              if (data.with_velocity)
+              if (velocity)
                 {
                   val += data.density * data.capacity * temp_vals.get_gradient(q_index) *
                          velocity_vals.get_value(q_index);

--- a/include/meltpooldg/heat/heat_transfer_problem.hpp
+++ b/include/meltpooldg/heat/heat_transfer_problem.hpp
@@ -12,33 +12,13 @@ namespace MeltPoolDG::Heat
   using namespace dealii;
 
   template <int dim>
-  class VelocityField : public Function<dim>
-  {
-  public:
-    VelocityField(double velocity)
-      : Function<dim>(dim)
-      , vel(velocity)
-    {}
-
-    double
-    value(const Point<dim> &, const unsigned int component) const override
-    {
-      if (component == 0)
-        return -vel;
-      else
-        return 0.0;
-    }
-
-  private:
-    const double vel;
-  };
-
-  template <int dim>
   class HeatTransferProblem : public ProblemBase<dim>
   {
   private:
     using VectorType      = LinearAlgebra::distributed::Vector<double>;
     using BlockVectorType = LinearAlgebra::distributed::BlockVector<double>;
+
+    VectorType velocity;
 
     TimeIterator<double> time_iterator;
     DoFHandler<dim>      dof_handler;
@@ -72,6 +52,9 @@ namespace MeltPoolDG::Heat
 
           scratch_data->get_pcout()
             << "t= " << std::setw(10) << std::left << time_iterator.get_current_time();
+
+          if (base_in->parameters.heat.velocity != 0.0)
+            compute_velocity_field(*base_in->get_velocity_field("heat_transfer"));
 
           heat_operation->solve(dt);
 
@@ -182,6 +165,16 @@ namespace MeltPoolDG::Heat
       initial_solution.update_ghost_values();
 
       /*
+       *    set velocity field
+       */
+      VectorType *velocity_ptr = nullptr;
+      if (base_in->parameters.heat.velocity != 0.0)
+        {
+          compute_velocity_field(*base_in->get_velocity_field("heat_transfer"));
+          velocity_ptr = &velocity;
+        }
+
+      /*
        *    initialize the heat operation class
        */
       heat_operation =
@@ -191,26 +184,10 @@ namespace MeltPoolDG::Heat
                                                      temp_dof_idx,
                                                      temp_hanging_nodes_dof_idx,
                                                      temp_quad_idx,
-                                                     velocity_dof_idx);
+                                                     velocity_dof_idx,
+                                                     velocity_ptr);
 
       heat_operation->set_initial_condition(initial_solution);
-
-      /*
-       *    set velocity field
-       */
-      VectorType velocity;
-      scratch_data->initialize_dof_vector(velocity, velocity_dof_idx);
-
-      if (base_in->parameters.heat.with_velocity)
-        {
-          VelocityField<dim> function(base_in->parameters.heat.velocity);
-          dealii::VectorTools::interpolate(scratch_data->get_mapping(),
-                                           scratch_data->get_dof_handler(velocity_dof_idx),
-                                           function,
-                                           velocity);
-        }
-      velocity.update_ghost_values();
-      heat_operation->set_velocity(velocity);
 
       /*
        *  initialize postprocessor
@@ -295,6 +272,23 @@ namespace MeltPoolDG::Heat
 
       if (do_reinit)
         heat_operation->reinit();
+    }
+
+    void
+    compute_velocity_field(Function<dim> &field_function)
+    {
+      scratch_data->initialize_dof_vector(velocity, velocity_dof_idx);
+      /*
+       *  set the current time to the advection field function
+       */
+      field_function.set_time(time_iterator.get_current_time());
+      /*
+       *  interpolate the values of the advection velocity
+       */
+      dealii::VectorTools::interpolate(scratch_data->get_mapping(),
+                                       scratch_data->get_dof_handler(velocity_dof_idx),
+                                       field_function,
+                                       velocity);
     }
 
     /*

--- a/include/meltpooldg/interface/fieldconditions.hpp
+++ b/include/meltpooldg/interface/fieldconditions.hpp
@@ -11,6 +11,7 @@ namespace MeltPoolDG
   {
     std::shared_ptr<Function<dim>> initial_field;
     std::shared_ptr<Function<dim>> advection_field;
+    std::shared_ptr<Function<dim>> velocity_field;
     std::shared_ptr<Function<dim>> exact_solution_field;
   };
 } // namespace MeltPoolDG

--- a/include/meltpooldg/interface/parameters.hpp
+++ b/include/meltpooldg/interface/parameters.hpp
@@ -157,7 +157,6 @@ namespace MeltPoolDG
     number                      density                = 0.0;
     number                      conductivity           = 0.0;
     number                      capacity               = 0.0;
-    bool                        with_velocity          = false;
     number                      velocity               = 0.0;
     TimeSteppingData<number>    time_stepping;
     NonlinearSolverData<number> nlsolve;
@@ -770,10 +769,6 @@ namespace MeltPoolDG
                           "Conductivity for the heat problem.");
         prm.add_parameter("heat capacity", heat.capacity, "Heat capacity for the heat problem.");
         prm.add_parameter("heat density", heat.density, "Density for the heat problem.");
-        prm.add_parameter(
-          "heat with velocity",
-          heat.with_velocity,
-          "Set this parameter if the heat equation should include a velocity field.");
         prm.add_parameter("heat velocity", heat.velocity, "Velocity.");
       }
       prm.leave_subsection();

--- a/include/meltpooldg/interface/simulationbase.hpp
+++ b/include/meltpooldg/interface/simulationbase.hpp
@@ -87,6 +87,16 @@ namespace MeltPoolDG
 
     template <typename FunctionType>
     void
+    attach_velocity_field(std::shared_ptr<FunctionType> velocity, const std::string operation_name)
+    {
+      if (!field_conditions_map[operation_name])
+        field_conditions_map[operation_name] = std::make_shared<FieldConditions<dim>>();
+
+      field_conditions_map[operation_name]->velocity_field = velocity;
+    }
+
+    template <typename FunctionType>
+    void
     attach_exact_solution(std::shared_ptr<FunctionType> exact_solution,
                           const std::string             operation_name)
     {
@@ -247,6 +257,12 @@ namespace MeltPoolDG
     get_advection_field(const std::string operation_name)
     {
       return field_conditions_map[operation_name]->advection_field;
+    }
+
+    const std::shared_ptr<Function<dim>> &
+    get_velocity_field(const std::string operation_name)
+    {
+      return field_conditions_map[operation_name]->velocity_field;
     }
 
     const std::shared_ptr<Function<dim>> &

--- a/include/meltpooldg/simulations/unidirectional_heat_transfer/unidirectional_heat_transfer.hpp
+++ b/include/meltpooldg/simulations/unidirectional_heat_transfer/unidirectional_heat_transfer.hpp
@@ -77,6 +77,28 @@ namespace MeltPoolDG::Simulation::UnidirectionalHeatTransfer
   };
 
   template <int dim>
+  class UnidirectionalVelocityField : public Function<dim>
+  {
+  public:
+    UnidirectionalVelocityField(double velocity)
+      : Function<dim>(dim)
+      , vel(velocity)
+    {}
+
+    double
+    value(const Point<dim> &, const unsigned int component) const override
+    {
+      if (component == 0)
+        return -vel;
+      else
+        return 0.0;
+    }
+
+  private:
+    const double vel;
+  };
+
+  template <int dim>
   class SimulationUnidirectionalHeatTransfer : public SimulationBase<dim>
   {
   public:
@@ -161,6 +183,10 @@ namespace MeltPoolDG::Simulation::UnidirectionalHeatTransfer
                                        "heat_transfer");
       else
         this->attach_initial_condition(std::make_shared<LinearTemp<dim>>(), "heat_transfer");
+
+      this->attach_velocity_field(std::make_shared<UnidirectionalVelocityField<dim>>(
+                                    this->parameters.heat.velocity),
+                                  "heat_transfer");
     }
 
   private:

--- a/include/meltpooldg/simulations/unidirectional_heat_transfer/unidirectional_heat_transfer_with_velocity.json
+++ b/include/meltpooldg/simulations/unidirectional_heat_transfer/unidirectional_heat_transfer_with_velocity.json
@@ -4,7 +4,7 @@
     "degree": "1",
     "dimension": "2",
     "do simplex": "false",
-    "do print parameters": "true",
+    "do print parameters": "false",
     "global refinements": "7",
     "problem name": "heat_transfer"
   },
@@ -15,8 +15,7 @@
     "heat conductivity": "55.563",
     "heat capacity": "460",
     "heat density": "7850.0",
-    "heat with velocity": "true",
-    "heat velocity": "0.0001",
+    "heat velocity": "0.01",
     "heat start time": "0.0",
     "heat time step size": "0.001",
     "heat end time": "1.0",

--- a/tests/unidirectional_heat_transfer_with_velocity.json
+++ b/tests/unidirectional_heat_transfer_with_velocity.json
@@ -15,7 +15,6 @@
     "heat conductivity": "55.563",
     "heat capacity": "460",
     "heat density": "7850.0",
-    "heat with velocity": "true",
     "heat velocity": "0.01",
     "heat start time": "0.0",
     "heat time step size": "0.001",


### PR DESCRIPTION
This PR moves the velocity vector to the heat problem. The heat operation and operator get a pointer to that vector. If the pointer is a nullptr the velocity terms are ignored.

Also, the velocity field function is now handled by the field conditions map.