### PR TITLE
Introduce alias GenericDataOut

### DIFF
--- a/include/meltpooldg/advection_diffusion/advection_diffusion_adaflo_wrapper.hpp
+++ b/include/meltpooldg/advection_diffusion/advection_diffusion_adaflo_wrapper.hpp
@@ -184,7 +184,7 @@ namespace MeltPoolDG
       }
 
       void
-      attach_output_vectors(DataOut<dim> &data_out) const
+      attach_output_vectors(GenericDataOut<dim> &data_out) const
       {
         advected_field.update_ghost_values();
         data_out.add_data_vector(scratch_data.get_dof_handler(adaflo_params.dof_index_ls),

--- a/include/meltpooldg/advection_diffusion/advection_diffusion_operation.hpp
+++ b/include/meltpooldg/advection_diffusion/advection_diffusion_operation.hpp
@@ -188,7 +188,7 @@ namespace MeltPoolDG
       }
 
       void
-      attach_output_vectors(DataOut<dim> &data_out) const
+      attach_output_vectors(GenericDataOut<dim> &data_out) const
       {
         solution_advected_field.update_ghost_values();
         data_out.add_data_vector(scratch_data->get_dof_handler(advec_diff_dof_idx),

--- a/include/meltpooldg/advection_diffusion/advection_diffusion_operation_base.hpp
+++ b/include/meltpooldg/advection_diffusion/advection_diffusion_operation_base.hpp
@@ -72,7 +72,7 @@ namespace MeltPoolDG
       attach_vectors(std::vector<LinearAlgebra::distributed::Vector<double> *> &vectors) = 0;
 
       virtual void
-      attach_output_vectors(DataOut<dim> &data_out) const = 0;
+      attach_output_vectors(GenericDataOut<dim> &data_out) const = 0;
     };
 
   } // namespace AdvectionDiffusion

--- a/include/meltpooldg/advection_diffusion/advection_diffusion_problem.hpp
+++ b/include/meltpooldg/advection_diffusion/advection_diffusion_problem.hpp
@@ -319,7 +319,7 @@ namespace MeltPoolDG
       void
       output_results(const unsigned int time_step, const double current_time)
       {
-        const auto attach_output_vectors = [&](DataOut<dim> &data_out) {
+        const auto attach_output_vectors = [&](GenericDataOut<dim> &data_out) {
           advec_diff_operation->attach_output_vectors(data_out);
 
           std::vector<DataComponentInterpretation::DataComponentInterpretation>

--- a/include/meltpooldg/evaporation/evaporation_operation.hpp
+++ b/include/meltpooldg/evaporation/evaporation_operation.hpp
@@ -509,7 +509,7 @@ namespace MeltPoolDG::Evaporation
     }
 
     void
-    attach_output_vectors(DataOut<dim> &data_out) const
+    attach_output_vectors(GenericDataOut<dim> &data_out) const
     {
       /*
        *  evaporation velocity

--- a/include/meltpooldg/flow/adaflo_wrapper.hpp
+++ b/include/meltpooldg/flow/adaflo_wrapper.hpp
@@ -338,7 +338,7 @@ namespace MeltPoolDG::Flow
     }
 
     void
-    attach_output_vectors(DataOut<dim> &data_out)
+    attach_output_vectors(GenericDataOut<dim> &data_out)
     {
       MeltPoolDG::VectorTools::update_ghost_values(get_velocity(),
                                                    get_pressure(),

--- a/include/meltpooldg/flow/flow_base.hpp
+++ b/include/meltpooldg/flow/flow_base.hpp
@@ -107,7 +107,7 @@ namespace MeltPoolDG
       distribute_constraints() = 0;
 
       virtual void
-      attach_output_vectors(DataOut<dim> &data_out) = 0;
+      attach_output_vectors(GenericDataOut<dim> &data_out) = 0;
     };
 
   } // namespace Flow

--- a/include/meltpooldg/flow/two_phase_flow_problem.hpp
+++ b/include/meltpooldg/flow/two_phase_flow_problem.hpp
@@ -826,7 +826,7 @@ namespace MeltPoolDG::Flow
       /**
        * collect all relevant output data
        */
-      const auto attach_output_vectors = [&](DataOut<dim> &data_out) {
+      const auto attach_output_vectors = [&](GenericDataOut<dim> &data_out) {
         level_set_operation.attach_output_vectors(data_out);
 
         flow_operation->attach_output_vectors(data_out);

--- a/include/meltpooldg/heat/heat_transfer_operation.hpp
+++ b/include/meltpooldg/heat/heat_transfer_operation.hpp
@@ -232,7 +232,7 @@ namespace MeltPoolDG::Heat
     }
 
     void
-    attach_output_vectors(DataOut<dim> &data_out) const
+    attach_output_vectors(GenericDataOut<dim> &data_out) const
     {
       MeltPoolDG::VectorTools::update_ghost_values(temperature, temperature_old, heat_source);
       if (velocity)

--- a/include/meltpooldg/heat/heat_transfer_problem.hpp
+++ b/include/meltpooldg/heat/heat_transfer_problem.hpp
@@ -324,7 +324,7 @@ namespace MeltPoolDG::Heat
       /**
        * collect all relevant output data
        */
-      const auto attach_output_vectors = [&](DataOut<dim> &data_out) {
+      const auto attach_output_vectors = [&](GenericDataOut<dim> &data_out) {
         heat_operation->attach_output_vectors(data_out);
       };
       /**

--- a/include/meltpooldg/interface/scratch_data.hpp
+++ b/include/meltpooldg/interface/scratch_data.hpp
@@ -24,6 +24,7 @@
 
 #include <meltpooldg/utilities/conditional_ostream.hpp>
 #include <meltpooldg/utilities/fe_integrator.hpp>
+#include <meltpooldg/utilities/postprocessor.hpp> // TODO[PM]: find a better place to include?
 #include <meltpooldg/utilities/utilityfunctions.hpp>
 
 

--- a/include/meltpooldg/level_set/level_set_operation.hpp
+++ b/include/meltpooldg/level_set/level_set_operation.hpp
@@ -381,7 +381,7 @@ namespace MeltPoolDG
       }
 
       void
-      attach_output_vectors(DataOut<dim> &data_out) const
+      attach_output_vectors(GenericDataOut<dim> &data_out) const
       {
         MeltPoolDG::VectorTools::update_ghost_values(get_level_set(),
                                                      get_curvature(),

--- a/include/meltpooldg/level_set/level_set_problem.hpp
+++ b/include/meltpooldg/level_set/level_set_problem.hpp
@@ -350,7 +350,7 @@ namespace MeltPoolDG
       void
       output_results(const unsigned int time_step, const double time) const
       {
-        const auto attach_output_vectors = [&](DataOut<dim> &data_out) {
+        const auto attach_output_vectors = [&](GenericDataOut<dim> &data_out) {
           level_set_operation.attach_output_vectors(data_out);
           if (evaporation_operation)
             evaporation_operation->attach_output_vectors(data_out);

--- a/include/meltpooldg/melt_pool/melt_pool_operation.hpp
+++ b/include/meltpooldg/melt_pool/melt_pool_operation.hpp
@@ -252,7 +252,7 @@ namespace MeltPoolDG
       }
 
       void
-      attach_output_vectors(DataOut<dim> &data_out) const
+      attach_output_vectors(GenericDataOut<dim> &data_out) const
       {
         heat_operation->attach_output_vectors(data_out);
         MeltPoolDG::VectorTools::update_ghost_values(solid, liquid);

--- a/include/meltpooldg/reinitialization/reinitialization_operation.hpp
+++ b/include/meltpooldg/reinitialization/reinitialization_operation.hpp
@@ -274,7 +274,7 @@ namespace MeltPoolDG
       }
 
       void
-      attach_output_vectors(DataOut<dim> &data_out) const
+      attach_output_vectors(GenericDataOut<dim> &data_out) const
       {
         solution_level_set.update_ghost_values();
         data_out.add_data_vector(scratch_data->get_dof_handler(reinit_dof_idx),

--- a/include/meltpooldg/reinitialization/reinitialization_operation_adaflo_wrapper.hpp
+++ b/include/meltpooldg/reinitialization/reinitialization_operation_adaflo_wrapper.hpp
@@ -187,7 +187,7 @@ namespace MeltPoolDG
       }
 
       void
-      attach_output_vectors(DataOut<dim> &data_out) const
+      attach_output_vectors(GenericDataOut<dim> &data_out) const
       {
         get_level_set().update_ghost_values();
         data_out.add_data_vector(scratch_data.get_dof_handler(reinit_params_adaflo.dof_index_ls),

--- a/include/meltpooldg/reinitialization/reinitialization_operation_base.hpp
+++ b/include/meltpooldg/reinitialization/reinitialization_operation_base.hpp
@@ -63,7 +63,7 @@ namespace MeltPoolDG
       attach_vectors(std::vector<LinearAlgebra::distributed::Vector<double> *> &vectors) = 0;
 
       virtual void
-      attach_output_vectors(DataOut<dim> &data_out) const = 0;
+      attach_output_vectors(GenericDataOut<dim> &data_out) const = 0;
     };
 
   } // namespace Reinitialization

--- a/include/meltpooldg/reinitialization/reinitialization_problem.hpp
+++ b/include/meltpooldg/reinitialization/reinitialization_problem.hpp
@@ -305,7 +305,7 @@ namespace MeltPoolDG
       {
         post_processor->process(
           time_step,
-          [&](DataOut<dim> &data_out) { reinit_operation->attach_output_vectors(data_out); },
+          [&](GenericDataOut<dim> &data_out) { reinit_operation->attach_output_vectors(data_out); },
           time);
       }
 

--- a/include/meltpooldg/utilities/postprocessor.hpp
+++ b/include/meltpooldg/utilities/postprocessor.hpp
@@ -11,6 +11,8 @@
 #include <deal.II/base/conditional_ostream.h>
 #include <deal.II/base/table_handler.h>
 
+#include <meltpooldg/utilities/utilityfunctions.hpp>
+
 #include <filesystem>
 
 using namespace dealii;
@@ -19,6 +21,9 @@ using namespace dealii;
 
 namespace MeltPoolDG
 {
+  template <int dim>
+  using GenericDataOut = DataOut<dim>; // TODO[PM]: create a new class
+
   template <int dim>
   class Postprocessor
   {
@@ -34,8 +39,6 @@ namespace MeltPoolDG
     const Triangulation<dim> &  triangulation;
     ConditionalOStream          pcout;
     bool                        do_simplex;
-
-    DataOut<dim> data_out;
 
     std::vector<std::pair<double, std::string>> times_and_names;
 
@@ -73,11 +76,13 @@ namespace MeltPoolDG
             const double                               time           = -1.0,
             const std::function<void()> &              post_operation = {})
     {
+      GenericDataOut<dim> data_out;
+
       if ((pv_data.do_output) && !(n_time_step % pv_data.write_frequency))
         {
           attach_output_vectors(data_out);
 
-          write_paraview_files(n_time_step, time);
+          write_paraview_files(n_time_step, time, data_out);
 
           if (pv_data.print_boundary_id)
             print_boundary_ids();
@@ -85,14 +90,16 @@ namespace MeltPoolDG
 
       if (post_operation)
         post_operation();
-
-      data_out.clear();
     }
 
   private:
     void
-    write_paraview_files(const unsigned int n_time_step, const double time)
+    write_paraview_files(const unsigned int   n_time_step,
+                         const double         time,
+                         GenericDataOut<dim> &data_out)
     {
+      // TODO[PM]: convert GenericDataOut to DatOut
+
       DataOutBase::VtkFlags flags;
       if ((do_simplex == false) && (dim > 1))
         flags.write_higher_order_cells = true;


### PR DESCRIPTION
This is how far as I was able to come till now. Since I will have time to continue the earliest in the late afternoon, I would suggest to merge and I will add the actual `GenericDataOut` implementation and the conversion function (`GenericDataOut` -> `DataOut`) then!

References #152.