### PR TITLE
Do not use DataOut::attach_dof_handler()

### DIFF
--- a/include/meltpooldg/advection_diffusion/advection_diffusion_adaflo_wrapper.hpp
+++ b/include/meltpooldg/advection_diffusion/advection_diffusion_adaflo_wrapper.hpp
@@ -187,8 +187,9 @@ namespace MeltPoolDG
       attach_output_vectors(DataOut<dim> &data_out) const
       {
         advected_field.update_ghost_values();
-        data_out.attach_dof_handler(scratch_data.get_dof_handler(adaflo_params.dof_index_ls));
-        data_out.add_data_vector(advected_field, "advected_field");
+        data_out.add_data_vector(scratch_data.get_dof_handler(adaflo_params.dof_index_ls),
+                                 advected_field,
+                                 "advected_field");
       }
 
       const LinearAlgebra::distributed::Vector<double> &

--- a/include/meltpooldg/advection_diffusion/advection_diffusion_operation.hpp
+++ b/include/meltpooldg/advection_diffusion/advection_diffusion_operation.hpp
@@ -191,8 +191,9 @@ namespace MeltPoolDG
       attach_output_vectors(DataOut<dim> &data_out) const
       {
         solution_advected_field.update_ghost_values();
-        data_out.attach_dof_handler(scratch_data->get_dof_handler(advec_diff_dof_idx));
-        data_out.add_data_vector(solution_advected_field, "advected_field");
+        data_out.add_data_vector(scratch_data->get_dof_handler(advec_diff_dof_idx),
+                                 solution_advected_field,
+                                 "advected_field");
       }
 
     private:

--- a/include/meltpooldg/level_set/level_set_operation.hpp
+++ b/include/meltpooldg/level_set/level_set_operation.hpp
@@ -391,26 +391,35 @@ namespace MeltPoolDG
         /*
          *  output advected field
          */
-        data_out.attach_dof_handler(scratch_data->get_dof_handler(ls_dof_idx));
-        data_out.add_data_vector(get_level_set(), "level_set");
+        data_out.add_data_vector(scratch_data->get_dof_handler(ls_dof_idx),
+                                 get_level_set(),
+                                 "level_set");
 
         /*
          *  output normal vector field
          */
         for (unsigned int d = 0; d < dim; ++d)
-          data_out.add_data_vector(get_normal_vector().block(d), "normal_" + std::to_string(d));
+          data_out.add_data_vector(scratch_data->get_dof_handler(ls_dof_idx),
+                                   get_normal_vector().block(d),
+                                   "normal_" + std::to_string(d));
         /*
          *  output curvature
          */
-        data_out.add_data_vector(get_curvature(), "curvature");
+        data_out.add_data_vector(scratch_data->get_dof_handler(ls_dof_idx),
+                                 get_curvature(),
+                                 "curvature");
         /*
          *  output heaviside
          */
-        data_out.add_data_vector(level_set_as_heaviside, "heaviside");
+        data_out.add_data_vector(scratch_data->get_dof_handler(ls_dof_idx),
+                                 level_set_as_heaviside,
+                                 "heaviside");
         /*
          *  output distance function
          */
-        data_out.add_data_vector(distance_to_level_set, "distance");
+        data_out.add_data_vector(scratch_data->get_dof_handler(ls_dof_idx),
+                                 distance_to_level_set,
+                                 "distance");
       }
       void
       do_reinitialization()

--- a/include/meltpooldg/reinitialization/reinitialization_operation.hpp
+++ b/include/meltpooldg/reinitialization/reinitialization_operation.hpp
@@ -277,13 +277,16 @@ namespace MeltPoolDG
       attach_output_vectors(DataOut<dim> &data_out) const
       {
         solution_level_set.update_ghost_values();
-        data_out.attach_dof_handler(scratch_data->get_dof_handler(reinit_dof_idx));
-        data_out.add_data_vector(get_level_set(), "psi");
+        data_out.add_data_vector(scratch_data->get_dof_handler(reinit_dof_idx),
+                                 get_level_set(),
+                                 "psi");
 
         //@todo: attach_output_vectors from normal_vector_operation
         get_normal_vector().update_ghost_values();
         for (unsigned int d = 0; d < dim; ++d)
-          data_out.add_data_vector(get_normal_vector().block(d), "normal_" + std::to_string(d));
+          data_out.add_data_vector(scratch_data->get_dof_handler(reinit_dof_idx),
+                                   get_normal_vector().block(d),
+                                   "normal_" + std::to_string(d));
       }
 
 

--- a/include/meltpooldg/reinitialization/reinitialization_operation_adaflo_wrapper.hpp
+++ b/include/meltpooldg/reinitialization/reinitialization_operation_adaflo_wrapper.hpp
@@ -190,14 +190,16 @@ namespace MeltPoolDG
       attach_output_vectors(DataOut<dim> &data_out) const
       {
         get_level_set().update_ghost_values();
-        data_out.attach_dof_handler(
-          scratch_data.get_dof_handler(reinit_params_adaflo.dof_index_ls));
-        data_out.add_data_vector(get_level_set(), "psi");
+        data_out.add_data_vector(scratch_data.get_dof_handler(reinit_params_adaflo.dof_index_ls),
+                                 get_level_set(),
+                                 "psi");
 
         //@todo: attach_output_vectors from normal_vector_operation
         get_normal_vector().update_ghost_values();
         for (unsigned int d = 0; d < dim; ++d)
-          data_out.add_data_vector(get_normal_vector().block(d), "normal_" + std::to_string(d));
+          data_out.add_data_vector(scratch_data.get_dof_handler(reinit_params_adaflo.dof_index_ls),
+                                   get_normal_vector().block(d),
+                                   "normal_" + std::to_string(d));
       }
 
       void


### PR DESCRIPTION
... as a preparation of #152. In a follow-up PR, I would like to remove the direct usage of `DataOut`.