### PR TITLE
Fix newton precision of converged step

### DIFF
--- a/include/meltpooldg/utilities/newton_raphson_solver.hpp
+++ b/include/meltpooldg/utilities/newton_raphson_solver.hpp
@@ -85,10 +85,14 @@ namespace MeltPoolDG
 
           if (is_converged())
             {
-              scratch_data.get_pcout() << "Newton Raphson solver converged: ||solution|| = "
-                                       << MeltPoolDG::VectorTools::compute_L2_norm<dim>(
-                                            solution, scratch_data, dof_idx, quad_idx)
-                                       << std::endl;
+              scratch_data.get_pcout()
+                << "Newton Raphson solver converged: ||solution|| = " << std::scientific
+                << std::setprecision(5)
+                << MeltPoolDG::VectorTools::compute_L2_norm<dim>(solution,
+                                                                 scratch_data,
+                                                                 dof_idx,
+                                                                 quad_idx)
+                << std::endl;
               return;
             }
 

--- a/tests/solidification_slab.output
+++ b/tests/solidification_slab.output
@@ -1,5 +1,5 @@
-t= 200       Newton Raphson solver converged: ||solution|| = 282.87
-t= 400       Newton Raphson solver converged: ||solution|| = 282.81
-t= 600       Newton Raphson solver converged: ||solution|| = 282.766
-t= 800       Newton Raphson solver converged: ||solution|| = 282.729
-t= 1000      Newton Raphson solver converged: ||solution|| = 282.697
+t= 200       Newton Raphson solver converged: ||solution|| = 2.82870e+02
+t= 400       Newton Raphson solver converged: ||solution|| = 2.82810e+02
+t= 600       Newton Raphson solver converged: ||solution|| = 2.82766e+02
+t= 800       Newton Raphson solver converged: ||solution|| = 2.82729e+02
+t= 1000      Newton Raphson solver converged: ||solution|| = 2.82697e+02

--- a/tests/tests_not_robust/film_boiling.with_adaflo_support=on.mpirun=4.output
+++ b/tests/tests_not_robust/film_boiling.with_adaflo_support=on.mpirun=4.output
@@ -25,9 +25,9 @@ t= 0.002      	 |n_0| = 0.26468524871    |n_1| = 6.2677992133
  	 |n_0| = 0.25357817574    |n_1| = 6.1325010151    
 |k| = 0.55597129646   
     | two phase flow: total mass = 1.1531413069
-Newton Raphson solver converged: ||solution|| = 39.354185802
-    | evaporation: jump in the velocity field = -0.00010425277702
-    | evapor: |m|2 = 1.032080264e-05
+Newton Raphson solver converged: ||solution|| = 3.93542e+01
+    | evaporation: jump in the velocity field = -0.00010425
+    | evapor: |m|2 = 1.0321e-05
 
 Time step #1, advancing from t_n-1 = 0 to t = 0.002 (dt = 0.002). 
  |velocity| = 0.000108420671686267
@@ -47,9 +47,9 @@ t= 0.004      	 |n_0| = 0.25357817574    |n_1| = 6.1325010151
  	 |n_0| = 0.25145222837    |n_1| = 6.094563202     
 |k| = 0.55670042759   
     | two phase flow: total mass = 1.1530754661
-Newton Raphson solver converged: ||solution|| = 39.353265653
-    | evaporation: jump in the velocity field = -7.334601203e-05
-    | evapor: |m|2 = 6.2932118752e-06
+Newton Raphson solver converged: ||solution|| = 3.93533e+01
+    | evaporation: jump in the velocity field = -7.3346e-05
+    | evapor: |m|2 = 6.2932e-06
 
 Time step #2, advancing from t_n-1 = 0.002 to t = 0.004 (dt = 0.002). 
  |velocity| = 9.68293194909533e-05
@@ -69,9 +69,9 @@ t= 0.006      	 |n_0| = 0.25145222837    |n_1| = 6.094563202
  	 |n_0| = 0.25212230723    |n_1| = 6.0825834136    
 |k| = 0.55694388014   
     | two phase flow: total mass = 1.1530163183
-Newton Raphson solver converged: ||solution|| = 39.352842826
-    | evaporation: jump in the velocity field = -6.222579589e-05
-    | evapor: |m|2 = 5.0308890417e-06
+Newton Raphson solver converged: ||solution|| = 3.93528e+01
+    | evaporation: jump in the velocity field = -6.2226e-05
+    | evapor: |m|2 = 5.0309e-06
 
 Time step #3, advancing from t_n-1 = 0.004 to t = 0.006 (dt = 0.002). 
  |velocity| = 0.000109159211578868
@@ -91,9 +91,9 @@ t= 0.008      	 |n_0| = 0.25212230723    |n_1| = 6.0825834136
  	 |n_0| = 0.25403774727    |n_1| = 6.0785640409    
 |k| = 0.55718006701   
     | two phase flow: total mass = 1.152959578
-Newton Raphson solver converged: ||solution|| = 39.352665299
-    | evaporation: jump in the velocity field = -5.7413841355e-05
-    | evapor: |m|2 = 4.5200701267e-06
+Newton Raphson solver converged: ||solution|| = 3.93527e+01
+    | evaporation: jump in the velocity field = -5.7414e-05
+    | evapor: |m|2 = 4.5201e-06
 
 Time step #4, advancing from t_n-1 = 0.006 to t = 0.008 (dt = 0.002). 
  |velocity| = 0.000127054289307498
@@ -113,9 +113,9 @@ t= 0.01       	 |n_0| = 0.25403774727    |n_1| = 6.0785640409
  	 |n_0| = 0.25666717974    |n_1| = 6.0771185327    
 |k| = 0.55717702684   
     | two phase flow: total mass = 1.1529042401
-Newton Raphson solver converged: ||solution|| = 39.352607078
-    | evaporation: jump in the velocity field = -5.5409901197e-05
-    | evapor: |m|2 = 4.3033398728e-06
+Newton Raphson solver converged: ||solution|| = 3.93526e+01
+    | evaporation: jump in the velocity field = -5.541e-05
+    | evapor: |m|2 = 4.3033e-06
 
 Time step #5, advancing from t_n-1 = 0.008 to t = 0.01 (dt = 0.002). 
  |velocity| = 0.000145864395404481

--- a/tests/thermo_capillary_droplet.with_adaflo_support=on.mpirun=4.output
+++ b/tests/thermo_capillary_droplet.with_adaflo_support=on.mpirun=4.output
@@ -36,7 +36,7 @@ t= 0.0005    |vel|= 0
  |phi_update|² = 0.0054698484018445 |
  	 |n_0| = 5.3385972977     |n_1| = 5.3385975361    
 |k| = 26.554019451    
-Newton Raphson solver converged: ||solution|| = 1.6737188613
+Newton Raphson solver converged: ||solution|| = 1.67372e+00
 
 Time step #1, advancing from t_n-1 = 0 to t = 0.0005 (dt = 0.0005). 
  |velocity| = 1.15222352131666e-06
@@ -61,7 +61,7 @@ t= 0.001     |vel|= 0.0256101964724115
  |phi_update|² = 0.00546991382725577 |
  	 |n_0| = 5.3390864142     |n_1| = 5.339086533     
 |k| = 26.551239968    
-Newton Raphson solver converged: ||solution|| = 1.673718895
+Newton Raphson solver converged: ||solution|| = 1.67372e+00
 
 Time step #2, advancing from t_n-1 = 0.0005 to t = 0.001 (dt = 0.0005). 
  |velocity| = 2.06926571353387e-06
@@ -86,7 +86,7 @@ t= 0.0015    |vel|= 0.0459963892288176
  |phi_update|² = 0.00546992302406581 |
  	 |n_0| = 5.3391585407     |n_1| = 5.3391587752    
 |k| = 26.549769881    
-Newton Raphson solver converged: ||solution|| = 1.673718869
+Newton Raphson solver converged: ||solution|| = 1.67372e+00
 
 Time step #3, advancing from t_n-1 = 0.001 to t = 0.0015 (dt = 0.0005). 
  |velocity| = 2.79539134240706e-06
@@ -110,8 +110,8 @@ t= 0.002     |vel|= 0.0621412190961418
  |ΔΨ|² = 3.84543226951851e-08 |
  |phi_update|² = 0.00546992407180679 |
  	 |n_0| = 5.339169163      |n_1| = 5.3391697444    
-|k| = 26.551874646    
-Newton Raphson solver converged: ||solution|| = 1.6737188426
+|k| = 26.551874169    
+Newton Raphson solver converged: ||solution|| = 1.67372e+00
 
 Time step #4, advancing from t_n-1 = 0.0015 to t = 0.002 (dt = 0.0005). 
  |velocity| = 3.38931464020779e-06

--- a/tests/thermo_capillary_two_droplets.with_adaflo_support=on.mpirun=4.output
+++ b/tests/thermo_capillary_two_droplets.with_adaflo_support=on.mpirun=4.output
@@ -36,7 +36,7 @@ t= 0.05      |vel|= 0
  |phi_update|² = 0.516837796255391 |
  	 |n_0| = 3.5163228589     |n_1| = 3.583907893     
 |k| = 16.834780786    
-Newton Raphson solver converged: ||solution|| = 2.4079477077
+Newton Raphson solver converged: ||solution|| = 2.40795e+00
 
 Time step #1, advancing from t_n-1 = 0 to t = 0.05 (dt = 0.05). 
  |velocity| = 5.76821458593279e-05
@@ -61,7 +61,7 @@ t= 0.1       |vel|= 0.0115550114413756
  |phi_update|² = 0.516844928008607 |
  	 |n_0| = 3.5084957743     |n_1| = 3.5885707586    
 |k| = 16.849634461    
-Newton Raphson solver converged: ||solution|| = 2.407948988
+Newton Raphson solver converged: ||solution|| = 2.40795e+00
 
 Time step #2, advancing from t_n-1 = 0.05 to t = 0.1 (dt = 0.05). 
  |velocity| = 0.000111715969303408
@@ -86,7 +86,7 @@ t= 0.15      |vel|= 0.021645764467816
  |phi_update|² = 0.516850690304704 |
  	 |n_0| = 3.5011720869     |n_1| = 3.5930685336    
 |k| = 16.834826852    
-Newton Raphson solver converged: ||solution|| = 2.4079503088
+Newton Raphson solver converged: ||solution|| = 2.40795e+00
 
 Time step #3, advancing from t_n-1 = 0.1 to t = 0.15 (dt = 0.05). 
  |velocity| = 0.000163643463374861
@@ -111,7 +111,7 @@ t= 0.2       |vel|= 0.0307513394190348
  |phi_update|² = 0.51685605415596 |
  	 |n_0| = 3.4942442454     |n_1| = 3.5974260533    
 |k| = 16.832224875    
-Newton Raphson solver converged: ||solution|| = 2.407951625
+Newton Raphson solver converged: ||solution|| = 2.40795e+00
 
 Time step #4, advancing from t_n-1 = 0.15 to t = 0.2 (dt = 0.05). 
  |velocity| = 0.000214971179810887
@@ -136,7 +136,7 @@ t= 0.25      |vel|= 0.0394505871062324
  |phi_update|² = 0.51686136911622 |
  	 |n_0| = 3.4876083286     |n_1| = 3.6016554783    
 |k| = 16.802588942    
-Newton Raphson solver converged: ||solution|| = 2.4079529598
+Newton Raphson solver converged: ||solution|| = 2.40795e+00
 
 Time step #5, advancing from t_n-1 = 0.2 to t = 0.25 (dt = 0.05). 
  |velocity| = 0.000266087744152761

--- a/tests/unidirectional_heat_transfer.mpirun=4.output
+++ b/tests/unidirectional_heat_transfer.mpirun=4.output
@@ -1,5 +1,5 @@
-t= 0.0001    Newton Raphson solver converged: ||solution|| = 0.00564198
-t= 0.0002    Newton Raphson solver converged: ||solution|| = 0.00553556
-t= 0.0003    Newton Raphson solver converged: ||solution|| = 0.00544694
-t= 0.0004    Newton Raphson solver converged: ||solution|| = 0.00537273
-t= 0.0005    Newton Raphson solver converged: ||solution|| = 0.00531056
+t= 0.0001    Newton Raphson solver converged: ||solution|| = 5.64198e-03
+t= 0.0002    Newton Raphson solver converged: ||solution|| = 5.53556e-03
+t= 0.0003    Newton Raphson solver converged: ||solution|| = 5.44694e-03
+t= 0.0004    Newton Raphson solver converged: ||solution|| = 5.37273e-03
+t= 0.0005    Newton Raphson solver converged: ||solution|| = 5.31056e-03

--- a/tests/unidirectional_heat_transfer_with_convection.mpirun=4.output
+++ b/tests/unidirectional_heat_transfer_with_convection.mpirun=4.output
@@ -1,5 +1,5 @@
-t= 0.01      Newton Raphson solver converged: ||solution|| = 100
-t= 0.02      Newton Raphson solver converged: ||solution|| = 99.9999
-t= 0.03      Newton Raphson solver converged: ||solution|| = 99.9999
-t= 0.04      Newton Raphson solver converged: ||solution|| = 99.9998
-t= 0.05      Newton Raphson solver converged: ||solution|| = 99.9998
+t= 0.01      Newton Raphson solver converged: ||solution|| = 1.00000e+02
+t= 0.02      Newton Raphson solver converged: ||solution|| = 9.99999e+01
+t= 0.03      Newton Raphson solver converged: ||solution|| = 9.99999e+01
+t= 0.04      Newton Raphson solver converged: ||solution|| = 9.99998e+01
+t= 0.05      Newton Raphson solver converged: ||solution|| = 9.99998e+01

--- a/tests/unidirectional_heat_transfer_with_radiation.mpirun=4.output
+++ b/tests/unidirectional_heat_transfer_with_radiation.mpirun=4.output
@@ -1,5 +1,5 @@
-t= 0.01      Newton Raphson solver converged: ||solution|| = 99.9998
-t= 0.02      Newton Raphson solver converged: ||solution|| = 99.9997
-t= 0.03      Newton Raphson solver converged: ||solution|| = 99.9995
-t= 0.04      Newton Raphson solver converged: ||solution|| = 99.9994
-t= 0.05      Newton Raphson solver converged: ||solution|| = 99.9992
+t= 0.01      Newton Raphson solver converged: ||solution|| = 9.99998e+01
+t= 0.02      Newton Raphson solver converged: ||solution|| = 9.99997e+01
+t= 0.03      Newton Raphson solver converged: ||solution|| = 9.99995e+01
+t= 0.04      Newton Raphson solver converged: ||solution|| = 9.99994e+01
+t= 0.05      Newton Raphson solver converged: ||solution|| = 9.99992e+01

--- a/tests/unidirectional_heat_transfer_with_radiation_and_convection.mpirun=4.output
+++ b/tests/unidirectional_heat_transfer_with_radiation_and_convection.mpirun=4.output
@@ -1,5 +1,5 @@
-t= 0.01      Newton Raphson solver converged: ||solution|| = 99.9998
-t= 0.02      Newton Raphson solver converged: ||solution|| = 99.9996
-t= 0.03      Newton Raphson solver converged: ||solution|| = 99.9994
-t= 0.04      Newton Raphson solver converged: ||solution|| = 99.9992
-t= 0.05      Newton Raphson solver converged: ||solution|| = 99.999
+t= 0.01      Newton Raphson solver converged: ||solution|| = 9.99998e+01
+t= 0.02      Newton Raphson solver converged: ||solution|| = 9.99996e+01
+t= 0.03      Newton Raphson solver converged: ||solution|| = 9.99994e+01
+t= 0.04      Newton Raphson solver converged: ||solution|| = 9.99992e+01
+t= 0.05      Newton Raphson solver converged: ||solution|| = 9.99990e+01

--- a/tests/unidirectional_heat_transfer_with_radiation_and_convection_amr.mpirun=4.output
+++ b/tests/unidirectional_heat_transfer_with_radiation_and_convection_amr.mpirun=4.output
@@ -1,5 +1,5 @@
-t= 0.005     Newton Raphson solver converged: ||solution|| = 99.9999
-t= 0.01      Newton Raphson solver converged: ||solution|| = 99.9998
-t= 0.015     Newton Raphson solver converged: ||solution|| = 99.9997
-t= 0.02      Newton Raphson solver converged: ||solution|| = 99.9996
-t= 0.025     Newton Raphson solver converged: ||solution|| = 99.9995
+t= 0.005     Newton Raphson solver converged: ||solution|| = 9.99999e+01
+t= 0.01      Newton Raphson solver converged: ||solution|| = 9.99998e+01
+t= 0.015     Newton Raphson solver converged: ||solution|| = 9.99997e+01
+t= 0.02      Newton Raphson solver converged: ||solution|| = 9.99996e+01
+t= 0.025     Newton Raphson solver converged: ||solution|| = 9.99995e+01

--- a/tests/unidirectional_heat_transfer_with_two_phase.mpirun=4.output
+++ b/tests/unidirectional_heat_transfer_with_two_phase.mpirun=4.output
@@ -1,5 +1,5 @@
-t= 0.001     Newton Raphson solver converged: ||solution|| = 99.9999
-t= 0.002     Newton Raphson solver converged: ||solution|| = 99.9999
-t= 0.003     Newton Raphson solver converged: ||solution|| = 99.9998
-t= 0.004     Newton Raphson solver converged: ||solution|| = 99.9998
-t= 0.005     Newton Raphson solver converged: ||solution|| = 99.9997
+t= 0.001     Newton Raphson solver converged: ||solution|| = 9.99999e+01
+t= 0.002     Newton Raphson solver converged: ||solution|| = 9.99999e+01
+t= 0.003     Newton Raphson solver converged: ||solution|| = 9.99998e+01
+t= 0.004     Newton Raphson solver converged: ||solution|| = 9.99998e+01
+t= 0.005     Newton Raphson solver converged: ||solution|| = 9.99997e+01

--- a/tests/unidirectional_heat_transfer_with_velocity.mpirun=4.output
+++ b/tests/unidirectional_heat_transfer_with_velocity.mpirun=4.output
@@ -1,5 +1,5 @@
-t= 0.001     Newton Raphson solver converged: ||solution|| = 100
-t= 0.002     Newton Raphson solver converged: ||solution|| = 100
-t= 0.003     Newton Raphson solver converged: ||solution|| = 99.9999
-t= 0.004     Newton Raphson solver converged: ||solution|| = 99.9999
-t= 0.005     Newton Raphson solver converged: ||solution|| = 99.9999
+t= 0.001     Newton Raphson solver converged: ||solution|| = 1.00000e+02
+t= 0.002     Newton Raphson solver converged: ||solution|| = 1.00000e+02
+t= 0.003     Newton Raphson solver converged: ||solution|| = 9.99999e+01
+t= 0.004     Newton Raphson solver converged: ||solution|| = 9.99999e+01
+t= 0.005     Newton Raphson solver converged: ||solution|| = 9.99999e+01

--- a/tests/unidirectional_heat_transfer_with_velocity_and_solidification.output
+++ b/tests/unidirectional_heat_transfer_with_velocity_and_solidification.output
@@ -1,5 +1,5 @@
-t= 0.01      Newton Raphson solver converged: ||solution|| = 197.002
-t= 0.02      Newton Raphson solver converged: ||solution|| = 197.003
-t= 0.03      Newton Raphson solver converged: ||solution|| = 197.004
-t= 0.04      Newton Raphson solver converged: ||solution|| = 197.005
-t= 0.05      Newton Raphson solver converged: ||solution|| = 197.006
+t= 0.01      Newton Raphson solver converged: ||solution|| = 1.97002e+02
+t= 0.02      Newton Raphson solver converged: ||solution|| = 1.97003e+02
+t= 0.03      Newton Raphson solver converged: ||solution|| = 1.97004e+02
+t= 0.04      Newton Raphson solver converged: ||solution|| = 1.97005e+02
+t= 0.05      Newton Raphson solver converged: ||solution|| = 1.97006e+02


### PR DESCRIPTION
This PR sets a fixed number of decimal places for the converged Newton steps. @nmuch: please recreate the output of the `solidification_slab.json` in #162 based on this PR.