### PR TITLE
Add two-phase material parameter input for heat transfer

### DIFF
--- a/include/meltpooldg/heat/heat_transfer_operation.hpp
+++ b/include/meltpooldg/heat/heat_transfer_operation.hpp
@@ -56,12 +56,13 @@ namespace MeltPoolDG::Heat
                           const ScratchData<dim> &                        scratch_data_in,
                           const HeatData<double> &                        heat_data_in,
                           const unsigned int                              temp_dof_idx_in,
-                          const unsigned int temp_hanging_nodes_dof_idx_in,
-                          const unsigned int temp_quad_idx_in,
-                          const unsigned int vel_dof_idx_in            = 0,
-                          VectorType *       velocity_in               = nullptr,
-                          const unsigned int ls_dof_idx_in             = 0,
-                          VectorType *       level_set_as_heaviside_in = nullptr)
+                          const unsigned int          temp_hanging_nodes_dof_idx_in,
+                          const unsigned int          temp_quad_idx_in,
+                          const unsigned int          vel_dof_idx_in            = 0,
+                          VectorType *                velocity_in               = nullptr,
+                          const unsigned int          ls_dof_idx_in             = 0,
+                          VectorType *                level_set_as_heaviside_in = nullptr,
+                          const MaterialData<double> *material_data_in          = nullptr)
       : scratch_data(scratch_data_in)
       , heat_data(heat_data_in)
       , temp_dof_idx(temp_dof_idx_in)
@@ -82,7 +83,8 @@ namespace MeltPoolDG::Heat
                                                                   vel_dof_idx,
                                                                   velocity,
                                                                   ls_dof_idx,
-                                                                  level_set_as_heaviside);
+                                                                  level_set_as_heaviside,
+                                                                  material_data_in);
     }
 
     void

--- a/include/meltpooldg/heat/heat_transfer_operator.hpp
+++ b/include/meltpooldg/heat/heat_transfer_operator.hpp
@@ -102,9 +102,9 @@ namespace MeltPoolDG::Heat
     const VectorType * velocity;
 
     // optional level-set heaviside field for two phase flow
-    const unsigned int ls_dof_idx;
-    const VectorType * level_set_as_heaviside;
-
+    const unsigned int          ls_dof_idx;
+    const VectorType *          level_set_as_heaviside;
+    const MaterialData<double> *material_data;
 
   public:
     HeatTransferOperator(const std::shared_ptr<BoundaryConditions<dim>> &bc,
@@ -117,7 +117,8 @@ namespace MeltPoolDG::Heat
                          const unsigned int                              vel_dof_idx_in = 0,
                          const VectorType *                              velocity_in    = nullptr,
                          const unsigned int                              ls_dof_idx_in  = 0,
-                         const VectorType *level_set_as_heaviside_in                    = nullptr)
+                         const VectorType *          level_set_as_heaviside_in          = nullptr,
+                         const MaterialData<double> *material_data_in                   = nullptr)
       // clang-format off
     : scratch_data           ( scratch_data_in           )
     , data                   ( data_in                   )
@@ -129,8 +130,9 @@ namespace MeltPoolDG::Heat
     , velocity               ( velocity_in               )
     , ls_dof_idx             ( ls_dof_idx_in             )
     , level_set_as_heaviside ( level_set_as_heaviside_in )
+, material_data(material_data_in)
     {
-      AssertThrow(!level_set_as_heaviside || (velocity && level_set_as_heaviside) ,
+      AssertThrow(!level_set_as_heaviside || (velocity && level_set_as_heaviside && material_data) ,
           ExcMessage("Two-phase flow must come with a velocity! Abort..."));
 
       if (bc)
@@ -480,14 +482,14 @@ namespace MeltPoolDG::Heat
         weight = UtilityFunctions::heaviside(ls_heaviside_val, 0.5);
 
       const auto density      = UtilityFunctions::interpolate(weight,
-                                                         /*other dens*/ data.density / 2,
-                                                         data.density);
+                                                         material_data->gas.density,
+                                                         material_data->liquid.density);
       const auto capacity     = UtilityFunctions::interpolate(weight,
-                                                          /*other cap*/ data.capacity / 2,
-                                                          data.capacity);
+                                                          material_data->gas.capacity,
+                                                          material_data->liquid.capacity);
       const auto conductivity = UtilityFunctions::interpolate(weight,
-                                                              /*other cond*/ data.conductivity / 2,
-                                                              data.conductivity);
+                                                              material_data->gas.conductivity,
+                                                              material_data->liquid.conductivity);
       return std::make_tuple(density, capacity, conductivity);
     }
   };

--- a/include/meltpooldg/heat/heat_transfer_problem.hpp
+++ b/include/meltpooldg/heat/heat_transfer_problem.hpp
@@ -204,6 +204,12 @@ namespace MeltPoolDG::Heat
         }
 
       /*
+       *    two-phase material properties
+       */
+      MaterialData<double> *material_data_ptr;
+      if (base_in->parameters.heat.two_phase)
+        material_data_ptr = &base_in->parameters.material;
+      /*
        *    initialize the heat operation class
        */
       heat_operation =
@@ -216,7 +222,8 @@ namespace MeltPoolDG::Heat
                                                      velocity_dof_idx,
                                                      velocity_ptr,
                                                      level_set_dof_idx,
-                                                     level_set_as_heaviside_ptr);
+                                                     level_set_as_heaviside_ptr,
+                                                     material_data_ptr);
 
       heat_operation->set_initial_condition(initial_solution);
 

--- a/include/meltpooldg/interface/parameters.hpp
+++ b/include/meltpooldg/interface/parameters.hpp
@@ -239,6 +239,24 @@ namespace MeltPoolDG
   };
 
   template <typename number = double>
+  struct MaterialData
+  {
+    struct Liquid
+    {
+      number capacity     = 0.0;
+      number conductivity = 0.0;
+      number density      = 0.0;
+    } liquid;
+
+    struct Gas
+    {
+      number capacity     = 0.0;
+      number conductivity = 0.0;
+      number density      = 0.0;
+    } gas;
+  };
+
+  template <typename number = double>
   struct ParaviewData
   {
     bool        do_output           = false;
@@ -937,6 +955,23 @@ namespace MeltPoolDG
       }
       prm.leave_subsection();
       /*
+       *  material
+       */
+      prm.enter_subsection("material");
+      {
+        prm.add_parameter("material liquid capacity", material.liquid.capacity, "liquid capacity");
+        prm.add_parameter("material liquid conductivity",
+                          material.liquid.conductivity,
+                          "liquid conductivity");
+        prm.add_parameter("material liquid density", material.liquid.density, "liquid density");
+        prm.add_parameter("material gas capacity", material.gas.capacity, "gas capacity");
+        prm.add_parameter("material gas conductivity",
+                          material.gas.conductivity,
+                          "gas conductivity");
+        prm.add_parameter("material gas density", material.gas.density, "gas density");
+      }
+      prm.leave_subsection();
+      /*
        *   paraview
        */
       prm.enter_subsection("paraview");
@@ -1025,6 +1060,7 @@ namespace MeltPoolDG
     MeltPoolData<number>           mp;
     RecoilPressureData<number>     recoil;
     EvaporationData<number>        evapor;
+    MaterialData<number>           material;
     ParaviewData<number>           paraview;
     OutputData<number>             output;
     Flow::AdafloWrapperParameters  adaflo_params;

--- a/include/meltpooldg/simulations/unidirectional_heat_transfer/unidirectional_heat_transfer_with_two_phase.json
+++ b/include/meltpooldg/simulations/unidirectional_heat_transfer/unidirectional_heat_transfer_with_two_phase.json
@@ -12,9 +12,6 @@
     "heat emissivity": "0.98",
     "heat convection coefficient": "25",
     "heat temperature infinity": "300.0",
-    "heat conductivity": "55.563",
-    "heat capacity": "460",
-    "heat density": "7850.0",
     "heat velocity": "0.01",
     "heat two phase": "true",
     "heat variable properties over interface": "false",
@@ -24,6 +21,14 @@
     "heat max n steps": "100",
     "heat solver rel tolerance rhs": "1e-12",
     "heat nlsolve residual tolerance": "1e-6"
+  },
+  "material": {
+    "material liquid capacity": "460",
+    "material liquid conductivity": "55.563",
+    "material liquid density": "7850",
+    "material gas capacity": "230",
+    "material gas conductivity": "27.7815",
+    "material gas density": "3925"
   },
   "paraview": {
     "paraview do output": "true",

--- a/tests/unidirectional_heat_transfer_with_two_phase.json
+++ b/tests/unidirectional_heat_transfer_with_two_phase.json
@@ -12,9 +12,6 @@
     "heat emissivity": "0.98",
     "heat convection coefficient": "25",
     "heat temperature infinity": "300.0",
-    "heat conductivity": "55.563",
-    "heat capacity": "460",
-    "heat density": "7850.0",
     "heat velocity": "0.01",
     "heat two phase": "true",
     "heat variable properties over interface": "false",
@@ -24,6 +21,14 @@
     "heat max n steps": "5",
     "heat solver rel tolerance rhs": "1e-12",
     "heat nlsolve residual tolerance": "1e-6"
+  },
+  "material": {
+    "material liquid capacity": "460",
+    "material liquid conductivity": "55.563",
+    "material liquid density": "7850",
+    "material gas capacity": "230",
+    "material gas conductivity": "27.7815",
+    "material gas density": "3925"
   },
   "paraview": {
     "paraview do output": "false"


### PR DESCRIPTION
This PR introduces a two-phase material parameter input section for heat transfer. This material parameter section can be expanded for more material parameters in other physical contexts.

@mschreter what do you think of this design? If we always use the material section to define materials we can remove the material_data pointer and pass this struct by reference instead.

This might create a merge conflict with #106. I'll rebase whatever is merged last.