### PR TITLE
Couple two phase flow with heat transfer

### DIFF
--- a/include/meltpooldg/flow/two_phase_flow_problem.hpp
+++ b/include/meltpooldg/flow/two_phase_flow_problem.hpp
@@ -24,6 +24,7 @@
 #include <meltpooldg/flow/adaflo_wrapper.hpp>
 #include <meltpooldg/flow/flow_base.hpp>
 #include <meltpooldg/flow/surface_tension_operation.hpp>
+#include <meltpooldg/heat/heat_transfer_operation.hpp>
 #include <meltpooldg/interface/problembase.hpp>
 #include <meltpooldg/interface/simulationbase.hpp>
 #include <meltpooldg/level_set/level_set_operation.hpp>
@@ -87,6 +88,11 @@ namespace MeltPoolDG::Flow
           // update the two phases
           update_phases(level_set_operation.get_level_set_as_heaviside(), base_in->parameters);
 
+          if (!melt_pool_operation && heat_operation)
+            {
+              heat_operation->solve(dt);
+            }
+
           // accumulate forces: a) gravity force
           compute_gravity_force(vel_force_rhs, base_in->parameters.base.gravity, true);
 
@@ -104,6 +110,24 @@ namespace MeltPoolDG::Flow
               flow_operation->get_dof_handler_idx_hanging_nodes_velocity(),
               flow_operation->get_quad_idx_velocity(),
               false /* false means not to zero out the vorce vector */);
+
+          // ... c) temperature-dependent surface tension
+          if (!melt_pool_operation && heat_operation &&
+              base_in->parameters.flow.temperature_dependent_surface_tension_coefficient > 0.0)
+            Flow::SurfaceTensionOperation<dim>::compute_temperature_dependent_surface_tension(
+              *scratch_data,
+              vel_force_rhs,
+              level_set_operation.get_level_set_as_heaviside(),
+              level_set_operation.get_curvature(),
+              heat_operation->get_temperature(),
+              base_in->parameters.flow.surface_tension_coefficient,
+              base_in->parameters.flow.temperature_dependent_surface_tension_coefficient,
+              base_in->parameters.flow.surface_tension_reference_temperature,
+              ls_dof_idx,
+              vel_dof_idx,
+              flow_operation->get_quad_idx_velocity(),
+              temp_dof_idx,
+              false /*false means add to force vector*/);
 
           if (evaporation_operation)
             {
@@ -283,6 +307,38 @@ namespace MeltPoolDG::Flow
                                      vel_dof_idx,
                                      ls_dof_idx /* todo: ls_zero_bc_idx*/);
       /*
+       *    initialize the heat operation class
+       */
+      // @todo: fill level set
+      if (base_in->parameters.base.problem_name == "two_phase_flow_with_heat_transfer")
+        {
+          heat_operation =
+            std::make_shared<Heat::HeatTransferOperation<dim>>(base_in->get_bc("heat_transfer"),
+                                                               *scratch_data,
+                                                               base_in->parameters.heat,
+                                                               temp_dof_idx,
+                                                               temp_dof_idx,
+                                                               temp_quad_idx,
+                                                               vel_dof_idx,
+                                                               &flow_operation->get_velocity());
+
+          /*
+           *    compute initial conditions of the temperature field
+           */
+          scratch_data->initialize_dof_vector(initial_solution, temp_dof_idx);
+
+          dealii::VectorTools::project(scratch_data->get_mapping(),
+                                       dof_handler,
+                                       scratch_data->get_constraint(temp_dof_idx),
+                                       scratch_data->get_quadrature(temp_quad_idx),
+                                       *base_in->get_initial_condition("heat_transfer"),
+                                       initial_solution);
+          initial_solution.update_ghost_values();
+
+          heat_operation->set_initial_condition(initial_solution);
+        }
+
+      /*
        *    initialize the evaporation class
        */
       if (base_in->parameters.base.problem_name == "two_phase_flow_with_evaporation" ||
@@ -368,6 +424,8 @@ namespace MeltPoolDG::Flow
               scratch_data->get_pcout()
                 << " T.size " << melt_pool_operation->get_temperature().size() << " solid.size "
                 << melt_pool_operation->get_solid().size();
+            if (heat_operation)
+              scratch_data->get_pcout() << " T.size " << heat_operation->get_temperature().size();
 
             scratch_data->get_pcout() << std::endl;
 
@@ -469,6 +527,8 @@ namespace MeltPoolDG::Flow
             evaporation_operation->reinit();
           if (melt_pool_operation)
             melt_pool_operation->reinit();
+          if (heat_operation)
+            heat_operation->reinit();
         }
 
 #ifdef MELT_POOL_DG_WITH_ADAFLO
@@ -643,6 +703,8 @@ namespace MeltPoolDG::Flow
 
         if (evaporation_operation)
           evaporation_operation->attach_output_vectors(data_out);
+        if (heat_operation)
+          heat_operation->attach_output_vectors(data_out);
       };
       /**
        * do the output operation
@@ -720,6 +782,11 @@ namespace MeltPoolDG::Flow
           });
         }
 
+      if (heat_operation)
+        data.emplace_back(&dof_handler, [&](std::vector<VectorType *> &vectors) {
+          heat_operation->attach_vectors(vectors);
+        });
+
       const auto post = [&]() {
         /**
          * level set
@@ -742,6 +809,11 @@ namespace MeltPoolDG::Flow
          */
         if (evaporation_operation)
           evaporation_operation->distribute_constraints();
+        /**
+         * melt pool
+         */
+        if (heat_operation)
+          heat_operation->distribute_constraints();
       };
 
       const auto setup_dof_system = [&]() { this->setup_dof_system(base_in); };
@@ -786,7 +858,7 @@ namespace MeltPoolDG::Flow
     LevelSet::LevelSetOperation<dim>                        level_set_operation;
     std::shared_ptr<MeltPool::MeltPoolOperation<dim>>       melt_pool_operation;
     std::shared_ptr<Evaporation::EvaporationOperation<dim>> evaporation_operation = nullptr;
-
-    std::shared_ptr<Postprocessor<dim>> post_processor;
+    std::shared_ptr<Heat::HeatTransferOperation<dim>>       heat_operation;
+    std::shared_ptr<Postprocessor<dim>>                     post_processor;
   };
 } // namespace MeltPoolDG::Flow

--- a/include/meltpooldg/heat/laser.hpp
+++ b/include/meltpooldg/heat/laser.hpp
@@ -116,6 +116,12 @@ namespace MeltPoolDG::Heat
       return laser_position;
     }
 
+    double
+    get_laser_power()
+    {
+      return laser_intensity * laser_data.power;
+    }
+
   private:
     void
     compute_laser_intensity()

--- a/include/meltpooldg/heat/laser_heat_source_gusarov.hpp
+++ b/include/meltpooldg/heat/laser_heat_source_gusarov.hpp
@@ -70,7 +70,7 @@ namespace MeltPoolDG::Heat
         scratch_data.initialize_dof_vector(heat_source_vector, temp_dof_idx);
 
       FEValues<dim> heat_source_eval(
-        scratch_data->get_mapping(),
+        scratch_data.get_mapping(),
         scratch_data.get_dof_handler(temp_dof_idx).get_fe(),
         Quadrature<dim>(
           scratch_data.get_dof_handler(temp_dof_idx).get_fe().get_unit_support_points()),
@@ -148,7 +148,7 @@ namespace MeltPoolDG::Heat
      * volumetric heat source; The z-axis (= axis of the laser beam) is assumed to correspond to
      * negative dim-1 coordinate.
      */
-    void
+    double
     local_heat_source(const Point<dim> &position,
                       const Point<dim> &laser_position,
                       const double      power)

--- a/include/meltpooldg/interface/parameters.hpp
+++ b/include/meltpooldg/interface/parameters.hpp
@@ -175,6 +175,7 @@ namespace MeltPoolDG
     bool        do_move                            = false;
     number      scan_speed                         = 0.0;
     bool        variable_properties_over_interface = false;
+    std::string heat_source_model                  = "Gusarov"; //@todo user input
     struct GusarovData
     {
       number laser_beam_radius      = 0.0; // R      //@todo user input
@@ -320,9 +321,10 @@ namespace MeltPoolDG
          */
 #ifdef MELT_POOL_DG_WITH_ADAFLO
 
-      if ((base.problem_name == "two_phase_flow") || (base.problem_name == "melt_pool") ||
-          (base.problem_name == "two_phase_flow_with_evaporation") ||
-          (base.problem_name == "melt_pool_with_evaporation"))
+      if (base.problem_name == "two_phase_flow" || base.problem_name == "melt_pool" ||
+          base.problem_name == "two_phase_flow_with_evaporation" ||
+          base.problem_name == "melt_pool_with_evaporation" ||
+          base.problem_name == "two_phase_flow_with_heat_transfer")
         {
           adaflo_params.parse_parameters(parameter_filename);
           // WARNING: by setting the differences to a non-zero value we force
@@ -409,7 +411,9 @@ namespace MeltPoolDG
           base.problem_name,
           "Sets the base name for the problem that should be solved.",
           Patterns::Selection(
-            "advection_diffusion|reinitialization|level_set|two_phase_flow|melt_pool|level_set_with_evaporation|two_phase_flow_with_evaporation|melt_pool_with_evaporation|heat_transfer"));
+            "advection_diffusion|reinitialization|level_set|two_phase_flow|melt_pool"
+            "|level_set_with_evaporation|two_phase_flow_with_evaporation|"
+            "melt_pool_with_evaporation|heat_transfer|two_phase_flow_with_heat_transfer"));
         prm.add_parameter("dimension", base.dimension, "Defines the dimension of the problem");
         prm.add_parameter("global refinements",
                           base.global_refinements,

--- a/include/meltpooldg/interface/problem_selector.hpp
+++ b/include/meltpooldg/interface/problem_selector.hpp
@@ -31,7 +31,8 @@ namespace MeltPoolDG
 
       else if (problem_name == "two_phase_flow" || problem_name == "melt_pool" ||
                problem_name == "two_phase_flow_with_evaporation" ||
-               problem_name == "melt_pool_with_evaporation")
+               problem_name == "melt_pool_with_evaporation" ||
+               problem_name == "two_phase_flow_with_heat_transfer")
         return std::make_shared<Flow::TwoPhaseFlowProblem<dim>>();
 
       else if (problem_name == "heat_transfer")

--- a/include/meltpooldg/melt_pool/melt_pool_operation.hpp
+++ b/include/meltpooldg/melt_pool/melt_pool_operation.hpp
@@ -138,371 +138,385 @@ namespace MeltPoolDG
                             "No requested laser model found. Please speficy the "
                             "heat source model in the laser section of the input parameters."))
           }
+      }
 
-        void set_initial_condition(const VectorType &level_set_as_heaviside,
-                                   VectorType &      level_set,
-                                   const double &    density_gas,
-                                   const double &    density_liquid)
-        {
-          /*
-           *  Compute analytical temperature field
-           */
-          if (mp_data.temperature_formulation == "analytical")
-            laser_operation->compute_analytical_temperature_field(
-              level_set_as_heaviside,
-              heat_operation->get_temperature(),
-              temp_dof_idx,
-              density_gas,
-              density_liquid,
-              mp_data,
-              -1.0 /* level set value for gas @todo */);
-          else if (mp_data.temperature_formulation == "solve_heat_equation")
+      void
+      set_initial_condition(const VectorType &level_set_as_heaviside,
+                            VectorType &      level_set,
+                            const double &    density_gas,
+                            const double &    density_liquid)
+      {
+        /*
+         *  Compute analytical temperature field
+         */
+        if (mp_data.temperature_formulation == "analytical")
+          laser_operation->compute_analytical_temperature_field(
+            level_set_as_heaviside,
+            heat_operation->get_temperature(),
+            temp_dof_idx,
+            density_gas,
+            density_liquid,
+            mp_data,
+            -1.0 /* level set value for gas @todo */);
+        else if (mp_data.temperature_formulation == "solve_heat_equation")
+          {
+            heat_operation->get_temperature() = mp_data.ambient_temperature;
+          }
+        else
+          AssertThrow(false, ExcNotImplemented());
+        /*
+         *  Compute the initial solid and liquid phases
+         */
+        compute_solid_and_liquid_phases(level_set_as_heaviside);
+        /*
+         *  Constraint the solid domain if requested
+         */
+        make_constraints_in_spatially_fixed_solid_domain();
+        scratch_data->get_constraint(ls_dof_idx).distribute(level_set);
+      }
+
+      void
+      solve(VectorType &      vel_force_rhs,
+            const VectorType &level_set_as_heaviside,
+            const VectorType &curvature,
+            const double &    surface_tension_coefficient,
+            const double &    temperature_dependent_surface_tension_coefficient,
+            const double &    surface_tension_reference_temperature,
+            const double &    density_gas,
+            const double &    density_liquid,
+            const double &    dt)
+      {
+        // 0) move laser
+        laser_operation->move_laser(dt);
+
+        // 1) compute temperature field
+        if (mp_data.temperature_formulation == "solve_heat_equation")
+          {
+            // @todo: support other heat source models
+            laser_heat_source_operation->compute_volumetric_heat_source(
+              heat_operation->get_heat_source(),
+              laser_operation->get_laser_power(),
+              laser_operation->get_laser_position(),
+              true /* zero_out */);
+            heat_operation->solve(dt);
+          }
+        else if (mp_data.temperature_formulation == "analytical")
+          laser_operation->compute_analytical_temperature_field(
+            level_set_as_heaviside,
+            heat_operation->get_temperature(),
+            temp_dof_idx,
+            density_gas,
+            density_liquid,
+            mp_data,
+            -1.0 /* level set value for gas @todo */);
+        else
+          AssertThrow(false, ExcNotImplemented());
+
+        // 2) update phases
+        if (mp_data.temperature_formulation != "analytical")
+          {
+            compute_solid_and_liquid_phases(level_set_as_heaviside);
+
+            // 3) update the constraints such that the solid domain is spatially fixed
+            make_constraints_in_spatially_fixed_solid_domain();
+          }
+
+        // 4) compute forces
+        //   i)  ... recoil pressure
+        if (recoil_pressure_operation)
+          recoil_pressure_operation->compute_recoil_pressure_force(
+            vel_force_rhs,
+            level_set_as_heaviside,
+            heat_operation->get_temperature(),
+            false /*false means add to force vector*/);
+
+        //   ii) ... or evaporative flux
+        //@todo
+
+        //   iii)  ... temperature dependent surface tension
+        if (temperature_dependent_surface_tension_coefficient > 0.0)
+          Flow::SurfaceTensionOperation<dim>::compute_temperature_dependent_surface_tension(
+            *scratch_data,
+            vel_force_rhs,
+            level_set_as_heaviside,
+            curvature,
+            heat_operation->get_temperature(),
+            surface_tension_coefficient,
+            temperature_dependent_surface_tension_coefficient,
+            surface_tension_reference_temperature,
+            ls_dof_idx,
+            flow_vel_dof_idx,
+            flow_vel_quad_idx,
+            temp_dof_idx,
+            false /*false means add to force vector*/);
+      }
+
+      void
+      reinit()
+      {
+        heat_operation->reinit();
+        scratch_data->initialize_dof_vector(solid, temp_dof_idx);
+        scratch_data->initialize_dof_vector(liquid, temp_dof_idx);
+      }
+
+      void
+      attach_vectors(std::vector<LinearAlgebra::distributed::Vector<double> *> &vectors)
+      {
+        heat_operation->attach_vectors(vectors);
+        solid.update_ghost_values();
+        liquid.update_ghost_values();
+        vectors.push_back(&solid);
+        vectors.push_back(&liquid);
+      }
+
+      void
+      attach_output_vectors(DataOut<dim> &data_out) const
+      {
+        heat_operation->attach_output_vectors(data_out);
+        MeltPoolDG::VectorTools::update_ghost_values(solid, liquid);
+        /**
+         *  solid
+         */
+        data_out.add_data_vector(scratch_data->get_dof_handler(temp_dof_idx), solid, "solid");
+        /**
+         *  liquid
+         */
+        data_out.add_data_vector(scratch_data->get_dof_handler(temp_dof_idx), liquid, "liquid");
+      }
+
+      void
+      distribute_constraints()
+      {
+        heat_operation->distribute_constraints();
+        scratch_data->get_constraint(temp_dof_idx).distribute(solid);
+        scratch_data->get_constraint(temp_dof_idx).distribute(liquid);
+      }
+
+      const VectorType &
+      get_temperature() const
+      {
+        return heat_operation->get_temperature();
+      }
+
+      const VectorType &
+      get_solid() const
+      {
+        return solid;
+      }
+
+      const VectorType &
+      get_liquid() const
+      {
+        return liquid;
+      }
+
+    private:
+      void
+      make_constraints_in_spatially_fixed_solid_domain()
+      {
+        /*
+         *    limit the level set interface to the touching regions of liquid/gas
+         */
+        if (mp_data.set_level_set_to_zero_in_solid)
+          {
+            remove_the_level_set_from_solid_regions(scratch_data->get_dof_handler(ls_dof_idx),
+                                                    scratch_data->get_constraint(ls_dof_idx));
+            remove_the_level_set_from_solid_regions(scratch_data->get_dof_handler(reinit_dof_idx),
+                                                    scratch_data->get_constraint(reinit_dof_idx));
+          }
+
+        if (mp_data.set_velocity_to_zero_in_solid)
+          set_flow_field_in_solid_regions_to_zero(scratch_data->get_dof_handler(flow_vel_dof_idx),
+                                                  scratch_data->get_constraint(flow_vel_dof_idx));
+      }
+
+
+      void
+      compute_solid_and_liquid_phases(const VectorType &level_set_as_heaviside)
+      {
+        level_set_as_heaviside.update_ghost_values();
+        heat_operation->get_temperature().update_ghost_values();
+
+        const unsigned int dofs_per_cell = scratch_data->get_n_dofs_per_cell(temp_dof_idx);
+
+        std::vector<types::global_dof_index> local_dof_indices(dofs_per_cell);
+
+        std::map<types::global_dof_index, Point<dim>> support_points;
+        DoFTools::map_dofs_to_support_points(scratch_data->get_mapping(),
+                                             scratch_data->get_dof_handler(temp_dof_idx),
+                                             support_points);
+
+        liquid = 0;
+        solid  = 0;
+
+        for (const auto &cell : scratch_data->get_dof_handler(temp_dof_idx).active_cell_iterators())
+          if (cell->is_locally_owned())
             {
-              heat_operation->get_temperature() = mp_data.ambient_temperature;
-            }
-          else
-            AssertThrow(false, ExcNotImplemented());
-          /*
-           *  Compute the initial solid and liquid phases
-           */
-          compute_solid_and_liquid_phases(level_set_as_heaviside);
-          /*
-           *  Constraint the solid domain if requested
-           */
-          make_constraints_in_spatially_fixed_solid_domain();
-          scratch_data->get_constraint(ls_dof_idx).distribute(level_set);
-        }
-
-        void solve(VectorType & vel_force_rhs,
-                   const VectorType &level_set_as_heaviside,
-                   const VectorType &curvature,
-                   const double &    surface_tension_coefficient,
-                   const double &    temperature_dependent_surface_tension_coefficient,
-                   const double &    surface_tension_reference_temperature,
-                   const double &    density_gas,
-                   const double &    density_liquid,
-                   const double &    dt)
-        {
-          // 0) move laser
-          laser_operation->move_laser(dt);
-
-          // 1) compute temperature field
-          if (mp_data.temperature_formulation == "solve_heat_equation")
-            {
-              // @todo: support other heat source models
-              laser_heat_source_operation->compute_volumetric_heat_source(
-                heat_operation->get_heat_source(),
-                laser_operation->get_laser_power(),
-                laser_operation->get_laser_position(),
-                true /* zero_out */);
-              heat_operation->solve(dt);
-            }
-          else if (mp_data.temperature_formulation == "analytical")
-            laser_operation->compute_analytical_temperature_field(
-              level_set_as_heaviside,
-              heat_operation->get_temperature(),
-              temp_dof_idx,
-              density_gas,
-              density_liquid,
-              mp_data,
-              -1.0 /* level set value for gas @todo */);
-          else
-            AssertThrow(false, ExcNotImplemented());
-
-          // 2) update phases
-          if (mp_data.temperature_formulation != "analytical")
-            {
-              compute_solid_and_liquid_phases(level_set_as_heaviside);
-
-              // 3) update the constraints such that the solid domain is spatially fixed
-              make_constraints_in_spatially_fixed_solid_domain();
+              cell->get_dof_indices(local_dof_indices);
+              for (unsigned int i = 0; i < dofs_per_cell; ++i)
+                {
+                  solid[local_dof_indices[i]] =
+                    is_solid_region(level_set_as_heaviside[local_dof_indices[i]],
+                                    heat_operation->get_temperature()[local_dof_indices[i]]);
+                  liquid[local_dof_indices[i]] =
+                    is_liquid_region(level_set_as_heaviside[local_dof_indices[i]],
+                                     heat_operation->get_temperature()[local_dof_indices[i]]);
+                }
             }
 
-          // 4) compute forces
-          //   i)  ... recoil pressure
-          if (recoil_pressure_operation)
-            recoil_pressure_operation->compute_recoil_pressure_force(
-              vel_force_rhs,
-              level_set_as_heaviside,
-              heat_operation->get_temperature(),
-              false /*false means add to force vector*/);
+        liquid.compress(VectorOperation::insert);
+        solid.compress(VectorOperation::insert);
 
-          //   ii) ... or evaporative flux
-          //@todo
+        scratch_data->get_constraint(temp_dof_idx).distribute(solid);
+        scratch_data->get_constraint(temp_dof_idx).distribute(liquid);
 
-          //   iii)  ... temperature dependent surface tension
-          if (temperature_dependent_surface_tension_coefficient > 0.0)
-            Flow::SurfaceTensionOperation<dim>::compute_temperature_dependent_surface_tension(
-              *scratch_data,
-              vel_force_rhs,
-              level_set_as_heaviside,
-              curvature,
-              heat_operation->get_temperature(),
-              surface_tension_coefficient,
-              temperature_dependent_surface_tension_coefficient,
-              surface_tension_reference_temperature,
-              ls_dof_idx,
-              flow_vel_dof_idx,
-              flow_vel_quad_idx,
-              temp_dof_idx,
-              false /*false means add to force vector*/);
-        }
+        heat_operation->get_temperature().zero_out_ghosts();
+        level_set_as_heaviside.zero_out_ghosts();
+      }
 
-        void reinit()
-        {
-          heat_operation->reinit();
-          scratch_data->initialize_dof_vector(solid, temp_dof_idx);
-          scratch_data->initialize_dof_vector(liquid, temp_dof_idx);
-        }
+      /**
+       *  The constraints of the flow velocity are modified such that they are zero in solid
+       *  regions.
+       */
+      void
+      set_flow_field_in_solid_regions_to_zero(const DoFHandler<dim> &    flow_dof_handler,
+                                              AffineConstraints<double> &flow_constraints)
+      {
+        solid.update_ghost_values();
 
-        void attach_vectors(std::vector<LinearAlgebra::distributed::Vector<double> *> & vectors)
-        {
-          heat_operation->attach_vectors(vectors);
-          solid.update_ghost_values();
-          liquid.update_ghost_values();
-          vectors.push_back(&solid);
-          vectors.push_back(&liquid);
-        }
+        IndexSet flow_locally_relevant_dofs;
+        DoFTools::extract_locally_relevant_dofs(flow_dof_handler, flow_locally_relevant_dofs);
 
-        void attach_output_vectors(DataOut<dim> & data_out) const
-        {
-          heat_operation->attach_output_vectors(data_out);
-          MeltPoolDG::VectorTools::update_ghost_values(solid, liquid);
-          /**
-           *  solid
-           */
-          data_out.add_data_vector(scratch_data->get_dof_handler(temp_dof_idx), solid, "solid");
-          /**
-           *  liquid
-           */
-          data_out.add_data_vector(scratch_data->get_dof_handler(temp_dof_idx), liquid, "liquid");
-        }
+        AffineConstraints<double> solid_constraints;
+        solid_constraints.reinit(flow_locally_relevant_dofs);
 
-        void distribute_constraints()
-        {
-          heat_operation->distribute_constraints();
-          scratch_data->get_constraint(temp_dof_idx).distribute(solid);
-          scratch_data->get_constraint(temp_dof_idx).distribute(liquid);
-        }
+        FEValues<dim> flow_eval(scratch_data->get_mapping(),
+                                flow_dof_handler.get_fe(),
+                                Quadrature<dim>(
+                                  flow_dof_handler.get_fe().get_unit_support_points()),
+                                update_quadrature_points);
 
-        const VectorType &get_temperature() const
-        {
-          return heat_operation->get_temperature();
-        }
+        FEValues<dim> solid_eval(scratch_data->get_mapping(),
+                                 scratch_data->get_dof_handler(temp_dof_idx).get_fe(),
+                                 Quadrature<dim>(
+                                   flow_dof_handler.get_fe().get_unit_support_points()),
+                                 update_values);
 
-        const VectorType &get_solid() const
-        {
-          return solid;
-        }
+        const unsigned int dofs_per_cell = flow_dof_handler.get_fe().n_dofs_per_cell();
+        std::vector<types::global_dof_index> local_dof_indices(dofs_per_cell);
+        std::vector<double>                  solid_at_q(dofs_per_cell);
 
-        const VectorType &get_liquid() const
-        {
-          return liquid;
-        }
+        typename DoFHandler<dim>::active_cell_iterator solid_cell =
+          scratch_data->get_dof_handler(temp_dof_idx).begin_active();
 
-      private:
-        void make_constraints_in_spatially_fixed_solid_domain()
-        {
-          /*
-           *    limit the level set interface to the touching regions of liquid/gas
-           */
-          if (mp_data.set_level_set_to_zero_in_solid)
-            {
-              remove_the_level_set_from_solid_regions(scratch_data->get_dof_handler(ls_dof_idx),
-                                                      scratch_data->get_constraint(ls_dof_idx));
-              remove_the_level_set_from_solid_regions(scratch_data->get_dof_handler(reinit_dof_idx),
-                                                      scratch_data->get_constraint(reinit_dof_idx));
-            }
-
-          if (mp_data.set_velocity_to_zero_in_solid)
-            set_flow_field_in_solid_regions_to_zero(scratch_data->get_dof_handler(flow_vel_dof_idx),
-                                                    scratch_data->get_constraint(flow_vel_dof_idx));
-        }
-
-
-        void compute_solid_and_liquid_phases(const VectorType &level_set_as_heaviside)
-        {
-          level_set_as_heaviside.update_ghost_values();
-          heat_operation->get_temperature().update_ghost_values();
-
-          const unsigned int dofs_per_cell = scratch_data->get_n_dofs_per_cell(temp_dof_idx);
-
-          std::vector<types::global_dof_index> local_dof_indices(dofs_per_cell);
-
-          std::map<types::global_dof_index, Point<dim>> support_points;
-          DoFTools::map_dofs_to_support_points(scratch_data->get_mapping(),
-                                               scratch_data->get_dof_handler(temp_dof_idx),
-                                               support_points);
-
-          liquid = 0;
-          solid  = 0;
-
-          for (const auto &cell :
-               scratch_data->get_dof_handler(temp_dof_idx).active_cell_iterators())
+        for (const auto &cell : flow_dof_handler.active_cell_iterators())
+          {
             if (cell->is_locally_owned())
               {
                 cell->get_dof_indices(local_dof_indices);
-                for (unsigned int i = 0; i < dofs_per_cell; ++i)
+
+                flow_eval.reinit(cell);
+
+                solid_eval.reinit(solid_cell);
+                solid_eval.get_function_values(solid, solid_at_q);
+
+                for (const auto q : flow_eval.quadrature_point_indices())
                   {
-                    solid[local_dof_indices[i]] =
-                      is_solid_region(level_set_as_heaviside[local_dof_indices[i]],
-                                      heat_operation->get_temperature()[local_dof_indices[i]]);
-                    liquid[local_dof_indices[i]] =
-                      is_liquid_region(level_set_as_heaviside[local_dof_indices[i]],
-                                       heat_operation->get_temperature()[local_dof_indices[i]]);
+                    if (solid_at_q[q] == 1.0)
+                      solid_constraints.add_line(local_dof_indices[q]);
                   }
               }
+            ++solid_cell;
+          }
 
-          liquid.compress(VectorOperation::insert);
-          solid.compress(VectorOperation::insert);
+        solid_constraints.close();
+        flow_constraints.merge(solid_constraints,
+                               AffineConstraints<double>::MergeConflictBehavior::left_object_wins);
 
-          scratch_data->get_constraint(temp_dof_idx).distribute(solid);
-          scratch_data->get_constraint(temp_dof_idx).distribute(liquid);
+        solid.zero_out_ghosts();
+      }
+      /**
+       *  The level set constraints are modified such that they are zero in solid
+       *  regions.
+       */
+      void
+      remove_the_level_set_from_solid_regions(const DoFHandler<dim> &    level_set_dof_handler,
+                                              AffineConstraints<double> &level_set_constraints)
+      {
+        solid.update_ghost_values();
+        AssertThrow(scratch_data->get_degree(temp_dof_idx) == scratch_data->get_degree(ls_dof_idx),
+                    ExcMessage(
+                      "The usage of this function assumes that the temperature field "
+                      "is interpolated with the polynomial with the same degree as the level set"));
 
-          heat_operation->get_temperature().zero_out_ghosts();
-          level_set_as_heaviside.zero_out_ghosts();
-        }
+        const unsigned int dofs_per_cell = level_set_dof_handler.get_fe().n_dofs_per_cell();
 
-        /**
-         *  The constraints of the flow velocity are modified such that they are zero in solid
-         *  regions.
-         */
-        void set_flow_field_in_solid_regions_to_zero(const DoFHandler<dim> &    flow_dof_handler,
-                                                     AffineConstraints<double> &flow_constraints)
-        {
-          solid.update_ghost_values();
+        std::vector<types::global_dof_index> local_dof_indices(dofs_per_cell);
 
-          IndexSet flow_locally_relevant_dofs;
-          DoFTools::extract_locally_relevant_dofs(flow_dof_handler, flow_locally_relevant_dofs);
+        std::map<types::global_dof_index, Point<dim>> support_points;
+        DoFTools::map_dofs_to_support_points(scratch_data->get_mapping(),
+                                             level_set_dof_handler,
+                                             support_points);
 
-          AffineConstraints<double> solid_constraints;
-          solid_constraints.reinit(flow_locally_relevant_dofs);
+        AffineConstraints<double> solid_constraints;
 
-          FEValues<dim> flow_eval(scratch_data->get_mapping(),
-                                  flow_dof_handler.get_fe(),
-                                  Quadrature<dim>(
-                                    flow_dof_handler.get_fe().get_unit_support_points()),
-                                  update_quadrature_points);
+        IndexSet ls_locally_relevant_dofs;
+        DoFTools::extract_locally_relevant_dofs(level_set_dof_handler, ls_locally_relevant_dofs);
 
-          FEValues<dim> solid_eval(scratch_data->get_mapping(),
-                                   scratch_data->get_dof_handler(temp_dof_idx).get_fe(),
-                                   Quadrature<dim>(
-                                     flow_dof_handler.get_fe().get_unit_support_points()),
-                                   update_values);
-
-          const unsigned int dofs_per_cell = flow_dof_handler.get_fe().n_dofs_per_cell();
-          std::vector<types::global_dof_index> local_dof_indices(dofs_per_cell);
-          std::vector<double>                  solid_at_q(dofs_per_cell);
-
-          typename DoFHandler<dim>::active_cell_iterator solid_cell =
-            scratch_data->get_dof_handler(temp_dof_idx).begin_active();
-
-          for (const auto &cell : flow_dof_handler.active_cell_iterators())
+        solid_constraints.reinit(ls_locally_relevant_dofs);
+        for (const auto &cell : level_set_dof_handler.active_cell_iterators())
+          if (cell->is_locally_owned())
             {
-              if (cell->is_locally_owned())
-                {
-                  cell->get_dof_indices(local_dof_indices);
+              cell->get_dof_indices(local_dof_indices);
 
-                  flow_eval.reinit(cell);
-
-                  solid_eval.reinit(solid_cell);
-                  solid_eval.get_function_values(solid, solid_at_q);
-
-                  for (const auto q : flow_eval.quadrature_point_indices())
-                    {
-                      if (solid_at_q[q] == 1.0)
-                        solid_constraints.add_line(local_dof_indices[q]);
-                    }
-                }
-              ++solid_cell;
+              for (unsigned int i = 0; i < dofs_per_cell; ++i)
+                if (solid[local_dof_indices[i]])
+                  solid_constraints.add_line(local_dof_indices[i]);
             }
+        level_set_constraints.merge(
+          solid_constraints, AffineConstraints<double>::MergeConflictBehavior::left_object_wins);
+        level_set_constraints.close();
+        solid.zero_out_ghosts();
+      }
 
-          solid_constraints.close();
-          flow_constraints.merge(
-            solid_constraints, AffineConstraints<double>::MergeConflictBehavior::left_object_wins);
+      void
+      set_melt_pool_parameters(const Parameters<double> &data_in)
+      {
+        mp_data = data_in.mp;
+      }
 
-          solid.zero_out_ghosts();
-        }
-        /**
-         *  The level set constraints are modified such that they are zero in solid
-         *  regions.
-         */
-        void remove_the_level_set_from_solid_regions(
-          const DoFHandler<dim> &    level_set_dof_handler,
-          AffineConstraints<double> &level_set_constraints)
-        {
-          solid.update_ghost_values();
-          AssertThrow(
-            scratch_data->get_degree(temp_dof_idx) == scratch_data->get_degree(ls_dof_idx),
-            ExcMessage(
-              "The usage of this function assumes that the temperature field "
-              "is interpolated with the polynomial with the same degree as the level set"));
-
-          const unsigned int dofs_per_cell = level_set_dof_handler.get_fe().n_dofs_per_cell();
-
-          std::vector<types::global_dof_index> local_dof_indices(dofs_per_cell);
-
-          std::map<types::global_dof_index, Point<dim>> support_points;
-          DoFTools::map_dofs_to_support_points(scratch_data->get_mapping(),
-                                               level_set_dof_handler,
-                                               support_points);
-
-          AffineConstraints<double> solid_constraints;
-
-          IndexSet ls_locally_relevant_dofs;
-          DoFTools::extract_locally_relevant_dofs(level_set_dof_handler, ls_locally_relevant_dofs);
-
-          solid_constraints.reinit(ls_locally_relevant_dofs);
-          for (const auto &cell : level_set_dof_handler.active_cell_iterators())
-            if (cell->is_locally_owned())
-              {
-                cell->get_dof_indices(local_dof_indices);
-
-                for (unsigned int i = 0; i < dofs_per_cell; ++i)
-                  if (solid[local_dof_indices[i]])
-                    solid_constraints.add_line(local_dof_indices[i]);
-              }
-          level_set_constraints.merge(
-            solid_constraints, AffineConstraints<double>::MergeConflictBehavior::left_object_wins);
-          level_set_constraints.close();
-          solid.zero_out_ghosts();
-        }
-
-        void set_melt_pool_parameters(const Parameters<double> &data_in)
-        {
-          mp_data = data_in.mp;
-        }
-
-        /**
-         *  This function determines for a given pair of level set and temperature values, whether
-         * it characterizes a solid state. For this purpose, it is assumed that phi=1 in the liquid
-         * AND the solid domain and phi=0 in the gaseous domain. Thus, if phi=1 and the temperature
-         * is SMALLER than the fusion point, a solid phase is met.
-         */
-        bool is_solid_region(const double phi_liquid, const double temperature)
-        {
-          if (phi_liquid <= 0.5)
-            return false; // point is gas phase
-          else if (phi_liquid > 0.5 && temperature >= mp_data.liquid.melting_point)
-            return false; // point is melted
-          else
-            return true;
-        }
-        /**
-         *  This function determines for a given pair of level set and temperature values, whether
-         * it characterizes a liquid state. For this purpose, it is assumed that phi=1 in the liquid
-         * AND the solid domain and phi=0 in the gaseous domain. Thus, if phi=1 and the temperature
-         * is LARGER than the fusion point, a liquid phase is met.
-         */
-        bool is_liquid_region(const double phi_liquid, const double temperature)
-        {
-          if (phi_liquid <= 0.5)
-            return false; // point is gas phase
-          else if (phi_liquid > 0.5 && temperature >= mp_data.liquid.melting_point)
-            return true; // point is melted
-          else
-            return false; // point is solid
-        }
-      };
-    } // namespace MeltPool
-  }   // namespace MeltPoolDG
+      /**
+       *  This function determines for a given pair of level set and temperature values, whether
+       * it characterizes a solid state. For this purpose, it is assumed that phi=1 in the liquid
+       * AND the solid domain and phi=0 in the gaseous domain. Thus, if phi=1 and the temperature
+       * is SMALLER than the fusion point, a solid phase is met.
+       */
+      bool
+      is_solid_region(const double phi_liquid, const double temperature)
+      {
+        if (phi_liquid <= 0.5)
+          return false; // point is gas phase
+        else if (phi_liquid > 0.5 && temperature >= mp_data.liquid.melting_point)
+          return false; // point is melted
+        else
+          return true;
+      }
+      /**
+       *  This function determines for a given pair of level set and temperature values, whether
+       * it characterizes a liquid state. For this purpose, it is assumed that phi=1 in the liquid
+       * AND the solid domain and phi=0 in the gaseous domain. Thus, if phi=1 and the temperature
+       * is LARGER than the fusion point, a liquid phase is met.
+       */
+      bool
+      is_liquid_region(const double phi_liquid, const double temperature)
+      {
+        if (phi_liquid <= 0.5)
+          return false; // point is gas phase
+        else if (phi_liquid > 0.5 && temperature >= mp_data.liquid.melting_point)
+          return true; // point is melted
+        else
+          return false; // point is solid
+      }
+    };
+  } // namespace MeltPool
+} // namespace MeltPoolDG

--- a/include/meltpooldg/melt_pool/melt_pool_operation.hpp
+++ b/include/meltpooldg/melt_pool/melt_pool_operation.hpp
@@ -123,366 +123,386 @@ namespace MeltPoolDG
         scratch_data->initialize_dof_vector(liquid, temp_dof_idx);
         heat_operation->reinit();
 
-
-        if (mp_data.temperature_formulation == "numerical")
-          laser_heat_source_operation =
-            std::make_shared<Heat::LaserHeatSourceGusarov<dim>>(*scratch_data,
-                                                                data_in.laser.gusarov,
-                                                                temp_dof_idx);
-      }
-
-      void
-      set_initial_condition(const VectorType &level_set_as_heaviside,
-                            VectorType &      level_set,
-                            const double &    density_gas,
-                            const double &    density_liquid)
-      {
-        /*
-         *  Compute analytical temperature field
-         */
-        if (mp_data.temperature_formulation == "analytical")
-          laser_operation->compute_analytical_temperature_field(
-            level_set_as_heaviside,
-            heat_operation->get_temperature(),
-            temp_dof_idx,
-            density_gas,
-            density_liquid,
-            mp_data,
-            -1.0 /* level set value for gas @todo */);
-        else
-          AssertThrow(false, ExcNotImplemented());
-        /*
-         *  Compute the initial solid and liquid phases
-         */
-        compute_solid_and_liquid_phases(level_set_as_heaviside);
-        /*
-         *  Constraint the solid domain if requested
-         */
-        make_constraints_in_spatially_fixed_solid_domain();
-        scratch_data->get_constraint(ls_dof_idx).distribute(level_set);
-      }
-
-      void
-      solve(VectorType &      vel_force_rhs,
-            const VectorType &level_set_as_heaviside,
-            const VectorType &curvature,
-            const double &    surface_tension_coefficient,
-            const double &    temperature_dependent_surface_tension_coefficient,
-            const double &    surface_tension_reference_temperature,
-            const double &    density_gas,
-            const double &    density_liquid,
-            const double &    dt)
-      {
-        // 0) move laser
-        laser_operation->move_laser(dt);
-
-        // 1) update temperature
-        if (mp_data.temperature_formulation == "analytical")
-          laser_operation->compute_analytical_temperature_field(
-            level_set_as_heaviside,
-            heat_operation->get_temperature(),
-            temp_dof_idx,
-            density_gas,
-            density_liquid,
-            mp_data,
-            -1.0 /* level set value for gas @todo */);
-
-        // 2) update phases
-        if (mp_data.temperature_formulation != "analytical")
+        if (mp_data.temperature_formulation == "solve_heat_equation")
           {
-            compute_solid_and_liquid_phases(level_set_as_heaviside);
-
-            // 3) update the constraints such that the solid domain is spatially fixed
-            make_constraints_in_spatially_fixed_solid_domain();
+            if (data_in.laser.heat_source_model == "Gusarov")
+              {
+                laser_heat_source_operation =
+                  std::make_shared<Heat::LaserHeatSourceGusarov<dim>>(*scratch_data,
+                                                                      data_in.laser.gusarov,
+                                                                      temp_dof_idx);
+              }
+            else
+              AssertThrow(false,
+                          ExcMessage(
+                            "No requested laser model found. Please speficy the "
+                            "heat source model in the laser section of the input parameters."))
           }
 
-        // 4) compute forces
-        //   i)  ... recoil pressure
-        if (recoil_pressure_operation)
-          recoil_pressure_operation->compute_recoil_pressure_force(
-            vel_force_rhs,
-            level_set_as_heaviside,
-            heat_operation->get_temperature(),
-            false /*false means add to force vector*/);
-
-        //     ... or evaporative flux
-        //@todo
-
-        //     ... temperature dependent surface tension
-        if (temperature_dependent_surface_tension_coefficient > 0.0)
-          Flow::SurfaceTensionOperation<dim>::compute_temperature_dependent_surface_tension(
-            *scratch_data,
-            vel_force_rhs,
-            level_set_as_heaviside,
-            curvature,
-            heat_operation->get_temperature(),
-            surface_tension_coefficient,
-            temperature_dependent_surface_tension_coefficient,
-            surface_tension_reference_temperature,
-            ls_dof_idx,
-            flow_vel_dof_idx,
-            flow_vel_quad_idx,
-            temp_dof_idx,
-            false /*false means add to force vector*/);
-      }
-
-      void
-      make_constraints_in_spatially_fixed_solid_domain()
-      {
-        /*
-         *    limit the level set interface to the touching regions of liquid/gas
-         */
-        if (mp_data.set_level_set_to_zero_in_solid)
-          {
-            remove_the_level_set_from_solid_regions(scratch_data->get_dof_handler(ls_dof_idx),
-                                                    scratch_data->get_constraint(ls_dof_idx));
-            remove_the_level_set_from_solid_regions(scratch_data->get_dof_handler(reinit_dof_idx),
-                                                    scratch_data->get_constraint(reinit_dof_idx));
-          }
-
-        if (mp_data.set_velocity_to_zero_in_solid)
-          set_flow_field_in_solid_regions_to_zero(scratch_data->get_dof_handler(flow_vel_dof_idx),
-                                                  scratch_data->get_constraint(flow_vel_dof_idx));
-      }
-
-      void
-      reinit()
-      {
-        heat_operation->reinit();
-        scratch_data->initialize_dof_vector(solid, temp_dof_idx);
-        scratch_data->initialize_dof_vector(liquid, temp_dof_idx);
-      }
-
-      void
-      attach_vectors(std::vector<LinearAlgebra::distributed::Vector<double> *> &vectors)
-      {
-        heat_operation->attach_vectors(vectors);
-        solid.update_ghost_values();
-        liquid.update_ghost_values();
-        vectors.push_back(&solid);
-        vectors.push_back(&liquid);
-      }
-
-      void
-      attach_output_vectors(DataOut<dim> &data_out) const
-      {
-        heat_operation->attach_output_vectors(data_out);
-        MeltPoolDG::VectorTools::update_ghost_values(solid, liquid);
-        /**
-         *  solid
-         */
-        data_out.add_data_vector(scratch_data->get_dof_handler(temp_dof_idx), solid, "solid");
-        /**
-         *  liquid
-         */
-        data_out.add_data_vector(scratch_data->get_dof_handler(temp_dof_idx), liquid, "liquid");
-      }
-
-      void
-      distribute_constraints()
-      {
-        heat_operation->distribute_constraints();
-        scratch_data->get_constraint(temp_dof_idx).distribute(solid);
-        scratch_data->get_constraint(temp_dof_idx).distribute(liquid);
-      }
-
-      const VectorType &
-      get_temperature() const
-      {
-        return heat_operation->get_temperature();
-      }
-
-      const VectorType &
-      get_solid() const
-      {
-        return solid;
-      }
-
-      const VectorType &
-      get_liquid() const
-      {
-        return liquid;
-      }
-
-    private:
-      void
-      compute_solid_and_liquid_phases(const VectorType &level_set_as_heaviside)
-      {
-        (void)level_set_as_heaviside; // @todo: the level set will be needed later, when the thermal
-                                      // coupling is completed
-        heat_operation->get_temperature().update_ghost_values();
-
-        const unsigned int dofs_per_cell = scratch_data->get_n_dofs_per_cell(temp_dof_idx);
-
-        std::vector<types::global_dof_index> local_dof_indices(dofs_per_cell);
-
-        std::map<types::global_dof_index, Point<dim>> support_points;
-        DoFTools::map_dofs_to_support_points(scratch_data->get_mapping(),
-                                             scratch_data->get_dof_handler(temp_dof_idx),
-                                             support_points);
-
-        for (const auto &cell : scratch_data->get_dof_handler(temp_dof_idx).active_cell_iterators())
-          if (cell->is_locally_owned())
+        void set_initial_condition(const VectorType &level_set_as_heaviside,
+                                   VectorType &      level_set,
+                                   const double &    density_gas,
+                                   const double &    density_liquid)
+        {
+          /*
+           *  Compute analytical temperature field
+           */
+          if (mp_data.temperature_formulation == "analytical")
+            laser_operation->compute_analytical_temperature_field(
+              level_set_as_heaviside,
+              heat_operation->get_temperature(),
+              temp_dof_idx,
+              density_gas,
+              density_liquid,
+              mp_data,
+              -1.0 /* level set value for gas @todo */);
+          else if (mp_data.temperature_formulation == "solve_heat_equation")
             {
-              cell->get_dof_indices(local_dof_indices);
-              for (unsigned int i = 0; i < dofs_per_cell; ++i)
-                {
-                  solid[local_dof_indices[i]] =
-                    is_solid_region(support_points[local_dof_indices[i]],
-                                    heat_operation->get_temperature()[local_dof_indices[i]]);
-                  liquid[local_dof_indices[i]] =
-                    is_liquid_region(support_points[local_dof_indices[i]],
-                                     heat_operation->get_temperature()[local_dof_indices[i]]);
-                }
+              heat_operation->get_temperature() = mp_data.ambient_temperature;
+            }
+          else
+            AssertThrow(false, ExcNotImplemented());
+          /*
+           *  Compute the initial solid and liquid phases
+           */
+          compute_solid_and_liquid_phases(level_set_as_heaviside);
+          /*
+           *  Constraint the solid domain if requested
+           */
+          make_constraints_in_spatially_fixed_solid_domain();
+          scratch_data->get_constraint(ls_dof_idx).distribute(level_set);
+        }
+
+        void solve(VectorType & vel_force_rhs,
+                   const VectorType &level_set_as_heaviside,
+                   const VectorType &curvature,
+                   const double &    surface_tension_coefficient,
+                   const double &    temperature_dependent_surface_tension_coefficient,
+                   const double &    surface_tension_reference_temperature,
+                   const double &    density_gas,
+                   const double &    density_liquid,
+                   const double &    dt)
+        {
+          // 0) move laser
+          laser_operation->move_laser(dt);
+
+          // 1) compute temperature field
+          if (mp_data.temperature_formulation == "solve_heat_equation")
+            {
+              // @todo: support other heat source models
+              laser_heat_source_operation->compute_volumetric_heat_source(
+                heat_operation->get_heat_source(),
+                laser_operation->get_laser_power(),
+                laser_operation->get_laser_position(),
+                true /* zero_out */);
+              heat_operation->solve(dt);
+            }
+          else if (mp_data.temperature_formulation == "analytical")
+            laser_operation->compute_analytical_temperature_field(
+              level_set_as_heaviside,
+              heat_operation->get_temperature(),
+              temp_dof_idx,
+              density_gas,
+              density_liquid,
+              mp_data,
+              -1.0 /* level set value for gas @todo */);
+          else
+            AssertThrow(false, ExcNotImplemented());
+
+          // 2) update phases
+          if (mp_data.temperature_formulation != "analytical")
+            {
+              compute_solid_and_liquid_phases(level_set_as_heaviside);
+
+              // 3) update the constraints such that the solid domain is spatially fixed
+              make_constraints_in_spatially_fixed_solid_domain();
             }
 
-        liquid.compress(VectorOperation::insert);
-        solid.compress(VectorOperation::insert);
+          // 4) compute forces
+          //   i)  ... recoil pressure
+          if (recoil_pressure_operation)
+            recoil_pressure_operation->compute_recoil_pressure_force(
+              vel_force_rhs,
+              level_set_as_heaviside,
+              heat_operation->get_temperature(),
+              false /*false means add to force vector*/);
 
-        scratch_data->get_constraint(temp_dof_idx).distribute(solid);
-        scratch_data->get_constraint(temp_dof_idx).distribute(liquid);
+          //   ii) ... or evaporative flux
+          //@todo
 
-        heat_operation->get_temperature().zero_out_ghosts();
-      }
+          //   iii)  ... temperature dependent surface tension
+          if (temperature_dependent_surface_tension_coefficient > 0.0)
+            Flow::SurfaceTensionOperation<dim>::compute_temperature_dependent_surface_tension(
+              *scratch_data,
+              vel_force_rhs,
+              level_set_as_heaviside,
+              curvature,
+              heat_operation->get_temperature(),
+              surface_tension_coefficient,
+              temperature_dependent_surface_tension_coefficient,
+              surface_tension_reference_temperature,
+              ls_dof_idx,
+              flow_vel_dof_idx,
+              flow_vel_quad_idx,
+              temp_dof_idx,
+              false /*false means add to force vector*/);
+        }
 
-      /**
-       *  The constraints of the flow velocity are modified such that they are zero in solid
-       *  regions.
-       */
-      void
-      set_flow_field_in_solid_regions_to_zero(const DoFHandler<dim> &    flow_dof_handler,
-                                              AffineConstraints<double> &flow_constraints)
-      {
-        solid.update_ghost_values();
+        void reinit()
+        {
+          heat_operation->reinit();
+          scratch_data->initialize_dof_vector(solid, temp_dof_idx);
+          scratch_data->initialize_dof_vector(liquid, temp_dof_idx);
+        }
 
-        IndexSet flow_locally_relevant_dofs;
-        DoFTools::extract_locally_relevant_dofs(flow_dof_handler, flow_locally_relevant_dofs);
+        void attach_vectors(std::vector<LinearAlgebra::distributed::Vector<double> *> & vectors)
+        {
+          heat_operation->attach_vectors(vectors);
+          solid.update_ghost_values();
+          liquid.update_ghost_values();
+          vectors.push_back(&solid);
+          vectors.push_back(&liquid);
+        }
 
-        AffineConstraints<double> solid_constraints;
-        solid_constraints.reinit(flow_locally_relevant_dofs);
+        void attach_output_vectors(DataOut<dim> & data_out) const
+        {
+          heat_operation->attach_output_vectors(data_out);
+          MeltPoolDG::VectorTools::update_ghost_values(solid, liquid);
+          /**
+           *  solid
+           */
+          data_out.add_data_vector(scratch_data->get_dof_handler(temp_dof_idx), solid, "solid");
+          /**
+           *  liquid
+           */
+          data_out.add_data_vector(scratch_data->get_dof_handler(temp_dof_idx), liquid, "liquid");
+        }
 
-        FEValues<dim> flow_eval(scratch_data->get_mapping(),
-                                flow_dof_handler.get_fe(),
-                                Quadrature<dim>(
-                                  flow_dof_handler.get_fe().get_unit_support_points()),
-                                update_quadrature_points);
+        void distribute_constraints()
+        {
+          heat_operation->distribute_constraints();
+          scratch_data->get_constraint(temp_dof_idx).distribute(solid);
+          scratch_data->get_constraint(temp_dof_idx).distribute(liquid);
+        }
 
-        FEValues<dim> solid_eval(scratch_data->get_mapping(),
-                                 scratch_data->get_dof_handler(temp_dof_idx).get_fe(),
-                                 Quadrature<dim>(
-                                   flow_dof_handler.get_fe().get_unit_support_points()),
-                                 update_values);
+        const VectorType &get_temperature() const
+        {
+          return heat_operation->get_temperature();
+        }
 
-        const unsigned int dofs_per_cell = flow_dof_handler.get_fe().n_dofs_per_cell();
-        std::vector<types::global_dof_index> local_dof_indices(dofs_per_cell);
-        std::vector<double>                  solid_at_q(dofs_per_cell);
+        const VectorType &get_solid() const
+        {
+          return solid;
+        }
 
-        typename DoFHandler<dim>::active_cell_iterator solid_cell =
-          scratch_data->get_dof_handler(temp_dof_idx).begin_active();
+        const VectorType &get_liquid() const
+        {
+          return liquid;
+        }
 
-        for (const auto &cell : flow_dof_handler.active_cell_iterators())
-          {
+      private:
+        void make_constraints_in_spatially_fixed_solid_domain()
+        {
+          /*
+           *    limit the level set interface to the touching regions of liquid/gas
+           */
+          if (mp_data.set_level_set_to_zero_in_solid)
+            {
+              remove_the_level_set_from_solid_regions(scratch_data->get_dof_handler(ls_dof_idx),
+                                                      scratch_data->get_constraint(ls_dof_idx));
+              remove_the_level_set_from_solid_regions(scratch_data->get_dof_handler(reinit_dof_idx),
+                                                      scratch_data->get_constraint(reinit_dof_idx));
+            }
+
+          if (mp_data.set_velocity_to_zero_in_solid)
+            set_flow_field_in_solid_regions_to_zero(scratch_data->get_dof_handler(flow_vel_dof_idx),
+                                                    scratch_data->get_constraint(flow_vel_dof_idx));
+        }
+
+
+        void compute_solid_and_liquid_phases(const VectorType &level_set_as_heaviside)
+        {
+          level_set_as_heaviside.update_ghost_values();
+          heat_operation->get_temperature().update_ghost_values();
+
+          const unsigned int dofs_per_cell = scratch_data->get_n_dofs_per_cell(temp_dof_idx);
+
+          std::vector<types::global_dof_index> local_dof_indices(dofs_per_cell);
+
+          std::map<types::global_dof_index, Point<dim>> support_points;
+          DoFTools::map_dofs_to_support_points(scratch_data->get_mapping(),
+                                               scratch_data->get_dof_handler(temp_dof_idx),
+                                               support_points);
+
+          liquid = 0;
+          solid  = 0;
+
+          for (const auto &cell :
+               scratch_data->get_dof_handler(temp_dof_idx).active_cell_iterators())
+            if (cell->is_locally_owned())
+              {
+                cell->get_dof_indices(local_dof_indices);
+                for (unsigned int i = 0; i < dofs_per_cell; ++i)
+                  {
+                    solid[local_dof_indices[i]] =
+                      is_solid_region(level_set_as_heaviside[local_dof_indices[i]],
+                                      heat_operation->get_temperature()[local_dof_indices[i]]);
+                    liquid[local_dof_indices[i]] =
+                      is_liquid_region(level_set_as_heaviside[local_dof_indices[i]],
+                                       heat_operation->get_temperature()[local_dof_indices[i]]);
+                  }
+              }
+
+          liquid.compress(VectorOperation::insert);
+          solid.compress(VectorOperation::insert);
+
+          scratch_data->get_constraint(temp_dof_idx).distribute(solid);
+          scratch_data->get_constraint(temp_dof_idx).distribute(liquid);
+
+          heat_operation->get_temperature().zero_out_ghosts();
+          level_set_as_heaviside.zero_out_ghosts();
+        }
+
+        /**
+         *  The constraints of the flow velocity are modified such that they are zero in solid
+         *  regions.
+         */
+        void set_flow_field_in_solid_regions_to_zero(const DoFHandler<dim> &    flow_dof_handler,
+                                                     AffineConstraints<double> &flow_constraints)
+        {
+          solid.update_ghost_values();
+
+          IndexSet flow_locally_relevant_dofs;
+          DoFTools::extract_locally_relevant_dofs(flow_dof_handler, flow_locally_relevant_dofs);
+
+          AffineConstraints<double> solid_constraints;
+          solid_constraints.reinit(flow_locally_relevant_dofs);
+
+          FEValues<dim> flow_eval(scratch_data->get_mapping(),
+                                  flow_dof_handler.get_fe(),
+                                  Quadrature<dim>(
+                                    flow_dof_handler.get_fe().get_unit_support_points()),
+                                  update_quadrature_points);
+
+          FEValues<dim> solid_eval(scratch_data->get_mapping(),
+                                   scratch_data->get_dof_handler(temp_dof_idx).get_fe(),
+                                   Quadrature<dim>(
+                                     flow_dof_handler.get_fe().get_unit_support_points()),
+                                   update_values);
+
+          const unsigned int dofs_per_cell = flow_dof_handler.get_fe().n_dofs_per_cell();
+          std::vector<types::global_dof_index> local_dof_indices(dofs_per_cell);
+          std::vector<double>                  solid_at_q(dofs_per_cell);
+
+          typename DoFHandler<dim>::active_cell_iterator solid_cell =
+            scratch_data->get_dof_handler(temp_dof_idx).begin_active();
+
+          for (const auto &cell : flow_dof_handler.active_cell_iterators())
+            {
+              if (cell->is_locally_owned())
+                {
+                  cell->get_dof_indices(local_dof_indices);
+
+                  flow_eval.reinit(cell);
+
+                  solid_eval.reinit(solid_cell);
+                  solid_eval.get_function_values(solid, solid_at_q);
+
+                  for (const auto q : flow_eval.quadrature_point_indices())
+                    {
+                      if (solid_at_q[q] == 1.0)
+                        solid_constraints.add_line(local_dof_indices[q]);
+                    }
+                }
+              ++solid_cell;
+            }
+
+          solid_constraints.close();
+          flow_constraints.merge(
+            solid_constraints, AffineConstraints<double>::MergeConflictBehavior::left_object_wins);
+
+          solid.zero_out_ghosts();
+        }
+        /**
+         *  The level set constraints are modified such that they are zero in solid
+         *  regions.
+         */
+        void remove_the_level_set_from_solid_regions(
+          const DoFHandler<dim> &    level_set_dof_handler,
+          AffineConstraints<double> &level_set_constraints)
+        {
+          solid.update_ghost_values();
+          AssertThrow(
+            scratch_data->get_degree(temp_dof_idx) == scratch_data->get_degree(ls_dof_idx),
+            ExcMessage(
+              "The usage of this function assumes that the temperature field "
+              "is interpolated with the polynomial with the same degree as the level set"));
+
+          const unsigned int dofs_per_cell = level_set_dof_handler.get_fe().n_dofs_per_cell();
+
+          std::vector<types::global_dof_index> local_dof_indices(dofs_per_cell);
+
+          std::map<types::global_dof_index, Point<dim>> support_points;
+          DoFTools::map_dofs_to_support_points(scratch_data->get_mapping(),
+                                               level_set_dof_handler,
+                                               support_points);
+
+          AffineConstraints<double> solid_constraints;
+
+          IndexSet ls_locally_relevant_dofs;
+          DoFTools::extract_locally_relevant_dofs(level_set_dof_handler, ls_locally_relevant_dofs);
+
+          solid_constraints.reinit(ls_locally_relevant_dofs);
+          for (const auto &cell : level_set_dof_handler.active_cell_iterators())
             if (cell->is_locally_owned())
               {
                 cell->get_dof_indices(local_dof_indices);
 
-                flow_eval.reinit(cell);
-
-                solid_eval.reinit(solid_cell);
-                solid_eval.get_function_values(solid, solid_at_q);
-
-                for (const auto q : flow_eval.quadrature_point_indices())
-                  {
-                    if (solid_at_q[q] == 1.0)
-                      solid_constraints.add_line(local_dof_indices[q]);
-                  }
+                for (unsigned int i = 0; i < dofs_per_cell; ++i)
+                  if (solid[local_dof_indices[i]])
+                    solid_constraints.add_line(local_dof_indices[i]);
               }
-            ++solid_cell;
-          }
+          level_set_constraints.merge(
+            solid_constraints, AffineConstraints<double>::MergeConflictBehavior::left_object_wins);
+          level_set_constraints.close();
+          solid.zero_out_ghosts();
+        }
 
-        solid_constraints.close();
-        flow_constraints.merge(solid_constraints,
-                               AffineConstraints<double>::MergeConflictBehavior::left_object_wins);
+        void set_melt_pool_parameters(const Parameters<double> &data_in)
+        {
+          mp_data = data_in.mp;
+        }
 
-        solid.zero_out_ghosts();
-      }
-      /**
-       *  The level set constraints are modified such that they are zero in solid
-       *  regions.
-       */
-      void
-      remove_the_level_set_from_solid_regions(const DoFHandler<dim> &    level_set_dof_handler,
-                                              AffineConstraints<double> &level_set_constraints)
-      {
-        solid.update_ghost_values();
-        AssertThrow(scratch_data->get_degree(temp_dof_idx) == scratch_data->get_degree(ls_dof_idx),
-                    ExcMessage(
-                      "The usage of this function assumes that the temperature field "
-                      "is interpolated with the polynomial with the same degree as the level set"));
-
-        const unsigned int dofs_per_cell = level_set_dof_handler.get_fe().n_dofs_per_cell();
-
-        std::vector<types::global_dof_index> local_dof_indices(dofs_per_cell);
-
-        std::map<types::global_dof_index, Point<dim>> support_points;
-        DoFTools::map_dofs_to_support_points(scratch_data->get_mapping(),
-                                             level_set_dof_handler,
-                                             support_points);
-
-        AffineConstraints<double> solid_constraints;
-
-        IndexSet ls_locally_relevant_dofs;
-        DoFTools::extract_locally_relevant_dofs(level_set_dof_handler, ls_locally_relevant_dofs);
-
-        solid_constraints.reinit(ls_locally_relevant_dofs);
-        for (const auto &cell : level_set_dof_handler.active_cell_iterators())
-          if (cell->is_locally_owned())
-            {
-              cell->get_dof_indices(local_dof_indices);
-
-              for (unsigned int i = 0; i < dofs_per_cell; ++i)
-                if (solid[local_dof_indices[i]])
-                  solid_constraints.add_line(local_dof_indices[i]);
-            }
-        level_set_constraints.merge(
-          solid_constraints, AffineConstraints<double>::MergeConflictBehavior::left_object_wins);
-        level_set_constraints.close();
-        solid.zero_out_ghosts();
-      }
-
-      void
-      set_melt_pool_parameters(const Parameters<double> &data_in)
-      {
-        mp_data = data_in.mp;
-      }
-
-      /**
-       *  This function determines for a given point, whether it belongs to the solid domain.
-       *
-       *  WARNING: All points above (component dim-1) the center point of the laser source are
-       *  automatically identified as gaseous parts. Thus, this function has to be modified when the
-       *  initial interface between the feedstock and the ambient gas is not planar.
-       */
-      bool
-      is_solid_region(const Point<dim> point, const double temperature)
-      {
-        if (point[dim - 1] >= laser_operation->get_laser_position()[dim - 1])
-          return false;
-        else
-          return (temperature >= mp_data.liquid.melting_point) ? false : true;
-      }
-
-      /*
-       * check if a given point is liquid
-       */
-      bool
-      is_liquid_region(const Point<dim> point, const double temperature)
-      {
-        if (point[dim - 1] >= laser_operation->get_laser_position()[dim - 1])
-          return false;
-        else
-          return (temperature >= mp_data.liquid.melting_point) ? true : false;
-      }
-    };
-  } // namespace MeltPool
-} // namespace MeltPoolDG
+        /**
+         *  This function determines for a given pair of level set and temperature values, whether
+         * it characterizes a solid state. For this purpose, it is assumed that phi=1 in the liquid
+         * AND the solid domain and phi=0 in the gaseous domain. Thus, if phi=1 and the temperature
+         * is SMALLER than the fusion point, a solid phase is met.
+         */
+        bool is_solid_region(const double phi_liquid, const double temperature)
+        {
+          if (phi_liquid <= 0.5)
+            return false; // point is gas phase
+          else if (phi_liquid > 0.5 && temperature >= mp_data.liquid.melting_point)
+            return false; // point is melted
+          else
+            return true;
+        }
+        /**
+         *  This function determines for a given pair of level set and temperature values, whether
+         * it characterizes a liquid state. For this purpose, it is assumed that phi=1 in the liquid
+         * AND the solid domain and phi=0 in the gaseous domain. Thus, if phi=1 and the temperature
+         * is LARGER than the fusion point, a liquid phase is met.
+         */
+        bool is_liquid_region(const double phi_liquid, const double temperature)
+        {
+          if (phi_liquid <= 0.5)
+            return false; // point is gas phase
+          else if (phi_liquid > 0.5 && temperature >= mp_data.liquid.melting_point)
+            return true; // point is melted
+          else
+            return false; // point is solid
+        }
+      };
+    } // namespace MeltPool
+  }   // namespace MeltPoolDG


### PR DESCRIPTION
This PR includes:
- add `two_phase_flow_with_heat_transfer` problem; If this problem type is chosen, a `HeatTransferOperation` is instantiated in the `TwoPhaseFlowProblem`.
- option enabled for solving a heat problem in case of a melt pool problem
- `compute_liquid_and_solid_phases`: liquid and solid regions are now distinguished based on the level set value and the temperature value.

Due to the numerous extensions available in the `TwoPhaseFlowProblem` it is currently a "mess". We should definitely discuss to split it up in separate operations, i.e. two-phase-flow, two-phase-flow with phase change, to maintain a clear coding structure. 