### PR TITLE
Remove template argument dim_q from ScratchData

### DIFF
--- a/include/meltpooldg/interface/scratch_data.hpp
+++ b/include/meltpooldg/interface/scratch_data.hpp
@@ -75,12 +75,11 @@ namespace MeltPoolDG
     /**
      * Setup everything in one go.
      */
-    template <int dim_q>
     void
     reinit(const Mapping<dim, spacedim> &                        mapping,
            const std::vector<const DoFHandler<dim, spacedim> *> &dof_handler,
            const std::vector<const AffineConstraints<number> *> &constraint,
-           const std::vector<Quadrature<dim_q>> &                quad)
+           const std::vector<Quadrature<dim>> &                  quad)
     {
       this->clear();
 


### PR DESCRIPTION
references https://github.com/MeltPoolDG/MeltPoolDG/issues/151#issuecomment-845679323

This is from the "old days" when `MatrixFree` only accepted 1D quadrature rules.