### PR TITLE
Fix AMGReduced

### DIFF
--- a/include/meltpooldg/heat/heat_transfer_operation.hpp
+++ b/include/meltpooldg/heat/heat_transfer_operation.hpp
@@ -166,7 +166,7 @@ namespace MeltPoolDG::Heat
 
             auto preconditioner =
               LinearSolve::setup_preconditioner(heat_transfer_preconditioner.get_system_matrix(),
-                                                heat_data.solver.preconditioner_type);
+                                                "AMG");
 
             return LinearSolve::solve<VectorType, SolverGMRES<VectorType>, OperatorBase<double>>(
               *heat_operator,

--- a/include/meltpooldg/heat/heat_transfer_operation.hpp
+++ b/include/meltpooldg/heat/heat_transfer_operation.hpp
@@ -159,14 +159,18 @@ namespace MeltPoolDG::Heat
               preconditioner);
           }
         else if (heat_data.solver.preconditioner_type == "AMG" ||
-                 heat_data.solver.preconditioner_type == "AMGReduced")
+                 heat_data.solver.preconditioner_type == "AMGReduced" ||
+                 heat_data.solver.preconditioner_type == "ILU" ||
+                 heat_data.solver.preconditioner_type == "ILUReduced")
           {
             heat_operator->compute_system_matrix(heat_transfer_preconditioner.get_system_matrix(),
-                                                 heat_data.solver.preconditioner_type == "AMG");
+                                                 heat_data.solver.preconditioner_type == "AMG" ||
+                                                   heat_data.solver.preconditioner_type == "ILU");
 
+            // take the first three letters as relevant preconditioner type
             auto preconditioner =
               LinearSolve::setup_preconditioner(heat_transfer_preconditioner.get_system_matrix(),
-                                                "AMG");
+                                                heat_data.solver.preconditioner_type.substr(0, 3));
 
             return LinearSolve::solve<VectorType, SolverGMRES<VectorType>, OperatorBase<double>>(
               *heat_operator,

--- a/include/meltpooldg/heat/heat_transfer_operation.hpp
+++ b/include/meltpooldg/heat/heat_transfer_operation.hpp
@@ -162,14 +162,16 @@ namespace MeltPoolDG::Heat
                  heat_data.solver.preconditioner_type == "ILU" ||
                  heat_data.solver.preconditioner_type == "ILUReduced")
           {
+            const std::string precondition_base_type =
+              heat_data.solver.preconditioner_type.find("AMG") != std::string::npos ? "AMG" : "ILU";
             heat_operator->compute_system_matrix(heat_transfer_preconditioner.get_system_matrix(),
-                                                 heat_data.solver.preconditioner_type == "AMG" ||
-                                                   heat_data.solver.preconditioner_type == "ILU");
+                                                 heat_data.solver.preconditioner_type ==
+                                                   precondition_base_type);
 
             // take the first three letters as relevant preconditioner type
             auto preconditioner =
               LinearSolve::setup_preconditioner(heat_transfer_preconditioner.get_system_matrix(),
-                                                heat_data.solver.preconditioner_type.substr(0, 3));
+                                                precondition_base_type);
 
             return LinearSolve::solve<VectorType, SolverGMRES<VectorType>, OperatorBase<double>>(
               *heat_operator,

--- a/include/meltpooldg/heat/heat_transfer_operation.hpp
+++ b/include/meltpooldg/heat/heat_transfer_operation.hpp
@@ -99,8 +99,6 @@ namespace MeltPoolDG::Heat
     {
       reinit();
 
-      heat_transfer_preconditioner.reinit();
-
       dealii::VectorTools::project(scratch_data.get_mapping(),
                                    scratch_data.get_dof_handler(temp_dof_idx),
                                    scratch_data.get_constraint(temp_dof_idx),
@@ -116,6 +114,7 @@ namespace MeltPoolDG::Heat
       scratch_data.initialize_dof_vector(temperature, temp_dof_idx);
       scratch_data.initialize_dof_vector(temperature_old, temp_dof_idx);
       scratch_data.initialize_dof_vector(heat_source, temp_dof_idx);
+      heat_transfer_preconditioner.reinit();
     }
 
     void

--- a/include/meltpooldg/interface/parameters.hpp
+++ b/include/meltpooldg/interface/parameters.hpp
@@ -782,7 +782,8 @@ namespace MeltPoolDG
         prm.add_parameter("heat solver preconditioner type",
                           heat.solver.preconditioner_type,
                           "Set this parameter for choosing a preconditioner type",
-                          Patterns::Selection("Identity|AMG|AMGReduced|Diagonal|DiagonalReduced"));
+                          Patterns::Selection(
+                            "Identity|AMG|AMGReduced|ILU|ILUReduced|Diagonal|DiagonalReduced"));
         prm.add_parameter(
           "heat solver max iterations",
           heat.solver.max_iterations,


### PR DESCRIPTION
... only a "minifix". I'll merge once CI is happy. @nmuch FYI: `AMGReduced` should now work without the exception. ~~However, I got into troubles when using `AMG` or `AMGReduced` together with AMR. I obtain the following stacktrace:~~

```bash
Stacktrace:
-----------
#0  /home/magdalena/TUM/build-deal/lib/libdeal_II.g.so.9.3.0-pre: dealii::TrilinosWrappers::SparseMatrix::add(unsigned int, unsigned int, unsigned int const*, double const*, bool, bool)
#1  /home/magdalena/TUM/build-deal/lib/libdeal_II.g.so.9.3.0-pre: void dealii::AffineConstraints<double>::distribute_local_to_global<dealii::TrilinosWrappers::SparseMatrix, dealii::Vector<double> >(dealii::FullMatrix<double> const&, dealii::Vector<double> const&, std::vector<unsigned int, std::allocator<unsigned int> > const&, dealii::TrilinosWrappers::SparseMatrix&, dealii::Vector<double>&, bool, std::integral_constant<bool, false>) const
#2  meltpooldg: void dealii::AffineConstraints<double>::distribute_local_to_global<dealii::TrilinosWrappers::SparseMatrix>(dealii::FullMatrix<double> const&, std::vector<unsigned int, std::allocator<unsigned int> > const&, dealii::TrilinosWrappers::SparseMatrix&) const
#3  meltpooldg: MeltPoolDG::Heat::HeatTransferOperator<2, double>::compute_system_matrix(dealii::TrilinosWrappers::SparseMatrix&, bool) const
#4  meltpooldg: MeltPoolDG::Heat::HeatTransferOperation<2>::solve(double)::{lambda(dealii::LinearAlgebra::distributed::Vector<double, dealii::MemorySpace::Host>&, dealii::LinearAlgebra::distributed::Vector<double, dealii::MemorySpace::Host> const&)#2}::operator()(dealii::LinearAlgebra::distributed::Vector<double, dealii::MemorySpace::Host>&, dealii::LinearAlgebra::distributed::Vector<double, dealii::MemorySpace::Host> const&) const
#5  meltpooldg: int std::__invoke_impl<int, MeltPoolDG::Heat::HeatTransferOperation<2>::solve(double)::{lambda(dealii::LinearAlgebra::distributed::Vector<double, dealii::MemorySpace::Host>&, dealii::LinearAlgebra::distributed::Vector<double, dealii::MemorySpace::Host> const&)#2}&, dealii::LinearAlgebra::distributed::Vector<double, dealii::MemorySpace::Host>&, dealii::LinearAlgebra::distributed::Vector<double, dealii::MemorySpace::Host> const&>(std::__invoke_other, MeltPoolDG::Heat::HeatTransferOperation<2>::solve(double)::{lambda(dealii::LinearAlgebra::distributed::Vector<double, dealii::MemorySpace::Host>&, dealii::LinearAlgebra::distributed::Vector<double, dealii::MemorySpace::Host> const&)#2}&, dealii::LinearAlgebra::distributed::Vector<double, dealii::MemorySpace::Host>&, dealii::LinearAlgebra::distributed::Vector<double, dealii::MemorySpace::Host> const&)
#6  meltpooldg: std::enable_if<is_invocable_r_v<int, MeltPoolDG::Heat::HeatTransferOperation<2>::solve(double)::{lambda(dealii::LinearAlgebra::distributed::Vector<double, dealii::MemorySpace::Host>&, dealii::LinearAlgebra::distributed::Vector<double, dealii::MemorySpace::Host> const&)#2}&, dealii::LinearAlgebra::distributed::Vector<double, dealii::MemorySpace::Host>&, dealii::LinearAlgebra::distributed::Vector<double, dealii::MemorySpace::Host> const&>, std::enable_if>::type std::__invoke_r<int, MeltPoolDG::Heat::HeatTransferOperation<2>::solve(double)::{lambda(dealii::LinearAlgebra::distributed::Vector<double, dealii::MemorySpace::Host>&, dealii::LinearAlgebra::distributed::Vector<double, dealii::MemorySpace::Host> const&)#2}&, dealii::LinearAlgebra::distributed::Vector<double, dealii::MemorySpace::Host>&, dealii::LinearAlgebra::distributed::Vector<double, dealii::MemorySpace::Host> const&>(int&&, (MeltPoolDG::Heat::HeatTransferOperation<2>::solve(double)::{lambda(dealii::LinearAlgebra::distributed::Vector<double, dealii::MemorySpace::Host>&, dealii
--------------------------------------------------------
An error occurred in line <1692> of file </home/magdalena/TUM/dealii/source/lac/trilinos_sparse_matrix.cc> in function
    void dealii::TrilinosWrappers::SparseMatrix::add(dealii::TrilinosWrappers::SparseMatrix::size_type, dealii::TrilinosWrappers::SparseMatrix::size_type, const size_type*, const TrilinosScalar*, bool, bool)
The violated condition was: 
    nonlocal_matrix->RowMap().LID( static_cast<TrilinosWrappers::types::int_type>(row)) != -1
Additional information: 
    Attempted to write into off-processor matrix row that has not be
    specified as being writable upon initialization
```

~~Dear @peterrum: Do you have any suspisions on that?~~