### PR TITLE
Enable heat transfer with solidification and two-phase flow

### DIFF
--- a/include/meltpooldg/heat/heat_transfer_operator.hpp
+++ b/include/meltpooldg/heat/heat_transfer_operator.hpp
@@ -249,34 +249,96 @@ namespace MeltPoolDG::Heat
                                      FEFaceIntegrator<dim, 1, number> &temp_vals,
                                      bool                              do_reinit_face) const;
 
-    /*
-     * Determine material parameters (capacity, conductivity and density) for
-     * solidification/melting. In the mushy zone (between solidus and liquidus temperature) the
-     * material parameters are linearly interpolated between the solid's and fluid's values.
+    /**
+     * Determine the material parameters. This function takes two-phase flow and solidification
+     * effects into account.
      *
-     * @TODO, handle variable fluid parameters. ATM the fluid's parameters are assumed to be
-     * material.second.<..>
+     * The values of \p rho_cp and \p conductivity must be set to the material.first values
+     * initially. This function only modifies their values if necessary. I.e. in case of no
+     * two-phase flow and no solidification this function does nothing.
      */
     void
-    get_material_parameters_with_solidification(VectorizedArray<number> &      capacity,
-                                                VectorizedArray<number> &      conductivity,
-                                                VectorizedArray<number> &      density,
-                                                const VectorizedArray<number> &temperature) const;
+    get_material_parameters(VectorizedArray<number> &               rho_cp,
+                            VectorizedArray<number> &               conductivity,
+                            bool                                    with_solidification,
+                            bool                                    with_two_phase,
+                            const FECellIntegrator<dim, 1, number> &temp_lin_val,
+                            const FECellIntegrator<dim, 1, number> &ls_heaviside_val,
+                            unsigned int                            q_index) const;
+
+    /**
+     * Determine the material parameters and their temperature derivatives. This function takes
+     * two-phase flow and solidification effects into account.
+     *
+     * The values of \p rho_cp, \p conductivity, \p d_rho_cp_dT and \p d_conductivity_dT must be set
+     * to the material.first values initially. This function only modifies their values if
+     * necessary. I.e. in case of no two-phase flow and no solidification this function does
+     * nothing.
+     */
+    void
+    get_material_parameters_and_derivatives(
+      VectorizedArray<number> &               rho_cp,
+      VectorizedArray<number> &               conductivity,
+      VectorizedArray<number> &               d_rho_cp_dT,
+      VectorizedArray<number> &               d_conductivity_dT,
+      bool                                    with_solidification,
+      bool                                    with_two_phase,
+      const FECellIntegrator<dim, 1, number> &temp_lin_val,
+      const FECellIntegrator<dim, 1, number> &ls_heaviside_val,
+      unsigned int                            q_index) const;
 
     /*
-     * Determine derivatives of the material parameters (capacity, conductivity and density) with
-     * respect to the temperature for solidification/melting. In the mushy zone (between solidus and
-     * liquidus temperature) the material parameters are linearly interpolated between the solid's
-     * and fluid's values, so this function return the slope of that linear function. Outside the
-     * mushy zone the parameters are constant and this function returns zeros.
+     * Determine material parameters (\p capacity, \p conductivity and \p density) for
+     * solidification/melting. Input the liquid's material parameters via \p liq_capacity, \p
+     * liq_conductivity and \p liq_density. In the mushy zone (where the solid fraction os between 0
+     * and 1) the material parameters will be interpolated with smooth cubic function, see
+     * UtilityFunctions::interpolate_cubic().
+     *
+     * In case of two-phase flow use get_material_parameters_with_two_phase_flow() to determine the
+     * liquid's parameters first.
+     */
+    void
+    get_material_parameters_with_solidification(
+      VectorizedArray<number> &      capacity,
+      VectorizedArray<number> &      conductivity,
+      VectorizedArray<number> &      density,
+      const VectorizedArray<number> &liq_capacity,
+      const VectorizedArray<number> &liq_conductivity,
+      const VectorizedArray<number> &liq_density,
+      const VectorizedArray<number> &solid_fraction) const;
+
+    /*
+     * Determine derivatives of the material parameters (\p d_capacity_dT, \p d_conductivity_dT and
+     * \p d_density_dT) with respect to the temperature for solidification/melting. Input the
+     * liquid's material parameters via \p liq_capacity, \p liq_conductivity and \p liq_density.
+     * This function will return the temperature derivatives of the values determined by
+     * get_material_parameters_with_solidification().
+     *
+     * In case of two-phase flow use get_material_parameters_with_two_phase_flow() to determine the
+     * liquid's parameters first.
      */
     void
     get_material_parameter_derivatives_with_solidification(
       VectorizedArray<number> &      d_capacity_dT,
       VectorizedArray<number> &      d_conductivity_dT,
       VectorizedArray<number> &      d_density_dT,
-      const VectorizedArray<number> &temperature) const;
+      const VectorizedArray<number> &liq_capacity,
+      const VectorizedArray<number> &liq_conductivity,
+      const VectorizedArray<number> &liq_density,
+      const VectorizedArray<number> &solid_fraction) const;
 
+    /*
+     * Determine the material parameters (\p capacity, \p conductivity and \p density) for two phase
+     * flow. If \p ls_heaviside_val = 0 this function returns the first materials parameters and if
+     * \p ls_heaviside_val = 1 it returns the second materials parameters. At the interface the
+     * parameters are smeared if "heat variable properties over interface" is set to true, else the
+     * parameters will jump.
+     *
+     * This does not account for solidification effect. In case of solidification this function must
+     * be used to determine the liquid's material parameters for
+     * get_material_parameters_with_solidification() and
+     * get_material_parameter_derivatives_with_solidification().
+     */
     void
     get_material_parameters_with_two_phase_flow(
       VectorizedArray<number> &      capacity,

--- a/include/meltpooldg/simulations/unidirectional_heat_transfer/unidirectional_heat_transfer.hpp
+++ b/include/meltpooldg/simulations/unidirectional_heat_transfer/unidirectional_heat_transfer.hpp
@@ -125,7 +125,31 @@ namespace MeltPoolDG::Simulation::UnidirectionalHeatTransfer
 
   private:
     const double eps   = 0.01;
-    const double level = 0.05;
+    const double level = x_max / 2;
+  };
+
+  template <int dim>
+  class CovectedVerticalLevelSetHeaviside : public Function<dim>
+  {
+  public:
+    CovectedVerticalLevelSetHeaviside(const double velocity)
+      : Function<dim>(1)
+      , velocity(velocity)
+    {}
+
+    double
+    value(const Point<dim> &p, const unsigned int) const override
+    {
+      const auto x = p[0];
+      return UtilityFunctions::CharacteristicFunctions::heaviside(level - x -
+                                                                    velocity * this->get_time(),
+                                                                  eps);
+    }
+
+  private:
+    const double eps   = 0.01;
+    const double level = x_max * 2. / 3.;
+    const double velocity;
   };
 
   template <int dim>
@@ -221,8 +245,17 @@ namespace MeltPoolDG::Simulation::UnidirectionalHeatTransfer
                                     this->parameters.heat.velocity),
                                   "heat_transfer");
 
-      this->template attach_initial_condition(std::make_shared<HorizontalLevelSetHeaviside<dim>>(),
-                                              "prescribed_level_set");
+      if (this->parameters.heat.two_phase)
+        {
+          if (!this->parameters.heat.solidification)
+            this->template attach_initial_condition(
+              std::make_shared<HorizontalLevelSetHeaviside<dim>>(), "prescribed_level_set");
+          else
+            this->template attach_initial_condition(
+              std::make_shared<CovectedVerticalLevelSetHeaviside<dim>>(
+                this->parameters.heat.velocity),
+              "prescribed_level_set");
+        }
     }
   };
 } // namespace MeltPoolDG::Simulation::UnidirectionalHeatTransfer

--- a/include/meltpooldg/simulations/unidirectional_heat_transfer/unidirectional_heat_transfer_with_two_phase_and_solidification.json
+++ b/include/meltpooldg/simulations/unidirectional_heat_transfer/unidirectional_heat_transfer_with_two_phase_and_solidification.json
@@ -1,0 +1,42 @@
+{
+  "base": {
+    "application name": "unidirectional_heat_transfer",
+    "degree": "1",
+    "dimension": "2",
+    "do simplex": "false",
+    "do print parameters": "false",
+    "global refinements": "5",
+    "problem name": "heat_transfer",
+    "verbosity level": "2"
+  },
+  "heat": {
+    "heat velocity": "0.0001",
+    "heat start time": "0.0",
+    "heat time step size": "1.0",
+    "heat end time": "100.0",
+    "heat max n steps": "100",
+    "heat two phase": "true",
+    "heat solidification": "true",
+    "heat solver rel tolerance": "1e-12",
+    "heat solver preconditioner type": "ILU",
+    "heat nlsolve residual tolerance": "1e-7"
+  },
+  "material": {
+    "material first capacity": "230",
+    "material first conductivity": "27.7815",
+    "material first density": "3925",
+    "material second conductivity": "55.563",
+    "material second capacity": "460.0",
+    "material second density": "7850.0",
+    "material solid conductivity": "17.0",
+    "material solid capacity": "700.0",
+    "material solid density": "7850.0",
+    "material solidus temperature": "1966.0",
+    "material liquidus temperature": "1974.0"
+  },
+  "paraview": {
+    "paraview do output": "true",
+    "paraview directory": "output/",
+    "paraview filename": "solution_heat_transfer_two_phase_and_solidification"
+  }
+}

--- a/include/meltpooldg/utilities/utilityfunctions.hpp
+++ b/include/meltpooldg/utilities/utilityfunctions.hpp
@@ -319,16 +319,18 @@ namespace MeltPoolDG
       return (1. - ls) * val1 + ls * val2;
     }
 
-    template <typename value_type>
-    inline value_type
-    interpolate_cubic(const value_type &ls, const double val1, const double val2)
+    template <typename value_type1, typename value_type2, typename value_type3>
+    inline value_type1
+    interpolate_cubic(const value_type1 &ls, const value_type2 &val1, const value_type3 &val2)
     {
       return val1 + (val2 - val1) * (-2. * ls * ls * ls + 3. * ls * ls);
     }
 
-    template <typename value_type>
-    inline value_type
-    interpolate_cubic_derivative(const value_type &ls, const double val1, const double val2)
+    template <typename value_type1, typename value_type2, typename value_type3>
+    inline value_type1
+    interpolate_cubic_derivative(const value_type1 &ls,
+                                 const value_type2 &val1,
+                                 const value_type3 &val2)
     {
       return (val2 - val1) * (-6. * ls * ls + 6. * ls);
     }

--- a/source/heat/heat_transfer_operator.cpp
+++ b/source/heat/heat_transfer_operator.cpp
@@ -65,9 +65,6 @@ namespace MeltPoolDG::Heat
       !data.solidification || material.liquidus_temperature > material.solidus_temperature,
       ExcMessage(
         "In case of solidification the liquidus temperature must be greater than the solidus temperature! Abort..."));
-    AssertThrow(!(data.solidification && level_set_as_heaviside),
-                ExcMessage(
-                  "Solidification and two-phase flow heat don't work together (yet)! Abort..."));
 
     if (bc)
       {
@@ -439,11 +436,8 @@ namespace MeltPoolDG::Heat
     FECellIntegrator<dim, 1, number>   ls_vals(matrix_free, ls_dof_idx, this->quad_idx);
     FECellIntegrator<dim, 1, number>   evapor_vals(matrix_free, temp_dof_idx, this->quad_idx);
 
-    VectorizedArray<number> capacity     = material.first.capacity;
+    VectorizedArray<number> rho_cp       = material.first.density * material.first.capacity;
     VectorizedArray<number> conductivity = material.first.conductivity;
-    VectorizedArray<number> density      = material.first.density;
-
-    VectorizedArray<number> rho_cp;
 
     q_vapor.resize(scratch_data.get_matrix_free().n_cell_batches(),
                    std::vector<VectorizedArray<double>>(temp_vals.n_q_points));
@@ -485,22 +479,13 @@ namespace MeltPoolDG::Heat
 
         for (unsigned int q_index = 0; q_index < temp_vals.n_q_points; ++q_index)
           {
-            if (level_set_as_heaviside)
-              {
-                get_material_parameters_with_two_phase_flow(capacity,
-                                                            conductivity,
-                                                            density,
-                                                            ls_vals.get_value(q_index));
-              }
-
-            if (data.solidification)
-              {
-                get_material_parameters_with_solidification(capacity,
-                                                            conductivity,
-                                                            density,
-                                                            temp_vals.get_value(q_index));
-              }
-            rho_cp = density * capacity;
+            get_material_parameters(rho_cp,
+                                    conductivity,
+                                    data.solidification,
+                                    level_set_as_heaviside,
+                                    temp_vals,
+                                    ls_vals,
+                                    q_index);
 
             auto val = this->d_tau_inv * rho_cp *
                          (temp_vals.get_value(q_index) - temp_vals_old.get_value(q_index)) -
@@ -687,16 +672,10 @@ namespace MeltPoolDG::Heat
     FECellIntegrator<dim, 1, number> &  ls_vals,
     const bool                          do_reinit_cells) const
   {
-    VectorizedArray<number> capacity     = material.first.capacity;
-    VectorizedArray<number> conductivity = material.first.conductivity;
-    VectorizedArray<number> density      = material.first.density;
-
-    VectorizedArray<number> d_capacity_dT     = 0.0;
+    VectorizedArray<number> rho_cp            = material.first.density * material.first.capacity;
+    VectorizedArray<number> conductivity      = material.first.conductivity;
+    VectorizedArray<number> d_rho_cp_dT       = 0.0;
     VectorizedArray<number> d_conductivity_dT = 0.0;
-    VectorizedArray<number> d_density_dT      = 0.0;
-
-    VectorizedArray<number> rho_cp;
-    VectorizedArray<number> d_rho_cp_dT;
 
     temp_vals.evaluate(true, true);
 
@@ -729,25 +708,15 @@ namespace MeltPoolDG::Heat
 
     for (unsigned int q_index = 0; q_index < temp_vals.n_q_points; ++q_index)
       {
-        if (level_set_as_heaviside)
-          {
-            get_material_parameters_with_two_phase_flow(capacity,
-                                                        conductivity,
-                                                        density,
-                                                        ls_vals.get_value(q_index));
-          }
-
-        if (data.solidification)
-          {
-            get_material_parameters_with_solidification(capacity,
-                                                        conductivity,
-                                                        density,
-                                                        temp_lin_vals.get_value(q_index));
-            get_material_parameter_derivatives_with_solidification(
-              d_capacity_dT, d_conductivity_dT, d_density_dT, temp_lin_vals.get_value(q_index));
-            d_rho_cp_dT = d_capacity_dT * density + d_density_dT * capacity;
-          }
-        rho_cp = density * capacity;
+        get_material_parameters_and_derivatives(rho_cp,
+                                                conductivity,
+                                                d_rho_cp_dT,
+                                                d_conductivity_dT,
+                                                data.solidification,
+                                                level_set_as_heaviside,
+                                                temp_lin_vals,
+                                                ls_vals,
+                                                q_index);
 
         auto val = this->d_tau_inv * rho_cp * temp_vals.get_value(q_index);
 
@@ -843,21 +812,123 @@ namespace MeltPoolDG::Heat
 
   template <int dim, typename number>
   void
+  HeatTransferOperator<dim, number>::get_material_parameters(
+    VectorizedArray<number> &               rho_cp,
+    VectorizedArray<number> &               conductivity,
+    const bool                              with_solidification,
+    const bool                              with_two_phase,
+    const FECellIntegrator<dim, 1, number> &temp_lin_val,
+    const FECellIntegrator<dim, 1, number> &ls_heaviside_val,
+    const unsigned int                      q_index) const
+  {
+    if (!with_solidification && !with_two_phase)
+      return;
+
+    VectorizedArray<number> liq_capacity     = material.second.capacity;
+    VectorizedArray<number> liq_conductivity = material.second.conductivity;
+    VectorizedArray<number> liq_density      = material.second.density;
+
+    if (with_two_phase)
+      {
+        get_material_parameters_with_two_phase_flow(liq_capacity,
+                                                    liq_conductivity,
+                                                    liq_density,
+                                                    ls_heaviside_val.get_value(q_index));
+        conductivity = liq_conductivity;
+        rho_cp       = liq_density * liq_capacity;
+      }
+
+    if (with_solidification)
+      {
+        VectorizedArray<number> capacity;
+        VectorizedArray<number> density;
+        const auto solid_fraction = calculate_solid_fraction(temp_lin_val.get_value(q_index));
+        get_material_parameters_with_solidification(capacity,
+                                                    conductivity,
+                                                    density,
+                                                    liq_capacity,
+                                                    liq_conductivity,
+                                                    liq_density,
+                                                    solid_fraction);
+        rho_cp = density * capacity;
+      }
+  }
+
+  template <int dim, typename number>
+  void
+  HeatTransferOperator<dim, number>::get_material_parameters_and_derivatives(
+    VectorizedArray<number> &               rho_cp,
+    VectorizedArray<number> &               conductivity,
+    VectorizedArray<number> &               d_rho_cp_dT,
+    VectorizedArray<number> &               d_conductivity_dT,
+    const bool                              with_solidification,
+    const bool                              with_two_phase,
+    const FECellIntegrator<dim, 1, number> &temp_lin_val,
+    const FECellIntegrator<dim, 1, number> &ls_heaviside_val,
+    const unsigned int                      q_index) const
+  {
+    if (!with_solidification && !with_two_phase)
+      return;
+
+    VectorizedArray<number> liq_capacity     = material.second.capacity;
+    VectorizedArray<number> liq_density      = material.second.density;
+    VectorizedArray<number> liq_conductivity = material.second.conductivity;
+
+    if (with_two_phase)
+      {
+        get_material_parameters_with_two_phase_flow(liq_capacity,
+                                                    liq_conductivity,
+                                                    liq_density,
+                                                    ls_heaviside_val.get_value(q_index));
+        conductivity = liq_conductivity;
+        rho_cp       = liq_density * liq_capacity;
+      }
+
+    if (with_solidification)
+      {
+        VectorizedArray<number> capacity;
+        VectorizedArray<number> density;
+        const auto solid_fraction = calculate_solid_fraction(temp_lin_val.get_value(q_index));
+        get_material_parameters_with_solidification(capacity,
+                                                    conductivity,
+                                                    density,
+                                                    liq_capacity,
+                                                    liq_conductivity,
+                                                    liq_density,
+                                                    solid_fraction);
+        rho_cp = density * capacity;
+        VectorizedArray<number> d_capacity_dT;
+        VectorizedArray<number> d_density_dT;
+        get_material_parameter_derivatives_with_solidification(d_capacity_dT,
+                                                               d_conductivity_dT,
+                                                               d_density_dT,
+                                                               liq_capacity,
+                                                               liq_conductivity,
+                                                               liq_density,
+                                                               solid_fraction);
+        d_rho_cp_dT = d_capacity_dT * density + d_density_dT * capacity;
+      }
+  }
+
+  template <int dim, typename number>
+  void
   HeatTransferOperator<dim, number>::get_material_parameters_with_solidification(
     VectorizedArray<number> &      capacity,
     VectorizedArray<number> &      conductivity,
     VectorizedArray<number> &      density,
-    const VectorizedArray<number> &current_temperature) const
+    const VectorizedArray<number> &liq_capacity,
+    const VectorizedArray<number> &liq_conductivity,
+    const VectorizedArray<number> &liq_density,
+    const VectorizedArray<number> &solid_fraction) const
   {
-    const auto solid_fraction = calculate_solid_fraction(current_temperature);
-
     if (solid_fraction == VectorizedArray<number>(0.0))
       {
-        capacity     = material.second.capacity;
-        conductivity = material.second.conductivity;
-        density      = material.second.density;
+        capacity     = liq_capacity;
+        conductivity = liq_conductivity;
+        density      = liq_density;
         return;
       }
+
     if (solid_fraction == VectorizedArray<number>(1.0))
       {
         capacity     = material.solid.capacity;
@@ -866,15 +937,13 @@ namespace MeltPoolDG::Heat
         return;
       }
 
-    capacity     = UtilityFunctions::interpolate_cubic(solid_fraction,
-                                                   material.second.capacity,
-                                                   material.solid.capacity);
+    capacity =
+      UtilityFunctions::interpolate_cubic(solid_fraction, liq_capacity, material.solid.capacity);
     conductivity = UtilityFunctions::interpolate_cubic(solid_fraction,
-                                                       material.second.conductivity,
+                                                       liq_conductivity,
                                                        material.solid.conductivity);
-    density      = UtilityFunctions::interpolate_cubic(solid_fraction,
-                                                  material.second.density,
-                                                  material.solid.density);
+    density =
+      UtilityFunctions::interpolate_cubic(solid_fraction, liq_density, material.solid.density);
   }
 
   template <int dim, typename number>
@@ -883,10 +952,11 @@ namespace MeltPoolDG::Heat
     VectorizedArray<number> &      d_capacity_dT,
     VectorizedArray<number> &      d_conductivity_dT,
     VectorizedArray<number> &      d_density_dT,
-    const VectorizedArray<number> &current_temperature) const
+    const VectorizedArray<number> &liq_capacity,
+    const VectorizedArray<number> &liq_conductivity,
+    const VectorizedArray<number> &liq_density,
+    const VectorizedArray<number> &solid_fraction) const
   {
-    const auto solid_fraction = calculate_solid_fraction(current_temperature);
-
     if (solid_fraction == VectorizedArray<number>(0.0) ||
         solid_fraction == VectorizedArray<number>(1.0))
       {
@@ -898,15 +968,15 @@ namespace MeltPoolDG::Heat
 
     d_capacity_dT = -1.0 * inv_mushy_interval *
                     UtilityFunctions::interpolate_cubic_derivative(solid_fraction,
-                                                                   material.second.capacity,
+                                                                   liq_capacity,
                                                                    material.solid.capacity);
     d_conductivity_dT = -1.0 * inv_mushy_interval *
                         UtilityFunctions::interpolate_cubic_derivative(solid_fraction,
-                                                                       material.second.conductivity,
+                                                                       liq_conductivity,
                                                                        material.solid.conductivity);
     d_density_dT = -1.0 * inv_mushy_interval *
                    UtilityFunctions::interpolate_cubic_derivative(solid_fraction,
-                                                                  material.second.density,
+                                                                  liq_density,
                                                                   material.solid.density);
   }
 

--- a/tests/unidirectional_heat_transfer_with_two_phase_and_solidification.json
+++ b/tests/unidirectional_heat_transfer_with_two_phase_and_solidification.json
@@ -1,0 +1,40 @@
+{
+  "base": {
+    "application name": "unidirectional_heat_transfer",
+    "degree": "1",
+    "dimension": "2",
+    "do simplex": "false",
+    "do print parameters": "false",
+    "global refinements": "5",
+    "problem name": "heat_transfer",
+    "verbosity level": "0"
+  },
+  "heat": {
+    "heat velocity": "0.0001",
+    "heat start time": "0.0",
+    "heat time step size": "1.0",
+    "heat end time": "100.0",
+    "heat max n steps": "5",
+    "heat two phase": "true",
+    "heat solidification": "true",
+    "heat solver rel tolerance": "1e-12",
+    "heat solver preconditioner type": "ILU",
+    "heat nlsolve residual tolerance": "1e-7"
+  },
+  "material": {
+    "material first capacity": "230",
+    "material first conductivity": "27.7815",
+    "material first density": "3925",
+    "material second conductivity": "55.563",
+    "material second capacity": "460.0",
+    "material second density": "7850.0",
+    "material solid conductivity": "17.0",
+    "material solid capacity": "700.0",
+    "material solid density": "7850.0",
+    "material solidus temperature": "1966.0",
+    "material liquidus temperature": "1974.0"
+  },
+  "paraview": {
+    "paraview do output": "false"
+  }
+}

--- a/tests/unidirectional_heat_transfer_with_two_phase_and_solidification.output
+++ b/tests/unidirectional_heat_transfer_with_two_phase_and_solidification.output
@@ -1,0 +1,5 @@
+t= 1         Newton Raphson solver converged: ||solution|| = 1.96996e+02
+t= 2         Newton Raphson solver converged: ||solution|| = 1.96992e+02
+t= 3         Newton Raphson solver converged: ||solution|| = 1.96987e+02
+t= 4         Newton Raphson solver converged: ||solution|| = 1.96983e+02
+t= 5         Newton Raphson solver converged: ||solution|| = 1.96979e+02


### PR DESCRIPTION
This PR enables heat transfer with solidification and two-phase flow. 

The liquid's material are determined with the level-set function. On top of that, the solidification material parameters are determined consistently. I.e. if the temperature is below the liquidus temperature the liquid's parameters are interpolated with the solid's material parameters. If the temperature is below the solidus temperature, the material parameters equal the solid's material parameters regardless of the level-set.

In the heat_transfer_operator the material parameters can be determined with the new `get_material_parameters()`. The tangent cell loop required the temperature derivatives of the material parameters too, so there is `get_material_parameters_and_derivatives()` that determines the derivatives in an efficient manner. 

Since density and capacity are only used in as a product in the heat equation, they are now combined to `rho_cp`.

The new test case `unidirectional_heat_transfer_with_two_phase_and_solidification` is a simple 1D simulation with a prescribed velocity field and a prescribed level-set filed that is transported with that velocity. 