### PR TITLE
Add jupyter notebook for two droplet simualtion parameters

### DIFF
--- a/include/meltpooldg/simulations/thermo_capillary_two_droplets/thermo_capillary_two_droplets_parameters.ipynb
+++ b/include/meltpooldg/simulations/thermo_capillary_two_droplets/thermo_capillary_two_droplets_parameters.ipynb
@@ -351,13 +351,6 @@
     "\n",
     "[2] Balcázar, N., Rigola, J., Castro, J., & Oliva, A. (2016). A level-set model for thermocapillary motion of deformable fluid particles. International Journal of Heat and Fluid Flow, 62, 324–343. https://doi.org/10.1016/j.ijheatfluidflow.2016.09.015"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/include/meltpooldg/simulations/thermo_capillary_two_droplets/thermo_capillary_two_droplets_parameters.ipynb
+++ b/include/meltpooldg/simulations/thermo_capillary_two_droplets/thermo_capillary_two_droplets_parameters.ipynb
@@ -49,7 +49,7 @@
     "\\text{Ma} = \\frac{U_r a \\rho_0 c_{p0}}{k_0} = \\frac{\\sigma_T |\\nabla T| a^2 \\rho_0 c_{p0}}{\\mu_0 k_0} = 40\n",
     "\\end{align} $\n",
     "\n",
-    "* and he capillary number Ca\n",
+    "* and the capillary number Ca\n",
     "\n",
     "$ \\begin{align}\n",
     "\\text{Ca} = \\frac{U_r \\mu_0}{\\sigma_0} = \\frac{\\sigma_T |\\nabla T| a}{\\sigma_0} = 0.041666 \\text{.}\n",

--- a/include/meltpooldg/simulations/thermo_capillary_two_droplets/thermo_capillary_two_droplets_parameters.ipynb
+++ b/include/meltpooldg/simulations/thermo_capillary_two_droplets/thermo_capillary_two_droplets_parameters.ipynb
@@ -1,0 +1,384 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Thermo-capillary interaction of two droplets"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### \"Light drops\" example by Nas & Tryggvason [1]: \n",
+    "\n",
+    "The thermo-capillary interaction of two light droplets example is goverened by\n",
+    "\n",
+    "- $a$ initial droplet radius\n",
+    "- $\\sigma_0$ surface tension at reference temperature\n",
+    "- $\\sigma_T$ surface tension temperature coefficient\n",
+    "- $\\nabla T$ initial temperature gradient\n",
+    "- surrounding fluid's material properties: $\\mu_0$, $\\rho_0$, $c_{p0}$, $k_0$\n",
+    "- droplets' material properties: $\\mu_i$, $\\rho_i$, $c_{pi}$, $k_i$"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Problem definition\n",
+    "\n",
+    "First we define a reference velocity $U_r$:\n",
+    "\n",
+    "$ \\begin{align} \n",
+    "U_r = \\frac{\\sigma_T |\\nabla T| a}{\\mu_0}\n",
+    "\\end{align} $\n",
+    "\n",
+    "The problem is defined by the following characteristic numbers [1]:\n",
+    "\n",
+    "* The Reynolds number Re\n",
+    "\n",
+    "$ \\begin{align} \\label{eq:Re}\n",
+    "\\text{Re} = \\frac{U_r a \\rho_0}{\\mu_0} = \\frac{\\sigma_T |\\nabla T| a^2 \\rho_0}{\\mu_0^2} = 40 \\text{,}\n",
+    "\\end{align} $\n",
+    "\n",
+    "* the Marangoni number Ma\n",
+    "\n",
+    "$ \\begin{align} \n",
+    "\\text{Ma} = \\frac{U_r a \\rho_0 c_{p0}}{k_0} = \\frac{\\sigma_T |\\nabla T| a^2 \\rho_0 c_{p0}}{\\mu_0 k_0} = 40\n",
+    "\\end{align} $\n",
+    "\n",
+    "* and he capillary number Ca\n",
+    "\n",
+    "$ \\begin{align}\n",
+    "\\text{Ca} = \\frac{U_r \\mu_0}{\\sigma_0} = \\frac{\\sigma_T |\\nabla T| a}{\\sigma_0} = 0.041666 \\text{.}\n",
+    "\\end{align} $\n",
+    "\n",
+    "Notice that $\\sigma_T |\\nabla T|$ and $\\frac{c_{p0}}{k_0}$ can be replaced by single quantities in the three equation above, eliminating one degree of freedom each."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "Re = 40\n",
+    "Ma = 40\n",
+    "Ca = 0.041666"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The ratio between the surrounding and the droplets fluid's material properties are defined as\n",
+    "\n",
+    "$ \\begin{align}\n",
+    "\\rho^* = \\frac{\\rho_i}{\\rho_0} = 0.5\n",
+    "\\end{align} $\n",
+    "\n",
+    "$ \\begin{align}\n",
+    "\\mu^* = \\frac{\\mu_i}{\\mu_0} = 0.5\n",
+    "\\end{align} $\n",
+    "\n",
+    "$ \\begin{align}\n",
+    "c_p^* = \\frac{c_{pi}}{c_{p0}} = 0.5\n",
+    "\\end{align} $\n",
+    "\n",
+    "$ \\begin{align}\n",
+    "k^* = \\frac{k_i}{k_0} = 0.5\n",
+    "\\end{align} $"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "rho_star = 0.5\n",
+    "mu_star  = 0.5\n",
+    "cp_star  = 0.5\n",
+    "k_star   = 0.5"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Quantities\n",
+    "\n",
+    "We define the following quantities with somewhat realistic values:\n",
+    "\n",
+    "$ \\begin{align}\n",
+    "\\mu_0 = 0.024 \\ N/m^2/s\n",
+    "\\end{align} $\n",
+    "\n",
+    "$ \\begin{align}\n",
+    "\\rho_0 = 500 \\ kg/m^3\n",
+    "\\end{align} $\n",
+    "\n",
+    "$ \\begin{align}\n",
+    "c_{p0} = 1 \\cdot 10^{-4} \\ J/kg/K\n",
+    "\\end{align} $\n",
+    "\n",
+    "$ \\begin{align}\n",
+    "\\sigma_T = 0.002 \\ N/m/K\n",
+    "\\end{align} $\n",
+    "\n",
+    "$ \\begin{align}\n",
+    "|\\nabla T| =  10 \\ K/m\n",
+    "\\end{align} $"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mu_0    = 0.024\n",
+    "rho_0   = 500\n",
+    "cp_0    = 1e-4\n",
+    "sigma_T = 0.002\n",
+    "grad_T  = 10"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The initial droplet radius can be determined with Reynolds number:\n",
+    "\n",
+    "$ \\begin{align}\n",
+    "a = \\sqrt{\\frac{\\text{Re} \\mu_0^2}{\\sigma_T |\\nabla T| \\rho_0}}\n",
+    "\\end{align} $"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "a = (Re * mu_0**2 / (sigma_T * grad_T * rho_0))**0.5"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The surrounding conductivity can be determined with Marangoni number:\n",
+    "\n",
+    "$ \\begin{align}\n",
+    "k_0 = \\frac{\\sigma_T |\\nabla T| a^2 \\rho_0 c_{p0}}{\\text{Ma} \\mu_0}\n",
+    "\\end{align} $"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "k_0 = sigma_T * grad_T * a**2 * rho_0 * cp_0 / (Ma * mu_0)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The surface tension at reference temperature can be determined with the capillary number:\n",
+    "\n",
+    "$ \\begin{align}\n",
+    "\\sigma_0 = \\frac{\\sigma_T |\\nabla T| a}{\\text{Ca}}\n",
+    "\\end{align} $"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sigma_0 = sigma_T * grad_T * a / Ca"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The droplets' material propertie are defined by the ratios:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "rho_i = rho_star * rho_0\n",
+    "mu_i  = mu_star * mu_0\n",
+    "cp_i  = cp_star * cp_0\n",
+    "k_i   = k_star * k_0"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Time scale\n",
+    "\n",
+    "The reference time scale is defined as\n",
+    "\n",
+    "$ \\begin{align}\n",
+    "t_r = \\frac{a}{U_r}\n",
+    "\\end{align} $"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "U_r = sigma_T * a * grad_T / mu_0\n",
+    "t_r = a / U_r"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "An estimate for the required time step size is given as [2]:\n",
+    "\n",
+    "$ \\begin{align}\n",
+    "\\Delta t = 0.1 \\min \\left(\\frac{a}{U_r}, \\frac{\\rho_0 a^2}{\\mu_0}, a^{3/2} \\cdot \\sqrt{\\frac{\\rho_0 + \\rho_i}{4 \\pi \\sigma_0}} \\right)\n",
+    "\\end{align} $"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from numpy import pi as pi\n",
+    "delta_t = 0.1 * min([a / U_r, rho_0 * a**2 / mu_0, a**1.5 * ((rho_0 + rho_i) / (4 * pi * sigma_0))**0.5])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Parameter set"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "initial droplet radius:\n",
+      "a = : 0.048\n",
+      "\n",
+      "time scale:\n",
+      "t_r     = : 1.2\n",
+      "delta_t = : 0.05352329529308249\n",
+      "\n",
+      "temperature gradient:\n",
+      "∇T = 10\n",
+      "\n",
+      "surface tension:\n",
+      "sigma_0 = 0.023040368645898333\n",
+      "sigma_T = 0.002\n",
+      "\n",
+      "surrounding material properties\n",
+      "mu_0  = 0.024\n",
+      "rho_0 = 500\n",
+      "cp_0  = 0.0001\n",
+      "k_0   = 2.4e-06\n",
+      "\n",
+      "droplet material properties\n",
+      "mu_i  = 0.012\n",
+      "rho_i = 250.0\n",
+      "cp_i  = 5e-05\n",
+      "k_i   = 1.2e-06\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(\"initial droplet radius:\")\n",
+    "print(\"a = : {:}\".format(a))\n",
+    "print(\"\")\n",
+    "print(\"time scale:\")\n",
+    "print(\"t_r     = : {:}\".format(t_r))\n",
+    "print(\"delta_t = : {:}\".format(delta_t))\n",
+    "print(\"\")\n",
+    "print(\"temperature gradient:\")\n",
+    "print(\"∇T = {:}\".format(grad_T))\n",
+    "print(\"\")\n",
+    "print(\"surface tension:\")\n",
+    "print(\"sigma_0 = {:}\".format(sigma_0))\n",
+    "print(\"sigma_T = {:}\".format(sigma_T))\n",
+    "print(\"\")\n",
+    "print(\"surrounding material properties\")\n",
+    "print(\"mu_0  = {:}\".format(mu_0))\n",
+    "print(\"rho_0 = {:}\".format(rho_0))\n",
+    "print(\"cp_0  = {:}\".format(cp_0))\n",
+    "print(\"k_0   = {:}\".format(k_0))\n",
+    "print(\"\")\n",
+    "print(\"droplet material properties\")\n",
+    "print(\"mu_i  = {:}\".format(mu_i))\n",
+    "print(\"rho_i = {:}\".format(rho_i))\n",
+    "print(\"cp_i  = {:}\".format(cp_i))\n",
+    "print(\"k_i   = {:}\".format(k_i))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### References\n",
+    "\n",
+    "[1] Nas, S., & Tryggvason, G. (2003). Thermocapillary interaction of two bubbles or drops. International Journal of Multiphase Flow, 29(7), 1117–1135. https://doi.org/10.1016/S0301-9322(03)00084-3\n",
+    "\n",
+    "[2] Balcázar, N., Rigola, J., Castro, J., & Oliva, A. (2016). A level-set model for thermocapillary motion of deformable fluid particles. International Journal of Heat and Fluid Flow, 62, 324–343. https://doi.org/10.1016/j.ijheatfluidflow.2016.09.015"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.1"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
This PR add a jupyter notebook for determining the concrete parameters from the dimensionless problem definition of the two thermo-capillary droplets simulation. For some parameters one must still choose arbitrary values.
Fyi @mschreter 