### PR TITLE
Utility function for merging two level set fields

### DIFF
--- a/include/meltpooldg/utilities/utilityfunctions.hpp
+++ b/include/meltpooldg/utilities/utilityfunctions.hpp
@@ -5,14 +5,26 @@
 #include <deal.II/base/vectorization.h>
 
 #include <deal.II/fe/fe_dgq.h>
+#include <deal.II/fe/fe_q.h>
 #include <deal.II/fe/fe_tools.h>
 
 #include <deal.II/lac/generic_linear_algebra.h>
+
+#include <deal.II/matrix_free/matrix_free.h>
+
+#include <meltpooldg/utilities/fe_integrator.hpp>
 
 namespace MeltPoolDG
 {
   using namespace dealii;
   using VectorType = LinearAlgebra::distributed::Vector<double>;
+
+  enum BooleanType
+  {
+    Union,
+    Intersection,
+    Subtraction
+  };
 
   namespace TypeDefs
   {
@@ -213,6 +225,68 @@ namespace MeltPoolDG
                                                                   VectorizedArray<double>(limit),
                                                                   1.0,
                                                                   0.0);
+    }
+
+    /**
+     * For two indicator vectors, representing e.g. implicit geometries, this function computes a
+     * boolean operation and returns the resulting vector. The user has to take care on distributing
+     * relevant constraints afterwards.
+     */
+    template <typename VectorType>
+    VectorType
+    merge_two_indicator_fields(const VectorType &indicator_1,
+                               const VectorType &indicator_2,
+                               BooleanType       type                     = BooleanType::Union,
+                               const double      indicator_value_interior = 1.0,
+                               const double      indicator_value_exterior = -1.0)
+    {
+      AssertThrow(indicator_1.size() == indicator_2.size(),
+                  ExcMessage("The two level set vectors to be merged must be of equal length."));
+
+      AssertThrow(indicator_value_interior != indicator_value_exterior,
+                  ExcMessage("The indicator value in the interior of the implicit geometry must be "
+                             "different than the one in the exterior. Make sure that the function "
+                             "arguments indicator_value_interior and indicator_value_exterior are "
+                             "set correctly."));
+
+      AssertThrow(indicator_1.linfty_norm() ==
+                    std::max(indicator_value_exterior, indicator_value_interior),
+                  ExcMessage(
+                    "The maximum indicator value does not correspond to the given bounds "
+                    "of indicator_value_interior and indicator_value_exterior. Make sure that "
+                    "the indicator_value_interior and indicator_value_exterior comply with the "
+                    "indicator field."));
+
+      VectorType merge_indicator(indicator_1);
+
+      bool is_interior_larger_than_exterior = indicator_value_interior > indicator_value_exterior;
+
+      for (const auto &i : indicator_1.locally_owned_elements())
+        switch (type)
+          {
+            case BooleanType::Union:
+              merge_indicator[i] = (is_interior_larger_than_exterior) ?
+                                     std::max(indicator_1[i], indicator_2[i]) :
+                                     std::min(indicator_1[i], indicator_2[i]);
+              break;
+            case BooleanType::Intersection:
+              merge_indicator[i] = (is_interior_larger_than_exterior) ?
+                                     std::min(indicator_1[i], indicator_2[i]) :
+                                     std::max(indicator_1[i], indicator_2[i]);
+              break;
+            case BooleanType::Subtraction:
+              merge_indicator[i] =
+                (indicator_1[i] == indicator_2[i] && indicator_1[i] == indicator_value_interior) ?
+                  indicator_value_exterior :
+                  indicator_1[i];
+              break;
+            default:
+              AssertThrow(false, ExcNotImplemented());
+          }
+
+      merge_indicator.compress(VectorOperation::insert);
+
+      return merge_indicator;
     }
 
     namespace CharacteristicFunctions

--- a/unit_tests/merge_two_level_set_fields.cc
+++ b/unit_tests/merge_two_level_set_fields.cc
@@ -1,0 +1,288 @@
+#include <deal.II/base/conditional_ostream.h>
+#include <deal.II/base/mpi.h>
+
+#include <deal.II/dofs/dof_handler.h>
+
+#include <deal.II/fe/fe_q.h>
+#include <deal.II/fe/mapping_fe.h>
+
+#include <deal.II/grid/grid_generator.h>
+
+#include <deal.II/lac/la_parallel_vector.h>
+
+#include <deal.II/matrix_free/matrix_free.h>
+
+#include <deal.II/numerics/data_out.h>
+#include <deal.II/numerics/vector_tools.h>
+
+#include <meltpooldg/utilities/utilityfunctions.hpp>
+
+#include <iostream>
+
+using namespace dealii;
+using namespace MeltPoolDG;
+using VectorType = LinearAlgebra::distributed::Vector<double>;
+
+template <int dim>
+class InitializePhi1 : public Function<dim>
+{
+public:
+  InitializePhi1(const Point<dim> &center, const double &radius)
+    : Function<dim>()
+    , center(center)
+    , radius(radius)
+  {}
+
+  virtual double
+  value(const Point<dim> &p, const unsigned int component = 0) const
+  {
+    (void)component;
+
+    return UtilityFunctions::CharacteristicFunctions::sgn(
+      UtilityFunctions::DistanceFunctions::spherical_manifold<dim>(p, center, radius));
+  }
+
+  Point<dim> center;
+  double     radius;
+};
+
+template <int dim>
+class InitializePhi2 : public Function<dim>
+{
+public:
+  InitializePhi2(const Point<dim> &center, const double &radius)
+    : Function<dim>()
+    , center(center)
+    , radius(radius)
+  {}
+
+  virtual double
+  value(const Point<dim> &p, const unsigned int component = 0) const
+  {
+    (void)component;
+
+    return -UtilityFunctions::CharacteristicFunctions::sgn(
+      UtilityFunctions::DistanceFunctions::spherical_manifold<dim>(p, center, radius));
+  }
+
+  Point<dim> center;
+  double     radius;
+};
+
+template <int dim>
+class InitializePhi3 : public Function<dim>
+{
+public:
+  InitializePhi3(const Point<dim> &center, const double &radius)
+    : Function<dim>()
+    , center(center)
+    , radius(radius)
+  {}
+
+  virtual double
+  value(const Point<dim> &p, const unsigned int component = 0) const
+  {
+    (void)component;
+
+    return UtilityFunctions::CharacteristicFunctions::heaviside(
+      UtilityFunctions::CharacteristicFunctions::sgn(
+        UtilityFunctions::DistanceFunctions::spherical_manifold<dim>(p, center, radius)),
+      0);
+  }
+
+  Point<dim> center;
+  double     radius;
+};
+
+template <int dim>
+class InitializePhi4 : public Function<dim>
+{
+public:
+  InitializePhi4(const Point<dim> &center, const double &radius)
+    : Function<dim>()
+    , center(center)
+    , radius(radius)
+  {}
+
+  virtual double
+  value(const Point<dim> &p, const unsigned int component = 0) const
+  {
+    (void)component;
+
+    return UtilityFunctions::CharacteristicFunctions::heaviside(
+      -UtilityFunctions::CharacteristicFunctions::sgn(
+        UtilityFunctions::DistanceFunctions::spherical_manifold<dim>(p, center, radius)),
+      0);
+  }
+
+  Point<dim> center;
+  double     radius;
+};
+
+template <int dim>
+class InitializePhi5 : public Function<dim>
+{
+public:
+  InitializePhi5(const Point<dim> &center, const double &radius)
+    : Function<dim>()
+    , center(center)
+    , radius(radius)
+  {}
+
+  virtual double
+  value(const Point<dim> &p, const unsigned int component = 0) const
+  {
+    (void)component;
+
+    return 5 * UtilityFunctions::CharacteristicFunctions::sgn(
+                 UtilityFunctions::DistanceFunctions::spherical_manifold<dim>(p, center, radius)) +
+           1.0;
+  }
+
+  Point<dim> center;
+  double     radius;
+};
+
+
+int
+main(int argc, char *argv[])
+{
+  Utilities::MPI::MPI_InitFinalize mpi_initialization(argc, argv, 1);
+  MPI_Comm                         mpi_comm(MPI_COMM_WORLD);
+
+  const int dim    = 2;
+  const int degree = 1;
+
+  Point<2>     center1(0.5, 0.5);
+  Point<2>     center2(0.3, 0.3);
+  const double radius = 0.25;
+
+  // triangulation
+  auto triangulation = parallel::distributed::Triangulation<dim>(mpi_comm);
+
+  GridGenerator::hyper_cube(triangulation);
+
+  triangulation.refine_global(5);
+
+  auto q_gauss = QGauss<dim>(degree + 1);
+  auto fe_q    = FE_Q<dim>(degree);
+  auto mapping = MappingFE<dim>(fe_q);
+
+  DoFHandler<dim> dof_handler;
+  dof_handler.reinit(triangulation);
+  dof_handler.distribute_dofs(fe_q);
+
+  AffineConstraints<double> constraints;
+
+  typename MatrixFree<dim, double, VectorizedArray<double>>::AdditionalData additional_data;
+  additional_data.mapping_update_flags =
+    update_values | update_gradients | update_JxW_values | dealii::update_quadrature_points;
+
+  MatrixFree<dim, double, VectorizedArray<double>> matrix_free;
+  matrix_free.reinit(mapping, dof_handler, constraints, q_gauss, additional_data);
+
+  const auto run_test = [&](const auto & level_set_1,
+                            const auto & level_set_2,
+                            const double level_set_interior_value = 1.0,
+                            const double level_set_exterior_value = -1.0,
+                            std::string  pv_name                  = "test") -> auto
+  {
+    level_set_1.update_ghost_values();
+    level_set_2.update_ghost_values();
+
+    auto merged_level_set_union =
+      UtilityFunctions::merge_two_indicator_fields(level_set_1,
+                                                   level_set_2,
+                                                   BooleanType::Union,
+                                                   level_set_interior_value,
+                                                   level_set_exterior_value);
+
+    auto merged_level_set_intersect =
+      UtilityFunctions::merge_two_indicator_fields(level_set_1,
+                                                   level_set_2,
+                                                   BooleanType::Intersection,
+                                                   level_set_interior_value,
+                                                   level_set_exterior_value);
+
+    auto merged_level_set_subtract =
+      UtilityFunctions::merge_two_indicator_fields(level_set_1,
+                                                   level_set_2,
+                                                   BooleanType::Subtraction,
+                                                   level_set_interior_value,
+                                                   level_set_exterior_value);
+
+    merged_level_set_union.update_ghost_values();
+    merged_level_set_intersect.update_ghost_values();
+    merged_level_set_subtract.update_ghost_values();
+
+    auto pcout = ConditionalOStream(std::cout, Utilities::MPI::this_mpi_process(mpi_comm) == 0);
+    pcout << "level_set_1: " << level_set_1.l2_norm() << std::endl;
+    pcout << "level_set_2: " << level_set_2.l2_norm() << std::endl;
+    pcout << "level_set_1 ∪ level_set_2 : " << merged_level_set_union.l2_norm() << std::endl;
+    pcout << "level_set_1 ∩ level_set_2 : " << merged_level_set_intersect.l2_norm() << std::endl;
+    pcout << "level_set_1 - level_set_2 : " << merged_level_set_subtract.l2_norm() << std::endl;
+
+#if 1
+    // write paraview output
+    DataOut<dim> data_out;
+    data_out.attach_dof_handler(dof_handler);
+
+    DataOutBase::VtkFlags flags;
+    flags.write_higher_order_cells = true;
+    data_out.set_flags(flags);
+
+    data_out.add_data_vector(level_set_1, "level_set_1");
+    data_out.add_data_vector(level_set_2, "level_set_2");
+    data_out.add_data_vector(merged_level_set_union, "merged_level_set_union");
+    data_out.add_data_vector(merged_level_set_intersect, "merged_level_set_intersect");
+    data_out.add_data_vector(merged_level_set_subtract, "merged_level_set_subtract");
+
+    data_out.build_patches(mapping);
+    data_out.write_vtu_with_pvtu_record("./", pv_name, 0, mpi_comm);
+#endif
+    level_set_1.zero_out_ghosts();
+    level_set_2.zero_out_ghosts();
+  };
+
+
+  VectorType level_set_1, level_set_2;
+  matrix_free.initialize_dof_vector(level_set_1, 0);
+  matrix_free.initialize_dof_vector(level_set_2, 0);
+
+  /*
+   * Test with level set interior = 1.0 and exterior = -1.0
+   */
+  VectorTools::interpolate(mapping, dof_handler, InitializePhi1<dim>(center1, radius), level_set_1);
+  VectorTools::interpolate(mapping, dof_handler, InitializePhi1<dim>(center2, radius), level_set_2);
+  run_test(level_set_1, level_set_2, 1.0, -1.0, "test_1");
+
+  /*
+   * Test with level set interior = -1.0 and exterior = 1.0
+   */
+  VectorTools::interpolate(mapping, dof_handler, InitializePhi2<dim>(center1, radius), level_set_1);
+  VectorTools::interpolate(mapping, dof_handler, InitializePhi2<dim>(center2, radius), level_set_2);
+  run_test(level_set_1, level_set_2, -1.0, 1.0, "test_2");
+
+  /*
+   * Test with level set interior = 1.0 and exterior = 0.0
+   */
+  VectorTools::interpolate(mapping, dof_handler, InitializePhi3<dim>(center1, radius), level_set_1);
+  VectorTools::interpolate(mapping, dof_handler, InitializePhi3<dim>(center2, radius), level_set_2);
+  run_test(level_set_1, level_set_2, 1.0, 0.0, "test_3");
+
+  /*
+   * Test with level set interior = 0.0 and exterior = 1.0
+   */
+  VectorTools::interpolate(mapping, dof_handler, InitializePhi4<dim>(center1, radius), level_set_1);
+  VectorTools::interpolate(mapping, dof_handler, InitializePhi4<dim>(center2, radius), level_set_2);
+  run_test(level_set_1, level_set_2, 0.0, 1.0, "test_4");
+
+  /*
+   * Test with level set interior = 6.0 and exterior = -4.0
+   */
+  VectorTools::interpolate(mapping, dof_handler, InitializePhi5<dim>(center1, radius), level_set_1);
+  VectorTools::interpolate(mapping, dof_handler, InitializePhi5<dim>(center2, radius), level_set_2);
+  run_test(level_set_1, level_set_2, 6.0, -4.0, "test_5");
+
+  return 0;
+}

--- a/unit_tests/merge_two_level_set_fields.mpirun=4.output
+++ b/unit_tests/merge_two_level_set_fields.mpirun=4.output
@@ -1,0 +1,25 @@
+level_set_1: 33
+level_set_2: 33
+level_set_1 ∪ level_set_2 : 33
+level_set_1 ∩ level_set_2 : 33
+level_set_1 - level_set_2 : 33
+level_set_1: 33
+level_set_2: 33
+level_set_1 ∪ level_set_2 : 33
+level_set_1 ∩ level_set_2 : 33
+level_set_1 - level_set_2 : 33
+level_set_1: 14.0357
+level_set_2: 14.2829
+level_set_1 ∪ level_set_2 : 18.3848
+level_set_1 ∩ level_set_2 : 7.93725
+level_set_1 - level_set_2 : 11.5758
+level_set_1: 29.8664
+level_set_2: 29.7489
+level_set_1 ∪ level_set_2 : 27.4044
+level_set_1 ∩ level_set_2 : 32.0312
+level_set_1 - level_set_2 : 30.9031
+level_set_1: 146.164
+level_set_2: 146.642
+level_set_1 ∪ level_set_2 : 155.512
+level_set_1 ∩ level_set_2 : 136.689
+level_set_1 - level_set_2 : 141.789


### PR DESCRIPTION
This PR introduces the utility function to merge two level set fields based on boolean algebra (and solves Issue #108). The following cases are supported:

- intersection
- difference 
- union

![image](https://user-images.githubusercontent.com/70260016/112990249-1e8a3d80-9166-11eb-9a39-aed4f17e3ff9.png)
