### PR TITLE
Draft for accessing result vectors

### DIFF
--- a/include/meltpooldg/advection_diffusion/advection_diffusion_problem.hpp
+++ b/include/meltpooldg/advection_diffusion/advection_diffusion_problem.hpp
@@ -57,7 +57,9 @@ namespace MeltPoolDG::AdvectionDiffusion
      *  perform output of results
      */
     void
-    output_results(unsigned int time_step, double current_time);
+    output_results(unsigned int                         time_step,
+                   double                               current_time,
+                   std::shared_ptr<SimulationBase<dim>> base_in);
 
     /*
      *  perform mesh refinement

--- a/include/meltpooldg/flow/two_phase_flow_problem.hpp
+++ b/include/meltpooldg/flow/two_phase_flow_problem.hpp
@@ -91,10 +91,12 @@ namespace MeltPoolDG::Flow
     compute_gravity_force(VectorType &vec, const double gravity, const bool zero_out = true) const;
 
     /*
-     *  This function is to create paraview output
+     *  perform output of results
      */
     void
-    output_results(const unsigned int n_time_step, const double current_time);
+    output_results(const unsigned int                   time_step,
+                   const double                         current_time,
+                   std::shared_ptr<SimulationBase<dim>> base_in);
     /*
      *  perform mesh refinement
      */

--- a/include/meltpooldg/heat/heat_transfer_problem.hpp
+++ b/include/meltpooldg/heat/heat_transfer_problem.hpp
@@ -75,11 +75,12 @@ namespace MeltPoolDG::Heat
     compute_field_vector(VectorType &vector, unsigned dof_idx, Function<dim> &field_function);
 
     /*
-     *  This function is to create paraview output
+     *  perform output of results
      */
     void
-    output_results(unsigned int n_time_step, double time);
-
+    output_results(unsigned int                         time_step,
+                   double                               current_time,
+                   std::shared_ptr<SimulationBase<dim>> base_in);
     /*
      *  perform adaptive mesh refinement
      */

--- a/include/meltpooldg/interface/scratch_data.hpp
+++ b/include/meltpooldg/interface/scratch_data.hpp
@@ -175,6 +175,9 @@ namespace MeltPoolDG
     const ConditionalOStream
     get_pcout(const unsigned int level = 0) const;
 
+    bool
+    is_hex_mesh(const unsigned int dof_idx = 0) const;
+
   private:
     bool                                                      do_matrix_free;
     std::vector<ConditionalOStream>                           pcout;

--- a/include/meltpooldg/interface/simulationbase.hpp
+++ b/include/meltpooldg/interface/simulationbase.hpp
@@ -10,6 +10,7 @@
 #include <meltpooldg/interface/fieldconditions.hpp>
 #include <meltpooldg/interface/parameters.hpp>
 #include <meltpooldg/interface/periodic_boundary_conditions.hpp>
+#include <meltpooldg/utilities/generic_data_out.hpp>
 // c++
 #include <memory>
 
@@ -60,6 +61,17 @@ namespace MeltPoolDG
           " this->triangulation = std::make_shared<parallel::distributed::Triangulation<dim>>(this->mpi_communicator); "));
       set_boundary_conditions();
       set_field_conditions();
+    }
+
+    /**
+     * This function may be overwritten for output purposes in your simulation case.
+     * It is called after every time step.
+     */
+    virtual void
+    do_postprocessing(const GenericDataOut<dim> &generic_data_out)
+    {
+      (void)generic_data_out;
+      // do nothing default
     }
 
     /**

--- a/include/meltpooldg/level_set/level_set_problem.hpp
+++ b/include/meltpooldg/level_set/level_set_problem.hpp
@@ -68,11 +68,12 @@ namespace MeltPoolDG::LevelSet
     void
     compute_advection_velocity(Function<dim> &advec_func);
     /*
-     *  This function is to create paraview output
+     *  perform output of results
      */
     void
-    output_results(const unsigned int time_step, const double time) const;
-
+    output_results(const unsigned int                   time_step,
+                   const double                         current_time,
+                   std::shared_ptr<SimulationBase<dim>> base_in);
     /*
      *  perform mesh refinement
      */

--- a/include/meltpooldg/reinitialization/reinitialization_problem.hpp
+++ b/include/meltpooldg/reinitialization/reinitialization_problem.hpp
@@ -87,10 +87,12 @@ namespace MeltPoolDG
       refine_mesh(std::shared_ptr<SimulationBase<dim>> base_in);
 
       /*
-       *  Creating paraview output
+       *  perform output of results
        */
       void
-      output_results(const unsigned int time_step, const double time) const;
+      output_results(const unsigned int                   time_step,
+                     const double                         current_time,
+                     std::shared_ptr<SimulationBase<dim>> base_in);
 
     private:
       DoFHandler<dim>           dof_handler;

--- a/include/meltpooldg/simulations/advection_diffusion/advection_diffusion_user_output.hpp
+++ b/include/meltpooldg/simulations/advection_diffusion/advection_diffusion_user_output.hpp
@@ -142,8 +142,9 @@ namespace MeltPoolDG::Simulation::AdvectionDiffusion
         for (const auto &name : std::get<2>(entry))
           {
             pcout << " * " << std::setw(20) << name << " Max-norm: " << std::setprecision(5)
-                  << std::setw(10) << std::get<1>(entry)->linfty_norm()
-                  << " number of dofs: " << std::get<0>(entry)->n_dofs() << std::endl;
+                  << std::setw(10) << generic_data_out.get_vector(name).linfty_norm()
+                  << " number of dofs: " << generic_data_out.get_dof_handler(name).n_dofs()
+                  << std::endl;
             break;
           }
       pcout << "---------------------------------------------" << std::endl;

--- a/include/meltpooldg/simulations/advection_diffusion/advection_diffusion_user_output.hpp
+++ b/include/meltpooldg/simulations/advection_diffusion/advection_diffusion_user_output.hpp
@@ -1,0 +1,158 @@
+#pragma once
+#include <deal.II/base/function.h>
+#include <deal.II/base/point.h>
+#include <deal.II/base/tensor_function.h>
+
+#include <deal.II/grid/grid_generator.h>
+
+#include <deal.II/lac/vector.h>
+
+#include <deal.II/numerics/vector_tools.h>
+
+#include <meltpooldg/interface/simulationbase.hpp>
+#include <meltpooldg/simulations/advection_diffusion/advection_diffusion.hpp>
+#include <meltpooldg/utilities/distance_functions.hpp>
+#include <meltpooldg/utilities/utilityfunctions.hpp>
+
+#include <cmath>
+#include <iostream>
+
+/*
+ * This is a simple simulation where the access to the output vectors in the Simulation
+ * class is shown.
+ */
+
+namespace MeltPoolDG::Simulation::AdvectionDiffusion
+{
+  using namespace dealii;
+
+  template <int dim>
+  class SimulationAdvectionDiffusionUserOutput : public SimulationBase<dim>
+  {
+  public:
+    SimulationAdvectionDiffusionUserOutput(std::string    parameter_file,
+                                           const MPI_Comm mpi_communicator)
+      : SimulationBase<dim>(parameter_file, mpi_communicator)
+    {
+      this->set_parameters();
+    }
+
+    void
+    create_spatial_discretization()
+    {
+      if (dim == 1 || this->parameters.base.do_simplex)
+        {
+          AssertDimension(Utilities::MPI::n_mpi_processes(this->mpi_communicator), 1);
+          this->triangulation = std::make_shared<Triangulation<dim>>();
+        }
+      else
+        {
+          this->triangulation =
+            std::make_shared<parallel::distributed::Triangulation<dim>>(this->mpi_communicator);
+        }
+
+      if (this->parameters.base.do_simplex)
+        {
+          GridGenerator::subdivided_hyper_cube_with_simplices(
+            *this->triangulation,
+            Utilities::pow(2, this->parameters.base.global_refinements),
+            left_domain,
+            right_domain);
+        }
+      else
+        {
+          GridGenerator::subdivided_hyper_cube(*this->triangulation, 2, left_domain, right_domain);
+          this->triangulation->refine_global(this->parameters.base.global_refinements - 1);
+        }
+    }
+
+    void
+    set_boundary_conditions() final
+    {
+      /*
+       *  create a pair of (boundary_id, dirichlet_function)
+       */
+      constexpr types::boundary_id inflow_bc  = 42;
+      constexpr types::boundary_id do_nothing = 0;
+
+      auto dirichlet = std::make_shared<DirichletCondition<dim>>();
+
+      this->attach_dirichlet_boundary_condition(inflow_bc, dirichlet, "advection_diffusion");
+
+      /*
+       *  mark inflow edges with boundary label (no boundary on outflow edges must be prescribed
+       *  due to the hyperbolic nature of the analyzed problem
+       *
+                  out    in
+      (-1,1)  +---------------+ (1,1)
+              |       :       |
+        in    |       :       | out
+              |_______________|
+              |       :       |
+        out   |       :       | in
+              |       :       |
+              +---------------+
+       * (-1,-1)  in     out   (1,-1)
+       */
+      if constexpr (dim == 2)
+        {
+          for (const auto &cell : this->triangulation->cell_iterators())
+            for (const auto &face : cell->face_iterators())
+              if ((face->at_boundary()))
+                {
+                  const double half_line = (right_domain + left_domain) / 2;
+
+                  if (face->center()[0] == left_domain && face->center()[1] > half_line)
+                    face->set_boundary_id(inflow_bc);
+                  else if (face->center()[0] == right_domain && face->center()[1] < half_line)
+                    face->set_boundary_id(inflow_bc);
+                  else if (face->center()[1] == right_domain && face->center()[0] > half_line)
+                    face->set_boundary_id(inflow_bc);
+                  else if (face->center()[1] == left_domain && face->center()[0] < half_line)
+                    face->set_boundary_id(inflow_bc);
+                  else
+                    face->set_boundary_id(do_nothing);
+                }
+        }
+      else
+        {
+          (void)do_nothing; // suppress unused variable for 1D
+        }
+    }
+
+    void
+    set_field_conditions() final
+    {
+      this->attach_initial_condition(std::make_shared<InitializePhi<dim>>(), "advection_diffusion");
+      this->attach_advection_field(std::make_shared<AdvectionField<dim>>(), "advection_diffusion");
+    }
+
+    void
+    do_postprocessing(const GenericDataOut<dim> &generic_data_out) final
+    {
+      dealii::ConditionalOStream pcout(std::cout,
+                                       Utilities::MPI::this_mpi_process(this->mpi_communicator) ==
+                                         0);
+
+      pcout << "---------------------------------------------" << std::endl;
+      pcout << "    Starting user defined postprocessing" << std::endl;
+      pcout << "---------------------------------------------" << std::endl;
+      pcout << "Accessible vectors:" << std::endl;
+      for (const auto &entry : generic_data_out.entries)
+        for (const auto &name : std::get<2>(entry))
+          {
+            pcout << " * " << std::setw(20) << name << " Max-norm: " << std::setprecision(5)
+                  << std::setw(10) << std::get<1>(entry)->linfty_norm()
+                  << " number of dofs: " << std::get<0>(entry)->n_dofs() << std::endl;
+            break;
+          }
+      pcout << "---------------------------------------------" << std::endl;
+      pcout << "    End of user defined postprocessing" << std::endl;
+      pcout << "---------------------------------------------" << std::endl;
+    }
+
+  private:
+    const double left_domain  = -1.0;
+    const double right_domain = 1.0;
+  };
+} // namespace MeltPoolDG::Simulation::AdvectionDiffusion

--- a/include/meltpooldg/utilities/generic_data_out.hpp
+++ b/include/meltpooldg/utilities/generic_data_out.hpp
@@ -14,7 +14,7 @@ namespace MeltPoolDG
   public:
     using VectorType = LinearAlgebra::distributed::Vector<double>;
 
-    GenericDataOut() = default;
+    GenericDataOut(const Mapping<dim> &mapping, const double current_time = 0.0);
 
     void
     add_data_vector(const DoFHandler<dim> &         dof_handler,
@@ -34,5 +34,8 @@ namespace MeltPoolDG
                            const std::vector<std::string>,
                            std::vector<DataComponentInterpretation::DataComponentInterpretation>>>
       entries;
+
+    const Mapping<dim> &mapping;
+    double              current_time;
   };
 } // namespace MeltPoolDG

--- a/include/meltpooldg/utilities/generic_data_out.hpp
+++ b/include/meltpooldg/utilities/generic_data_out.hpp
@@ -4,6 +4,8 @@
 
 #include <deal.II/numerics/data_out.h>
 
+#include <string>
+
 using namespace dealii;
 
 namespace MeltPoolDG
@@ -35,7 +37,16 @@ namespace MeltPoolDG
                            std::vector<DataComponentInterpretation::DataComponentInterpretation>>>
       entries;
 
+    const VectorType &
+    get_vector(const std::string &name) const;
+
+    const DoFHandler<dim> &
+    get_dof_handler(const std::string &name) const;
+
     const Mapping<dim> &mapping;
     double              current_time;
+
+  private:
+    std::map<std::string, unsigned int> entry_id;
   };
 } // namespace MeltPoolDG

--- a/include/meltpooldg/utilities/utilityfunctions.hpp
+++ b/include/meltpooldg/utilities/utilityfunctions.hpp
@@ -50,6 +50,13 @@ namespace MeltPoolDG
       const std::function<const VectorizedArray<double> &(const unsigned int cell,
                                                           const unsigned int q)> &cell_operation)
     {
+      AssertThrow(matrix_free.get_dof_handler(dof_idx)
+                    .get_triangulation()
+                    .all_reference_cells_are_hyper_cube(),
+                  ExcMessage(
+                    "The filling of a DoF Vector from a cell operation is currently only supported "
+                    "for hex meshes."));
+
       FE_DGQArbitraryNodes<1> fe_coarse(QGauss<1>(n_q_points_1D).get_points());
       FE_Q<1>                 fe_fine(fe_degree);
 
@@ -67,9 +74,9 @@ namespace MeltPoolDG
       FECellIntegrator<dim, n_components, double> fe_eval(matrix_free, dof_idx, quad_idx);
 
       // @todo: replace n_q_points_1D argument completely from fe_eval?
-      // AssertThrow(fe_eval.n_q_points == std::pow(n_q_points_1D, dim),
-      // ExcMessage("The number of quadrature points in 1D must comply with the number of "
-      //"quadrature points of the cell operation."));
+      AssertThrow(fe_eval.n_q_points == std::pow(n_q_points_1D, dim),
+                  ExcMessage("The number of quadrature points in 1D must comply with the number of "
+                             "quadrature points of the cell operation."));
 
       for (unsigned int cell = 0; cell < matrix_free.n_cell_batches(); ++cell)
         {
@@ -116,6 +123,13 @@ namespace MeltPoolDG
         const unsigned int cell,
         const unsigned int q)> &                              cell_operation)
     {
+      AssertThrow(matrix_free.get_dof_handler(dof_idx)
+                    .get_triangulation()
+                    .all_reference_cells_are_hyper_cube(),
+                  ExcMessage(
+                    "The filling of a DoF Vector from a cell operation is currently only supported "
+                    "for hex meshes."));
+
       FE_DGQArbitraryNodes<1> fe_coarse(QGauss<1>(n_q_points_1D).get_points());
       FE_Q<1>                 fe_fine(fe_degree);
 

--- a/include/meltpooldg/utilities/utilityfunctions.hpp
+++ b/include/meltpooldg/utilities/utilityfunctions.hpp
@@ -67,9 +67,9 @@ namespace MeltPoolDG
       FECellIntegrator<dim, n_components, double> fe_eval(matrix_free, dof_idx, quad_idx);
 
       // @todo: replace n_q_points_1D argument completely from fe_eval?
-      AssertThrow(fe_eval.n_q_points == std::pow(n_q_points_1D, dim),
-                  ExcMessage("The number of quadrature points in 1D must comply with the number of "
-                             "quadrature points of the cell operation."));
+      // AssertThrow(fe_eval.n_q_points == std::pow(n_q_points_1D, dim),
+      // ExcMessage("The number of quadrature points in 1D must comply with the number of "
+      //"quadrature points of the cell operation."));
 
       for (unsigned int cell = 0; cell < matrix_free.n_cell_batches(); ++cell)
         {
@@ -360,8 +360,6 @@ namespace MeltPoolDG
         compare_and_apply_mask<SIMDComparison::greater_than>(in, lower_limit, 1.0, 0.0),
         0.0);
     }
-
-
 
     /**
      * Return the exponent to the power of ten of an expression like 5*10^5 --> return 5

--- a/source/advection_diffusion/advection_diffusion_problem.cpp
+++ b/source/advection_diffusion/advection_diffusion_problem.cpp
@@ -41,7 +41,8 @@ namespace MeltPoolDG::AdvectionDiffusion
          *  do paraview output if requested
          */
         output_results(time_iterator.get_current_time_step_number(),
-                       time_iterator.get_current_time());
+                       time_iterator.get_current_time(),
+                       base_in);
 
         if (base_in->parameters.amr.do_amr)
           {
@@ -272,8 +273,9 @@ namespace MeltPoolDG::AdvectionDiffusion
 
   template <int dim>
   void
-  AdvectionDiffusionProblem<dim>::output_results(const unsigned int time_step,
-                                                 const double       current_time)
+  AdvectionDiffusionProblem<dim>::output_results(const unsigned int                   time_step,
+                                                 const double                         current_time,
+                                                 std::shared_ptr<SimulationBase<dim>> base_in)
   {
     const auto attach_output_vectors = [&](GenericDataOut<dim> &data_out) {
       advec_diff_operation->attach_output_vectors(data_out);
@@ -287,6 +289,14 @@ namespace MeltPoolDG::AdvectionDiffusion
                                std::vector<std::string>(dim, "velocity"),
                                vector_component_interpretation);
     };
+
+    GenericDataOut<dim> generic_data_out;
+    attach_output_vectors(generic_data_out);
+
+    // user-defined postprocessing
+    base_in->do_postprocessing(generic_data_out);
+
+    // paraview postprocessing
     post_processor->process(time_step, attach_output_vectors, current_time);
   }
 

--- a/source/advection_diffusion/advection_diffusion_problem.cpp
+++ b/source/advection_diffusion/advection_diffusion_problem.cpp
@@ -290,7 +290,7 @@ namespace MeltPoolDG::AdvectionDiffusion
                                vector_component_interpretation);
     };
 
-    GenericDataOut<dim> generic_data_out;
+    GenericDataOut<dim> generic_data_out(scratch_data->get_mapping());
     attach_output_vectors(generic_data_out);
 
     // user-defined postprocessing

--- a/source/evaporation/evaporation_operation.cpp
+++ b/source/evaporation/evaporation_operation.cpp
@@ -307,17 +307,18 @@ namespace MeltPoolDG::Evaporation
     /**
      * write interface velocity to dof vector
      */
-    UtilityFunctions::fill_dof_vector_from_cell_operation_vec<dim, dim>(
-      evaporation_velocity,
-      scratch_data->get_matrix_free(),
-      evapor_vel_dof_idx,
-      ls_quad_idx,
-      scratch_data->get_degree(evapor_vel_dof_idx),           // fe_degree of the resulting vector
-      scratch_data->get_degree(ls_hanging_nodes_dof_idx) + 1, // n_q_points_1d of cell operation
-      [&](const unsigned int cell,
-          const unsigned int quad) -> const Tensor<1, dim, VectorizedArray<double>> & {
-        return begin_evaporation_velocity(cell)[quad];
-      });
+    if (scratch_data->is_hex_mesh())
+      UtilityFunctions::fill_dof_vector_from_cell_operation_vec<dim, dim>(
+        evaporation_velocity,
+        scratch_data->get_matrix_free(),
+        evapor_vel_dof_idx,
+        ls_quad_idx,
+        scratch_data->get_degree(evapor_vel_dof_idx),           // fe_degree of the resulting vector
+        scratch_data->get_degree(ls_hanging_nodes_dof_idx) + 1, // n_q_points_1d of cell operation
+        [&](const unsigned int cell,
+            const unsigned int quad) -> const Tensor<1, dim, VectorizedArray<double>> & {
+          return begin_evaporation_velocity(cell)[quad];
+        });
 
     scratch_data->get_constraint(evapor_vel_dof_idx).distribute(evaporation_velocity);
 

--- a/source/evaporation/evaporation_operation_marching_cube.cpp
+++ b/source/evaporation/evaporation_operation_marching_cube.cpp
@@ -82,19 +82,21 @@ namespace MeltPoolDG::Evaporation
     /**
      * write interface velocity to dof vector
      */
-    UtilityFunctions::fill_dof_vector_from_cell_operation_vec<dim, dim>(
-      evaporation_velocity,
-      scratch_data.get_matrix_free(),
-      evapor_vel_dof_idx,
-      ls_quad_idx,
-      scratch_data.get_degree(evapor_vel_dof_idx),           // fe_degree of the resulting vector
-      scratch_data.get_degree(ls_hanging_nodes_dof_idx) + 1, // n_q_points_1d of cell operation
-      [&](const unsigned int cell,
-          const unsigned int quad) -> const Tensor<1, dim, VectorizedArray<double>> & {
-        return const_cast<const Tensor<1, dim, VectorizedArray<double>> &>(
-          evaporation_velocities[scratch_data.get_matrix_free().get_n_q_points(ls_quad_idx) * cell +
-                                 quad]);
-      });
+    if (scratch_data.is_hex_mesh())
+      UtilityFunctions::fill_dof_vector_from_cell_operation_vec<dim, dim>(
+        evaporation_velocity,
+        scratch_data.get_matrix_free(),
+        evapor_vel_dof_idx,
+        ls_quad_idx,
+        scratch_data.get_degree(evapor_vel_dof_idx),           // fe_degree of the resulting vector
+        scratch_data.get_degree(ls_hanging_nodes_dof_idx) + 1, // n_q_points_1d of cell operation
+        [&](const unsigned int cell,
+            const unsigned int quad) -> const Tensor<1, dim, VectorizedArray<double>> & {
+          return const_cast<const Tensor<1, dim, VectorizedArray<double>> &>(
+            evaporation_velocities[scratch_data.get_matrix_free().get_n_q_points(ls_quad_idx) *
+                                     cell +
+                                   quad]);
+        });
 
     scratch_data.get_constraint(evapor_vel_dof_idx).distribute(evaporation_velocity);
     scratch_data.get_pcout() << "    | evapor: |u|2 = " << evaporation_velocity.l2_norm()

--- a/source/flow/adaflo_wrapper.cpp
+++ b/source/flow/adaflo_wrapper.cpp
@@ -381,16 +381,18 @@ namespace MeltPoolDG::Flow
      *  density
      */
     scratch_data.initialize_dof_vector(density, dof_index_parameters);
-    UtilityFunctions::fill_dof_vector_from_cell_operation<dim, 1>(
-      density,
-      scratch_data.get_matrix_free(),
-      dof_index_parameters,
-      quad_index_u,
-      scratch_data.get_fe(dof_index_parameters).tensor_degree(),     // fe_degree,
-      scratch_data.get_fe(dof_index_parameters).tensor_degree() + 1, // fe_degree,
-      [&](const unsigned int cell, const unsigned int quad) -> const VectorizedArray<double> & {
-        return get_density(cell, quad);
-      });
+
+    if (scratch_data.is_hex_mesh())
+      UtilityFunctions::fill_dof_vector_from_cell_operation<dim, 1>(
+        density,
+        scratch_data.get_matrix_free(),
+        dof_index_parameters,
+        quad_index_u,
+        scratch_data.get_fe(dof_index_parameters).tensor_degree(),     // fe_degree,
+        scratch_data.get_fe(dof_index_parameters).tensor_degree() + 1, // fe_degree,
+        [&](const unsigned int cell, const unsigned int quad) -> const VectorizedArray<double> & {
+          return get_density(cell, quad);
+        });
 
     density.update_ghost_values();
     data_out.add_data_vector(dof_handler_parameters, density, "density");
@@ -398,16 +400,17 @@ namespace MeltPoolDG::Flow
      *  viscosity
      */
     scratch_data.initialize_dof_vector(viscosity, dof_index_parameters);
-    UtilityFunctions::fill_dof_vector_from_cell_operation<dim, 1>(
-      viscosity,
-      scratch_data.get_matrix_free(),
-      dof_index_parameters,
-      quad_index_u,
-      scratch_data.get_fe(dof_index_parameters).tensor_degree(),     // fe_degree,
-      scratch_data.get_fe(dof_index_parameters).tensor_degree() + 1, // fe_degree,
-      [&](const unsigned int cell, const unsigned int quad) -> const VectorizedArray<double> & {
-        return get_viscosity(cell, quad);
-      });
+    if (scratch_data.is_hex_mesh())
+      UtilityFunctions::fill_dof_vector_from_cell_operation<dim, 1>(
+        viscosity,
+        scratch_data.get_matrix_free(),
+        dof_index_parameters,
+        quad_index_u,
+        scratch_data.get_fe(dof_index_parameters).tensor_degree(),     // fe_degree,
+        scratch_data.get_fe(dof_index_parameters).tensor_degree() + 1, // fe_degree,
+        [&](const unsigned int cell, const unsigned int quad) -> const VectorizedArray<double> & {
+          return get_viscosity(cell, quad);
+        });
     viscosity.update_ghost_values();
     data_out.add_data_vector(dof_handler_parameters, viscosity, "viscosity");
   }

--- a/source/flow/two_phase_flow_problem.cpp
+++ b/source/flow/two_phase_flow_problem.cpp
@@ -788,7 +788,7 @@ namespace MeltPoolDG::Flow
         heat_operation->attach_output_vectors(data_out);
     };
 
-    GenericDataOut<dim> generic_data_out;
+    GenericDataOut<dim> generic_data_out(scratch_data->get_mapping(), current_time);
     attach_output_vectors(generic_data_out);
 
     // user-defined postprocessing

--- a/source/flow/two_phase_flow_problem.cpp
+++ b/source/flow/two_phase_flow_problem.cpp
@@ -210,7 +210,7 @@ namespace MeltPoolDG::Flow
                                                flow_operation->get_quad_idx_pressure())
           << std::endl;
         // ... and output the results to vtk files.
-        output_results(n, time_iterator.get_current_time());
+        output_results(n, time_iterator.get_current_time(), base_in);
 
         if (base_in->parameters.amr.do_amr)
           refine_mesh(base_in);
@@ -416,7 +416,7 @@ namespace MeltPoolDG::Flow
      *  @todo: find a way to plot vectors on the refined mesh, which are only relevant for output
      *  and which must not be transferred to the new mesh everytime refine_mesh() is called.
      */
-    output_results(0, base_in->parameters.flow.start_time);
+    output_results(0, base_in->parameters.flow.start_time, base_in);
     /*
      *    Do initial refinement steps if requested
      */
@@ -767,8 +767,9 @@ namespace MeltPoolDG::Flow
 
   template <int dim>
   void
-  TwoPhaseFlowProblem<dim>::output_results(const unsigned int n_time_step,
-                                           const double       current_time)
+  TwoPhaseFlowProblem<dim>::output_results(const unsigned int                   n_time_step,
+                                           const double                         current_time,
+                                           std::shared_ptr<SimulationBase<dim>> base_in)
   {
     /**
      * collect all relevant output data
@@ -786,9 +787,14 @@ namespace MeltPoolDG::Flow
       if (heat_operation)
         heat_operation->attach_output_vectors(data_out);
     };
-    /**
-     * do the output operation
-     */
+
+    GenericDataOut<dim> generic_data_out;
+    attach_output_vectors(generic_data_out);
+
+    // user-defined postprocessing
+    base_in->do_postprocessing(generic_data_out);
+
+    // paraview postprocessing
     post_processor->process(n_time_step, attach_output_vectors, current_time);
   }
 

--- a/source/heat/heat_transfer_operator.cpp
+++ b/source/heat/heat_transfer_operator.cpp
@@ -657,7 +657,7 @@ namespace MeltPoolDG::Heat
     if (evapor_data)
       {
         scratch_data.initialize_dof_vector(evapor_heat_source, temp_dof_idx);
-        if (!q_vapor.empty())
+        if (!q_vapor.empty() && scratch_data.is_hex_mesh())
           UtilityFunctions::fill_dof_vector_from_cell_operation<dim, 1>(
             evapor_heat_source,
             scratch_data.get_matrix_free(),

--- a/source/heat/heat_transfer_problem.cpp
+++ b/source/heat/heat_transfer_problem.cpp
@@ -42,7 +42,7 @@ namespace MeltPoolDG::Heat
         heat_operation->solve(dt);
 
         // ... and output the results to vtk files.
-        output_results(n, time_iterator.get_current_time());
+        output_results(n, time_iterator.get_current_time(), base_in);
 
         if (base_in->parameters.amr.do_amr)
           refine_mesh(base_in);
@@ -195,7 +195,7 @@ namespace MeltPoolDG::Heat
     /*
      *  output results of initialization
      */
-    output_results(0, base_in->parameters.heat.time_stepping.start_time);
+    output_results(0, base_in->parameters.heat.time_stepping.start_time, base_in);
   }
 
   template <int dim>
@@ -288,7 +288,9 @@ namespace MeltPoolDG::Heat
 
   template <int dim>
   void
-  HeatTransferProblem<dim>::output_results(const unsigned int n_time_step, const double time)
+  HeatTransferProblem<dim>::output_results(const unsigned int                   n_time_step,
+                                           const double                         time,
+                                           std::shared_ptr<SimulationBase<dim>> base_in)
   {
     /**
      * collect all relevant output data
@@ -296,9 +298,14 @@ namespace MeltPoolDG::Heat
     const auto attach_output_vectors = [&](GenericDataOut<dim> &data_out) {
       heat_operation->attach_output_vectors(data_out);
     };
-    /**
-     * do the output operation
-     */
+
+    GenericDataOut<dim> generic_data_out;
+    attach_output_vectors(generic_data_out);
+
+    // user-defined postprocessing
+    base_in->do_postprocessing(generic_data_out);
+
+    // paraview postprocessing
     post_processor->process(n_time_step, attach_output_vectors, time);
   }
 

--- a/source/heat/heat_transfer_problem.cpp
+++ b/source/heat/heat_transfer_problem.cpp
@@ -299,7 +299,7 @@ namespace MeltPoolDG::Heat
       heat_operation->attach_output_vectors(data_out);
     };
 
-    GenericDataOut<dim> generic_data_out;
+    GenericDataOut<dim> generic_data_out(scratch_data->get_mapping(), time);
     attach_output_vectors(generic_data_out);
 
     // user-defined postprocessing

--- a/source/interface/scratch_data.cpp
+++ b/source/interface/scratch_data.cpp
@@ -459,6 +459,14 @@ namespace MeltPoolDG
     return pcout[level];
   }
 
+  template <int dim, int spacedim, typename number, typename VectorizedArrayType>
+  bool
+  ScratchData<dim, spacedim, number, VectorizedArrayType>::is_hex_mesh(
+    const unsigned int dof_idx) const
+  {
+    return get_triangulation(dof_idx).all_reference_cells_are_hyper_cube();
+  }
+
   template class ScratchData<1>;
   template class ScratchData<2>;
   template class ScratchData<3>;

--- a/source/level_set/level_set_problem.cpp
+++ b/source/level_set/level_set_problem.cpp
@@ -57,7 +57,8 @@ namespace MeltPoolDG::LevelSet
 
         // do paraview output if requested
         output_results(time_iterator.get_current_time_step_number(),
-                       time_iterator.get_current_time());
+                       time_iterator.get_current_time(),
+                       base_in);
 
         if (base_in->parameters.amr.do_amr)
           refine_mesh(base_in);
@@ -207,7 +208,7 @@ namespace MeltPoolDG::LevelSet
                                            scratch_data->get_mapping(),
                                            scratch_data->get_triangulation(ls_dof_idx));
 
-    output_results(0, base_in->parameters.ls.start_time);
+    output_results(0, base_in->parameters.ls.start_time, base_in);
     /*
      *    Do initial refinement steps if requested
      */
@@ -327,7 +328,9 @@ namespace MeltPoolDG::LevelSet
    */
   template <int dim>
   void
-  LevelSetProblem<dim>::output_results(const unsigned int time_step, const double time) const
+  LevelSetProblem<dim>::output_results(const unsigned int                   time_step,
+                                       const double                         time,
+                                       std::shared_ptr<SimulationBase<dim>> base_in)
   {
     const auto attach_output_vectors = [&](GenericDataOut<dim> &data_out) {
       level_set_operation.attach_output_vectors(data_out);
@@ -346,6 +349,14 @@ namespace MeltPoolDG::LevelSet
                                std::vector<std::string>(dim, "velocity"),
                                vector_component_interpretation);
     };
+
+    GenericDataOut<dim> generic_data_out;
+    attach_output_vectors(generic_data_out);
+
+    // user-defined postprocessing
+    base_in->do_postprocessing(generic_data_out);
+
+    // paraview postprocessing
     post_processor->process(time_step, attach_output_vectors, time);
   }
 

--- a/source/level_set/level_set_problem.cpp
+++ b/source/level_set/level_set_problem.cpp
@@ -350,7 +350,7 @@ namespace MeltPoolDG::LevelSet
                                vector_component_interpretation);
     };
 
-    GenericDataOut<dim> generic_data_out;
+    GenericDataOut<dim> generic_data_out(scratch_data->get_mapping(), time);
     attach_output_vectors(generic_data_out);
 
     // user-defined postprocessing

--- a/source/reinitialization/reinitialization_problem.cpp
+++ b/source/reinitialization/reinitialization_problem.cpp
@@ -240,7 +240,7 @@ namespace MeltPoolDG::Reinitialization
       reinit_operation->attach_output_vectors(data_out);
     };
 
-    GenericDataOut<dim> generic_data_out;
+    GenericDataOut<dim> generic_data_out(scratch_data->get_mapping(), time);
     attach_output_vectors(generic_data_out);
 
     // user-defined postprocessing

--- a/source/reinitialization/reinitialization_problem.cpp
+++ b/source/reinitialization/reinitialization_problem.cpp
@@ -17,7 +17,8 @@ namespace MeltPoolDG::Reinitialization
         reinit_operation->solve(d_tau);
 
         output_results(time_iterator.get_current_time_step_number(),
-                       time_iterator.get_current_time());
+                       time_iterator.get_current_time(),
+                       base_in);
 
         if (base_in->parameters.amr.do_amr)
           refine_mesh(base_in);
@@ -231,13 +232,22 @@ namespace MeltPoolDG::Reinitialization
 
   template <int dim>
   void
-  ReinitializationProblem<dim>::output_results(const unsigned int time_step,
-                                               const double       time) const
+  ReinitializationProblem<dim>::output_results(const unsigned int                   time_step,
+                                               const double                         time,
+                                               std::shared_ptr<SimulationBase<dim>> base_in)
   {
-    post_processor->process(
-      time_step,
-      [&](GenericDataOut<dim> &data_out) { reinit_operation->attach_output_vectors(data_out); },
-      time);
+    const auto attach_output_vectors = [&](GenericDataOut<dim> &data_out) {
+      reinit_operation->attach_output_vectors(data_out);
+    };
+
+    GenericDataOut<dim> generic_data_out;
+    attach_output_vectors(generic_data_out);
+
+    // user-defined postprocessing
+    base_in->do_postprocessing(generic_data_out);
+
+    // paraview postprocessing
+    post_processor->process(time_step, attach_output_vectors, time);
   }
 
 

--- a/source/simulations/simulation_selector.cpp
+++ b/source/simulations/simulation_selector.cpp
@@ -2,6 +2,7 @@
 #include <meltpooldg/utilities/utilityfunctions.hpp>
 // simulations
 #include <meltpooldg/simulations/advection_diffusion/advection_diffusion.hpp>
+#include <meltpooldg/simulations/advection_diffusion/advection_diffusion_user_output.hpp>
 #include <meltpooldg/simulations/evaporating_droplet/evaporating_droplet.hpp>
 #include <meltpooldg/simulations/evaporating_droplet/evaporating_droplet_with_heat.hpp>
 #include <meltpooldg/simulations/film_boiling/film_boiling.hpp>
@@ -36,6 +37,9 @@ namespace MeltPoolDG::Simulation
     else if (simulation_name == "advection_diffusion")
       return std::make_shared<AdvectionDiffusion::SimulationAdvec<dim>>(parameter_file,
                                                                         mpi_communicator);
+    else if (simulation_name == "advection_diffusion_user_output")
+      return std::make_shared<AdvectionDiffusion::SimulationAdvectionDiffusionUserOutput<dim>>(
+        parameter_file, mpi_communicator);
     else if (simulation_name == "rotating_bubble")
       return std::make_shared<RotatingBubble::SimulationRotatingBubble<dim>>(parameter_file,
                                                                              mpi_communicator);

--- a/source/utilities/generic_data_out.cpp
+++ b/source/utilities/generic_data_out.cpp
@@ -3,6 +3,12 @@
 namespace MeltPoolDG
 {
   template <int dim>
+  GenericDataOut<dim>::GenericDataOut(const Mapping<dim> &mapping, const double current_time)
+    : mapping(mapping)
+    , current_time(current_time)
+  {}
+
+  template <int dim>
   void
   GenericDataOut<dim>::add_data_vector(
     const DoFHandler<dim> &         dof_handler,

--- a/source/utilities/generic_data_out.cpp
+++ b/source/utilities/generic_data_out.cpp
@@ -18,6 +18,7 @@ namespace MeltPoolDG
       &data_component_interpretation)
   {
     entries.emplace_back(&dof_handler, &data, names, data_component_interpretation);
+    entry_id[names[0]] = entries.size() - 1;
   }
 
   template <int dim>
@@ -31,6 +32,47 @@ namespace MeltPoolDG
                          std::vector<std::string>{name},
                          std::vector<DataComponentInterpretation::DataComponentInterpretation>{
                            DataComponentInterpretation::component_is_scalar});
+    entry_id[name] = entries.size() - 1;
+  }
+
+  template <int dim>
+  const GenericDataOut<dim>::VectorType &
+  GenericDataOut<dim>::get_vector(const std::string &name) const
+  {
+    if (entry_id.find(name) == entry_id.end())
+      {
+        std::ostringstream exc_message;
+        exc_message << "Your requested output variable >>> " + name +
+                         " <<< cannot be found in the entries"
+                         " of GenericDataOut. The available values are: "
+                    << std::endl;
+        for (auto &[key, value] : entry_id)
+          exc_message << "* " << key << std::endl;
+
+        AssertThrow(false, ExcMessage(exc_message.str()));
+      }
+
+    return *std::get<1>(entries[entry_id.at(name)]);
+  }
+
+  template <int dim>
+  const DoFHandler<dim> &
+  GenericDataOut<dim>::get_dof_handler(const std::string &name) const
+  {
+    if (entry_id.find(name) == entry_id.end())
+      {
+        std::ostringstream exc_message;
+        exc_message << "Your requested output variable >>> " + name +
+                         " <<< cannot be found in the entries"
+                         " of GenericDataOut. The available values are: "
+                    << std::endl;
+        for (auto &[key, value] : entry_id)
+          exc_message << "* " << key << std::endl;
+
+        AssertThrow(false, ExcMessage(exc_message.str()));
+      }
+
+    return *std::get<0>(entries[entry_id.at(name)]);
   }
 
   template class GenericDataOut<1>;

--- a/source/utilities/postprocessor.cpp
+++ b/source/utilities/postprocessor.cpp
@@ -38,7 +38,7 @@ namespace MeltPoolDG
     const double                                      time,
     const std::function<void()> &                     post_operation)
   {
-    GenericDataOut<dim> data_out;
+    GenericDataOut<dim> data_out(mapping);
 
     if ((pv_data.do_output) && !(n_time_step % pv_data.write_frequency))
       {

--- a/tests/advection_diffusion_user_output.json
+++ b/tests/advection_diffusion_user_output.json
@@ -1,0 +1,23 @@
+{
+  "base": {
+    "problem name": "advection_diffusion",
+    "application name": "advection_diffusion_user_output",
+    "dimension": "2",
+    "global refinements": "5",
+    "degree": "1",
+    "do print parameters": "false"
+  },
+  "advection diffusion": {
+    "advec diff diffusivity": "0.000000",
+    "advec diff implementation": "meltpooldg",
+    "advec diff integration scheme": "crank_nicolson",
+    "advec diff start time": "0.0",
+    "advec diff end time": "0.05",
+    "advec diff time step size": "0.01",
+    "advec diff do matrix free": "false",
+    "advec diff do print l2norm": "true"
+  },
+  "paraview": {
+    "paraview do output": "false"
+  }
+}

--- a/tests/advection_diffusion_user_output.mpirun=4.output
+++ b/tests/advection_diffusion_user_output.mpirun=4.output
@@ -1,0 +1,55 @@
+t= 0.01      |vel|= 111.095
+	 |ϕ|2 = 1.990445402    
+---------------------------------------------
+    Starting user defined postprocessing
+---------------------------------------------
+Accessible vectors:
+ *       advected_field Max-norm:     1.9929 number of dofs: 1089
+ *             velocity Max-norm:          4 number of dofs: 2178
+---------------------------------------------
+    End of user defined postprocessing
+---------------------------------------------
+t= 0.02      |vel|= 111.09
+	 |ϕ|2 = 1.990446547    
+---------------------------------------------
+    Starting user defined postprocessing
+---------------------------------------------
+Accessible vectors:
+ *       advected_field Max-norm:     2.0799 number of dofs: 1089
+ *             velocity Max-norm:          4 number of dofs: 2178
+---------------------------------------------
+    End of user defined postprocessing
+---------------------------------------------
+t= 0.03      |vel|= 111.09
+	 |ϕ|2 = 1.990446336    
+---------------------------------------------
+    Starting user defined postprocessing
+---------------------------------------------
+Accessible vectors:
+ *       advected_field Max-norm:     1.9841 number of dofs: 1089
+ *             velocity Max-norm:          4 number of dofs: 2178
+---------------------------------------------
+    End of user defined postprocessing
+---------------------------------------------
+t= 0.04      |vel|= 111.09
+	 |ϕ|2 = 1.990442727    
+---------------------------------------------
+    Starting user defined postprocessing
+---------------------------------------------
+Accessible vectors:
+ *       advected_field Max-norm:     1.9361 number of dofs: 1089
+ *             velocity Max-norm:          4 number of dofs: 2178
+---------------------------------------------
+    End of user defined postprocessing
+---------------------------------------------
+t= 0.05      |vel|= 111.09
+	 |ϕ|2 = 1.990430972    
+---------------------------------------------
+    Starting user defined postprocessing
+---------------------------------------------
+Accessible vectors:
+ *       advected_field Max-norm:     2.0363 number of dofs: 1089
+ *             velocity Max-norm:          4 number of dofs: 2178
+---------------------------------------------
+    End of user defined postprocessing
+---------------------------------------------


### PR DESCRIPTION
This PR references #152. @peterrum: If this is what you thought about, I'll continue by integrating the user output also in the other problems.

@nmuch: This way, output vectors are available in the `Simulation` files. The goal is to directly obtain e.g. a value over time in table form or any other postprocessed variable you are interested in. This should save us in certain cases from opening Paraview at all. 