### PR TITLE
Melt front propagation

### DIFF
--- a/include/meltpooldg/heat/laser_heat_source_gusarov.hpp
+++ b/include/meltpooldg/heat/laser_heat_source_gusarov.hpp
@@ -39,7 +39,6 @@ namespace MeltPoolDG::Heat
   private:
     using VectorType = LinearAlgebra::distributed::Vector<double>;
 
-    const ScratchData<dim> &scratch_data;
     /*
      *  Parameters for the Gusarov model
      */
@@ -47,37 +46,37 @@ namespace MeltPoolDG::Heat
 
     const double lambda; // optical thickness (-)
 
-    const unsigned int temp_dof_idx;
-
   public:
-    LaserHeatSourceGusarov(const ScratchData<dim> &       scratch_data_in,
-                           LaserData<double>::GusarovData gusarov_data_in,
-                           unsigned int                   temp_dof_idx_in);
+    LaserHeatSourceGusarov(const LaserData<double>::GusarovData &gusarov_data_in);
 
     void
-    compute_volumetric_heat_source(VectorType &      heat_source_vector,
-                                   double            laser_power,
-                                   const Point<dim> &laser_position,
-                                   bool              zero_out = true);
-
-  private:
-    /**
-     * Equation (26) corrected to match Figure 5 of Gusarov et al. (2009)
-     */
-    double
-    power_density(double radius, double power);
-
-    /**
-     * Analytical derivative of equation (20)
-     */
-    double
-    dq_dxi(double xi);
+    compute_volumetric_heat_source(VectorType &            heat_source_vector,
+                                   const ScratchData<dim> &scratch_data,
+                                   unsigned int            temp_dof_idx,
+                                   double                  laser_power,
+                                   const Point<dim> &      laser_position,
+                                   bool                    zero_out = true);
 
     /**
      * volumetric heat source; The z-axis (= axis of the laser beam) is assumed to correspond to
      * negative dim-1 coordinate.
      */
     double
-    local_heat_source(const Point<dim> &position, const Point<dim> &laser_position, double power);
+    get_local_heat_source(const Point<dim> &position,
+                          const Point<dim> &laser_position,
+                          double            power) const;
+
+  private:
+    /**
+     * Equation (26) corrected to match Figure 5 of Gusarov et al. (2009)
+     */
+    double
+    power_density(double radius, double power) const;
+
+    /**
+     * Analytical derivative of equation (20)
+     */
+    double
+    dq_dxi(double xi) const;
   };
 } // namespace MeltPoolDG::Heat

--- a/include/meltpooldg/heat/laser_heat_source_gusarov.hpp
+++ b/include/meltpooldg/heat/laser_heat_source_gusarov.hpp
@@ -49,6 +49,9 @@ namespace MeltPoolDG::Heat
   public:
     LaserHeatSourceGusarov(const LaserData<double>::GusarovData &gusarov_data_in);
 
+    /**
+     * Compute a DoF vector of the heat source from the Gusarov laser model.
+     */
     void
     compute_volumetric_heat_source(VectorType &            heat_source_vector,
                                    const ScratchData<dim> &scratch_data,
@@ -62,9 +65,9 @@ namespace MeltPoolDG::Heat
      * negative dim-1 coordinate.
      */
     double
-    get_local_heat_source(const Point<dim> &position,
-                          const Point<dim> &laser_position,
-                          double            power) const;
+    local_compute_volumetric_heat_source(const Point<dim> &position,
+                                         const Point<dim> &laser_position,
+                                         double            power) const;
 
   private:
     /**
@@ -74,9 +77,12 @@ namespace MeltPoolDG::Heat
     power_density(double radius, double power) const;
 
     /**
-     * Analytical derivative of equation (20)
+     * Analytical derivative of equation (20) of Gusarov et al. (2009)
      */
     double
     dq_dxi(double xi) const;
+
+    const double a;
+    const double D;
   };
 } // namespace MeltPoolDG::Heat

--- a/include/meltpooldg/interface/fieldconditions.hpp
+++ b/include/meltpooldg/interface/fieldconditions.hpp
@@ -10,6 +10,7 @@ namespace MeltPoolDG
   struct FieldConditions
   {
     std::shared_ptr<Function<dim>> initial_field;
+    std::shared_ptr<Function<dim>> source_field;
     std::shared_ptr<Function<dim>> advection_field;
     std::shared_ptr<Function<dim>> velocity_field;
     std::shared_ptr<Function<dim>> exact_solution_field;

--- a/include/meltpooldg/interface/parameters.hpp
+++ b/include/meltpooldg/interface/parameters.hpp
@@ -172,13 +172,13 @@ namespace MeltPoolDG
     bool        do_move                            = false;
     number      scan_speed                         = 0.0;
     bool        variable_properties_over_interface = false;
-    std::string heat_source_model                  = "Gusarov"; //@todo user input
+    std::string heat_source_model                  = "Gusarov";
     struct GusarovData
     {
-      number laser_beam_radius      = 0.0; // R      //@todo user input
-      number reflectivity           = 0.0; // rho     //@todo user input
-      number extinction_coefficient = 0.0; // beta    //@todo user input
-      number layer_thickness        = 0.0; // L       //@todo user input
+      number laser_beam_radius      = 0.0; // R
+      number reflectivity           = 0.0; // rho
+      number extinction_coefficient = 0.0; // beta
+      number layer_thickness        = 0.0; // L
     } gusarov;
   };
 

--- a/include/meltpooldg/interface/simulationbase.hpp
+++ b/include/meltpooldg/interface/simulationbase.hpp
@@ -90,6 +90,17 @@ namespace MeltPoolDG
 
     template <typename FunctionType>
     void
+    attach_source_field(std::shared_ptr<FunctionType> source_function,
+                        const std::string             operation_name)
+    {
+      if (!field_conditions_map[operation_name])
+        field_conditions_map[operation_name] = std::make_shared<FieldConditions<dim>>();
+
+      field_conditions_map[operation_name]->source_field = source_function;
+    }
+
+    template <typename FunctionType>
+    void
     attach_advection_field(std::shared_ptr<FunctionType> advection_velocity,
                            const std::string             operation_name)
     {
@@ -290,6 +301,12 @@ namespace MeltPoolDG
     get_initial_condition(const std::string operation_name)
     {
       return field_conditions_map[operation_name]->initial_field;
+    }
+
+    const std::shared_ptr<Function<dim>> &
+    get_source_field(const std::string operation_name)
+    {
+      return field_conditions_map[operation_name]->source_field;
     }
 
     const std::shared_ptr<Function<dim>> &

--- a/include/meltpooldg/simulations/melt_front_propagation/melt_front_propagation.hpp
+++ b/include/meltpooldg/simulations/melt_front_propagation/melt_front_propagation.hpp
@@ -1,0 +1,145 @@
+#pragma once
+// deal-specific libraries
+#include <deal.II/base/function.h>
+#include <deal.II/base/point.h>
+
+#include <deal.II/grid/grid_generator.h>
+// c++
+#include <cmath>
+#include <iostream>
+// MeltPoolDG
+#include <meltpooldg/heat/laser_heat_source_gusarov.hpp>
+#include <meltpooldg/interface/simulationbase.hpp>
+#include <meltpooldg/utilities/distance_functions.hpp>
+
+/**
+ * This simulation represents simple test examples for heat transfer with melt front propagation.
+ * The problem is inspired by the Proell et al. [1] single track scan example.
+ *
+ * The slap has properties of Ti-6Al-4V and starts of below the solidus temperature and is subjected
+ * to a Gusarov laser heat source [2] at x = 0.
+ *
+ * [1] Proell, S. D., Wall, W. A., & Meier, C. (2019). On phase change and latent heat models in
+ * metal additive manufacturing process simulation. Advanced Modeling and Simulation in Engineering
+ * Sciences, 7(1), 1-32. http://arxiv.org/abs/1906.06238
+ *
+ * [2] Gusarov, A. V., Yadroitsev, I., Bertrand, P., & Smurov, I. (2009). Model of Radiation and
+ * Heat Transfer in Laser-Powder Interaction Zone at Selective Laser Melting. Journal of Heat
+ * Transfer, 131(7), 1-10. https://doi.org/10.1115/1.3109245
+ */
+
+namespace MeltPoolDG::Simulation::MeltFrontPropagation
+{
+  using namespace dealii;
+  using namespace MeltPoolDG::Simulation;
+
+  static constexpr double x_max = 0.6e-3;
+  static constexpr double y_max = 0.2e-3;
+  static constexpr double z_max = 0.2e-3;
+
+  static constexpr double T_0 = 1000.0;
+
+  template <int dim>
+  class LaserHeatSource : public Function<dim>
+  {
+  public:
+    LaserHeatSource(const LaserData<double> &laser_data)
+      : Function<dim>()
+      , laser(laser_data.gusarov)
+      , center(MeltPoolDG::UtilityFunctions::convert_string_coords_to_point<dim>(laser_data.center))
+      , power(laser_data.power)
+
+    {}
+
+    double
+    value(const Point<dim> &p, const unsigned int /*component*/) const
+    {
+      return laser.get_local_heat_source(p, center, power);
+    }
+
+  private:
+    Heat::LaserHeatSourceGusarov<dim> laser;
+    Point<dim>                        center;
+    const double                      power;
+  };
+
+  template <int dim>
+  class SimulationMeltFrontPropagation : public SimulationBase<dim>
+  {
+  public:
+    SimulationMeltFrontPropagation(std::string parameter_file, const MPI_Comm mpi_communicator)
+      : SimulationBase<dim>(parameter_file, mpi_communicator)
+    {
+      this->set_parameters();
+    }
+
+    void
+    create_spatial_discretization() override
+    {
+      if constexpr (dim == 1)
+        {
+          this->triangulation = std::make_shared<Triangulation<1>>();
+          // create mesh
+          const Point<1> left(0);
+          const Point<1> right(x_max);
+          GridGenerator::hyper_rectangle(*this->triangulation, left, right);
+          this->triangulation->refine_global(this->parameters.base.global_refinements);
+        }
+      else if constexpr (dim == 2)
+        {
+          this->triangulation =
+            std::make_shared<parallel::distributed::Triangulation<2>>(this->mpi_communicator);
+          std::vector<unsigned> refinements(2, 1);
+          refinements[0] = 3;
+          // create mesh
+          const Point<2> left(0, 0);
+          const Point<2> right(x_max, y_max);
+          GridGenerator::subdivided_hyper_rectangle(*this->triangulation, refinements, left, right);
+          this->triangulation->refine_global(this->parameters.base.global_refinements);
+        }
+      else if constexpr (dim == 3)
+        {
+          this->triangulation =
+            std::make_shared<parallel::distributed::Triangulation<3>>(this->mpi_communicator);
+          std::vector<unsigned int> refinements(3, 1);
+          refinements[0] = 3;
+          refinements[1] = 3;
+          // create mesh
+          const Point<3> left(0, 0, 0);
+          const Point<3> right(x_max, y_max, z_max);
+          GridGenerator::subdivided_hyper_rectangle(*this->triangulation, refinements, left, right);
+          this->triangulation->refine_global(this->parameters.base.global_refinements);
+        }
+      else
+        AssertThrow(false, ExcMessage("Impossible dimension! Abort ..."));
+    }
+
+    void
+    set_boundary_conditions() final
+    {
+      const types::boundary_id left_bc = 10;
+
+      for (const auto &cell : this->triangulation->cell_iterators())
+        {
+          for (auto &face : cell->face_iterators())
+            if (face->at_boundary())
+              {
+                if (face->center()[0] == x_max)
+                  face->set_boundary_id(left_bc);
+              }
+        }
+
+      this->attach_dirichlet_boundary_condition(
+        left_bc, std::make_shared<Functions::ConstantFunction<dim>>(T_0), "heat_transfer");
+    }
+
+    void
+    set_field_conditions() final
+    {
+      this->attach_initial_condition(std::make_shared<Functions::ConstantFunction<dim>>(T_0),
+                                     "heat_transfer");
+      this->attach_source_field(std::make_shared<LaserHeatSource<dim>>(this->parameters.laser),
+                                "heat_transfer");
+    }
+  };
+} // namespace MeltPoolDG::Simulation::MeltFrontPropagation

--- a/include/meltpooldg/simulations/melt_front_propagation/melt_front_propagation.hpp
+++ b/include/meltpooldg/simulations/melt_front_propagation/melt_front_propagation.hpp
@@ -16,7 +16,7 @@
  * This simulation represents simple test examples for heat transfer with melt front propagation.
  * The problem is inspired by the Proell et al. [1] single track scan example.
  *
- * The slap has properties of Ti-6Al-4V and starts of below the solidus temperature and is subjected
+ * The slab has properties of Ti-6Al-4V, is initially below the solidus temperature and is subjected
  * to a Gusarov laser heat source [2] at x = 0.
  *
  * [1] Proell, S. D., Wall, W. A., & Meier, C. (2019). On phase change and latent heat models in
@@ -54,7 +54,7 @@ namespace MeltPoolDG::Simulation::MeltFrontPropagation
     double
     value(const Point<dim> &p, const unsigned int /*component*/) const
     {
-      return laser.get_local_heat_source(p, center, power);
+      return laser.local_compute_volumetric_heat_source(p, center, power);
     }
 
   private:
@@ -78,7 +78,11 @@ namespace MeltPoolDG::Simulation::MeltFrontPropagation
     {
       if constexpr (dim == 1)
         {
-          this->triangulation = std::make_shared<Triangulation<1>>();
+          this->triangulation = std::make_shared<parallel::shared::Triangulation<1>>(
+            this->mpi_communicator,
+            (Triangulation<dim>::none),
+            false,
+            parallel::shared::Triangulation<dim>::Settings::partition_metis);
           // create mesh
           const Point<1> left(0);
           const Point<1> right(x_max);

--- a/include/meltpooldg/simulations/melt_front_propagation/melt_front_propagation_static_gusarov.json
+++ b/include/meltpooldg/simulations/melt_front_propagation/melt_front_propagation_static_gusarov.json
@@ -1,0 +1,46 @@
+{
+  "base": {
+    "application name": "melt_front_propagation",
+    "degree": "1",
+    "dimension": "2",
+    "do print parameters": "false",
+    "global refinements": "5",
+    "problem name": "heat_transfer",
+    "verbosity level": "2"
+  },
+  "heat": {
+    "heat start time": "0.0",
+    "heat time step size": "5e-6",
+    "heat end time": "0.015",
+    "heat max n steps": "3000",
+    "heat solidification": "true",
+    "heat solver rel tolerance": "1e-12",
+    "heat solver preconditioner type": "ILU",
+    "heat nlsolve residual tolerance": "1e-8"
+  },
+  "laser": {
+    "laser power": "30.",
+    "laser center": "0.0,0.0",
+    "laser do move": "false",
+    "laser heat source model": "Gusarov",
+    "laser gusarov laser beam radius": "0.06e-3",
+    "laser gusarov reflectivity": "0.7",
+    "laser gusarov extinction coefficient": "60.0e3",
+    "laser gusarov layer thickness": "0.05e-3"
+  },
+  "material": {
+    "material second conductivity": "55.563",
+    "material second capacity": "460.0",
+    "material second density": "7850.0",
+    "material solid conductivity": "17.0",
+    "material solid capacity": "700.0",
+    "material solid density": "7850.0",
+    "material solidus temperature": "1966.0",
+    "material liquidus temperature": "1974.0"
+  },
+  "paraview": {
+    "paraview do output": "true",
+    "paraview directory": "output",
+    "paraview filename": "melt_front_propagation_static_gusarov"
+  }
+}

--- a/source/heat/heat_transfer_problem.cpp
+++ b/source/heat/heat_transfer_problem.cpp
@@ -29,10 +29,15 @@ namespace MeltPoolDG::Heat
         scratch_data->get_pcout() << "t= " << std::setw(10) << std::left
                                   << time_iterator.get_current_time();
 
-        if (base_in->parameters.heat.velocity != 0.0)
-          compute_field_vector(velocity,
-                               velocity_dof_idx,
-                               *base_in->get_velocity_field("heat_transfer"));
+        const auto source_field_function = base_in->get_source_field("heat_transfer");
+        if (source_field_function)
+          compute_field_vector(heat_operation->get_heat_source(),
+                               temp_dof_idx,
+                               *source_field_function);
+
+        const auto velocity_field_function = base_in->get_velocity_field("heat_transfer");
+        if (velocity_field_function)
+          compute_field_vector(velocity, velocity_dof_idx, *velocity_field_function);
 
         if (base_in->parameters.heat.two_phase)
           compute_field_vector(level_set_as_heaviside,

--- a/source/heat/heat_transfer_problem.cpp
+++ b/source/heat/heat_transfer_problem.cpp
@@ -29,14 +29,12 @@ namespace MeltPoolDG::Heat
         scratch_data->get_pcout() << "t= " << std::setw(10) << std::left
                                   << time_iterator.get_current_time();
 
-        const auto source_field_function = base_in->get_source_field("heat_transfer");
-        if (source_field_function)
+        if (const auto source_field_function = base_in->get_source_field("heat_transfer"))
           compute_field_vector(heat_operation->get_heat_source(),
                                temp_dof_idx,
                                *source_field_function);
 
-        const auto velocity_field_function = base_in->get_velocity_field("heat_transfer");
-        if (velocity_field_function)
+        if (const auto velocity_field_function = base_in->get_velocity_field("heat_transfer"))
           compute_field_vector(velocity, velocity_dof_idx, *velocity_field_function);
 
         if (base_in->parameters.heat.two_phase)

--- a/source/heat/laser_heat_source_gusarov.cpp
+++ b/source/heat/laser_heat_source_gusarov.cpp
@@ -7,6 +7,9 @@ namespace MeltPoolDG::Heat
     const LaserData<double>::GusarovData &gusarov_data_in)
     : gusarov_data(gusarov_data_in)
     , lambda(gusarov_data.extinction_coefficient * gusarov_data.layer_thickness)
+    , a(std::sqrt(1. - gusarov_data.reflectivity))
+    , D((1. - a) * (1. - a - gusarov_data.reflectivity * (1. + a)) * std::exp(-2. * a * lambda) -
+        (1. + a) * (1. + a - gusarov_data.reflectivity * (1. - a)) * std::exp(2. * a * lambda))
   {}
 
   template <int dim>
@@ -42,18 +45,19 @@ namespace MeltPoolDG::Heat
 
             for (const auto q : heat_source_eval.quadrature_point_indices())
               heat_source_vector[local_dof_indices[q]] =
-                get_local_heat_source(heat_source_eval.quadrature_point(q),
-                                      laser_position,
-                                      laser_power);
+                local_compute_volumetric_heat_source(heat_source_eval.quadrature_point(q),
+                                                     laser_position,
+                                                     laser_power);
           }
       }
   }
 
   template <int dim>
   double
-  LaserHeatSourceGusarov<dim>::get_local_heat_source(const Point<dim> &position,
-                                                     const Point<dim> &laser_position,
-                                                     double            power) const
+  LaserHeatSourceGusarov<dim>::local_compute_volumetric_heat_source(
+    const Point<dim> &position,
+    const Point<dim> &laser_position,
+    double            power) const
   {
     const double radius = position.distance(laser_position);
     const double z      = -(position[dim - 1] - laser_position[dim - 1]);
@@ -79,10 +83,6 @@ namespace MeltPoolDG::Heat
   LaserHeatSourceGusarov<dim>::dq_dxi(const double xi) const
   {
     const double &rho = gusarov_data.reflectivity;
-    const double  a   = std::sqrt(1 - rho);
-
-    const double D = (1 - a) * (1 - a - rho * (1 + a)) * std::exp(-2 * a * lambda) -
-                     (1 + a) * (1 + a - rho * (1 - a)) * std::exp(2 * a * lambda);
 
     // clang-format off
     return xi < lambda ?

--- a/source/heat/laser_heat_source_gusarov.cpp
+++ b/source/heat/laser_heat_source_gusarov.cpp
@@ -4,19 +4,17 @@ namespace MeltPoolDG::Heat
 {
   template <int dim>
   LaserHeatSourceGusarov<dim>::LaserHeatSourceGusarov(
-    const ScratchData<dim> &             scratch_data_in,
-    const LaserData<double>::GusarovData gusarov_data_in,
-    unsigned int                         temp_dof_idx_in)
-    : scratch_data(scratch_data_in)
-    , gusarov_data(gusarov_data_in)
+    const LaserData<double>::GusarovData &gusarov_data_in)
+    : gusarov_data(gusarov_data_in)
     , lambda(gusarov_data.extinction_coefficient * gusarov_data.layer_thickness)
-    , temp_dof_idx(temp_dof_idx_in)
   {}
 
   template <int dim>
   void
-  LaserHeatSourceGusarov<dim>::compute_volumetric_heat_source(VectorType &      heat_source_vector,
-                                                              const double      laser_power,
+  LaserHeatSourceGusarov<dim>::compute_volumetric_heat_source(VectorType &heat_source_vector,
+                                                              const ScratchData<dim> &scratch_data,
+                                                              const unsigned int      temp_dof_idx,
+                                                              const double            laser_power,
                                                               const Point<dim> &laser_position,
                                                               bool              zero_out)
   {
@@ -44,16 +42,31 @@ namespace MeltPoolDG::Heat
 
             for (const auto q : heat_source_eval.quadrature_point_indices())
               heat_source_vector[local_dof_indices[q]] =
-                local_heat_source(heat_source_eval.quadrature_point(q),
-                                  laser_position,
-                                  laser_power);
+                get_local_heat_source(heat_source_eval.quadrature_point(q),
+                                      laser_position,
+                                      laser_power);
           }
       }
   }
 
   template <int dim>
   double
-  LaserHeatSourceGusarov<dim>::power_density(const double radius, const double power)
+  LaserHeatSourceGusarov<dim>::get_local_heat_source(const Point<dim> &position,
+                                                     const Point<dim> &laser_position,
+                                                     double            power) const
+  {
+    const double radius = position.distance(laser_position);
+    const double z      = -(position[dim - 1] - laser_position[dim - 1]);
+    const double xi     = z * gusarov_data.extinction_coefficient;
+
+    return (z >= gusarov_data.layer_thickness) || (z < laser_position[dim - 1]) ?
+             0. :
+             -gusarov_data.extinction_coefficient * power_density(radius, power) * dq_dxi(xi);
+  }
+
+  template <int dim>
+  double
+  LaserHeatSourceGusarov<dim>::power_density(const double radius, const double power) const
   {
     const double &R = gusarov_data.laser_beam_radius;
     return radius <= R ? 3. * power / (numbers::PI * R * R) * std::pow(1. - radius / R, 2) *
@@ -63,7 +76,7 @@ namespace MeltPoolDG::Heat
 
   template <int dim>
   double
-  LaserHeatSourceGusarov<dim>::dq_dxi(const double xi)
+  LaserHeatSourceGusarov<dim>::dq_dxi(const double xi) const
   {
     const double &rho = gusarov_data.reflectivity;
     const double  a   = std::sqrt(1 - rho);
@@ -91,21 +104,6 @@ namespace MeltPoolDG::Heat
            ) :
            0.0;
     // clang-format on
-  }
-
-  template <int dim>
-  double
-  LaserHeatSourceGusarov<dim>::local_heat_source(const Point<dim> &position,
-                                                 const Point<dim> &laser_position,
-                                                 const double      power)
-  {
-    const double radius = position.distance(laser_position);
-    const double z      = -(position[dim - 1] - laser_position[dim - 1]);
-    const double xi     = z * gusarov_data.extinction_coefficient;
-
-    return (z >= gusarov_data.layer_thickness) || (z < laser_position[dim - 1]) ?
-             0. :
-             -gusarov_data.extinction_coefficient * power_density(radius, power) * dq_dxi(xi);
   }
 
   template class LaserHeatSourceGusarov<1>;

--- a/source/interface/parameters.cpp
+++ b/source/interface/parameters.cpp
@@ -585,6 +585,22 @@ namespace MeltPoolDG
         laser.do_move,
         "Set this parameter to true to move the laser in x-direction with the given parameter scan speed "
         "(in case of an analytical temperature field).");
+      prm.add_parameter("laser heat source model",
+                        laser.heat_source_model,
+                        "Laser heat source model.",
+                        Patterns::Selection("Gusarov"));
+      prm.add_parameter("laser gusarov laser beam radius",
+                        laser.gusarov.laser_beam_radius,
+                        "Laser beam radius.");
+      prm.add_parameter("laser gusarov reflectivity",
+                        laser.gusarov.reflectivity,
+                        "Reflectivity of the material.");
+      prm.add_parameter("laser gusarov extinction coefficient",
+                        laser.gusarov.extinction_coefficient,
+                        "Extinction coefficient in [1/m].");
+      prm.add_parameter("laser gusarov layer thickness",
+                        laser.gusarov.layer_thickness,
+                        "Layer thickness");
     }
     prm.leave_subsection();
     /*

--- a/source/melt_pool/melt_pool_operation.cpp
+++ b/source/melt_pool/melt_pool_operation.cpp
@@ -75,9 +75,7 @@ namespace MeltPoolDG::MeltPool
         if (data_in.laser.heat_source_model == "Gusarov")
           {
             laser_heat_source_operation =
-              std::make_shared<Heat::LaserHeatSourceGusarov<dim>>(*scratch_data,
-                                                                  data_in.laser.gusarov,
-                                                                  temp_dof_idx);
+              std::make_shared<Heat::LaserHeatSourceGusarov<dim>>(data_in.laser.gusarov);
           }
         else
           AssertThrow(false,
@@ -139,6 +137,8 @@ namespace MeltPoolDG::MeltPool
         // @todo: support other heat source models
         laser_heat_source_operation->compute_volumetric_heat_source(
           heat_operation->get_heat_source(),
+          *scratch_data,
+          temp_dof_idx,
           laser_operation->get_laser_power(),
           laser_operation->get_laser_position(),
           true /* zero_out */);

--- a/source/simulations/simulation_selector.cpp
+++ b/source/simulations/simulation_selector.cpp
@@ -11,6 +11,7 @@
 #include <meltpooldg/simulations/evaporating_droplet/evaporating_droplet_with_heat.hpp>
 #include <meltpooldg/simulations/film_boiling/film_boiling.hpp>
 #include <meltpooldg/simulations/flow_past_cylinder/flow_past_cylinder.hpp>
+#include <meltpooldg/simulations/melt_front_propagation/melt_front_propagation.hpp>
 #include <meltpooldg/simulations/recoil_pressure/recoil_pressure.hpp>
 #include <meltpooldg/simulations/reinit_circle/reinit_circle.hpp>
 #include <meltpooldg/simulations/rising_bubble/rising_bubble.hpp>
@@ -105,6 +106,9 @@ namespace MeltPoolDG::Simulation
     else if (simulation_name == "film_boiling")
       return std::make_shared<FilmBoiling::SimulationFilmBoiling<dim>>(parameter_file,
                                                                        mpi_communicator);
+    else if (simulation_name == "melt_front_propagation")
+      return std::make_shared<MeltFrontPropagation::SimulationMeltFrontPropagation<dim>>(
+        parameter_file, mpi_communicator);
 
     /* add your simulation here*/
     else

--- a/tests/melt_front_propagation_static_gusarov.json
+++ b/tests/melt_front_propagation_static_gusarov.json
@@ -1,0 +1,44 @@
+{
+  "base": {
+    "application name": "melt_front_propagation",
+    "degree": "1",
+    "dimension": "2",
+    "do print parameters": "false",
+    "global refinements": "5",
+    "problem name": "heat_transfer",
+    "verbosity level": "0"
+  },
+  "heat": {
+    "heat start time": "0.0",
+    "heat time step size": "5e-6",
+    "heat end time": "0.015",
+    "heat max n steps": "5",
+    "heat solidification": "true",
+    "heat solver rel tolerance": "1e-12",
+    "heat solver preconditioner type": "ILU",
+    "heat nlsolve residual tolerance": "1e-8"
+  },
+  "laser": {
+    "laser power": "30.",
+    "laser center": "0.0,0.0",
+    "laser do move": "false",
+    "laser heat source model": "Gusarov",
+    "laser gusarov laser beam radius": "0.06e-3",
+    "laser gusarov reflectivity": "0.7",
+    "laser gusarov extinction coefficient": "60.0e3",
+    "laser gusarov layer thickness": "0.05e-3"
+  },
+  "material": {
+    "material second conductivity": "55.563",
+    "material second capacity": "460.0",
+    "material second density": "7850.0",
+    "material solid conductivity": "17.0",
+    "material solid capacity": "700.0",
+    "material solid density": "7850.0",
+    "material solidus temperature": "1966.0",
+    "material liquidus temperature": "1974.0"
+  },
+  "paraview": {
+    "paraview do output": "false"
+  }
+}

--- a/tests/melt_front_propagation_static_gusarov.mpirun=4.output
+++ b/tests/melt_front_propagation_static_gusarov.mpirun=4.output
@@ -1,0 +1,5 @@
+t= 5e-06     Newton Raphson solver converged: ||solution|| = 3.46465e-01
+t= 1e-05     Newton Raphson solver converged: ||solution|| = 3.46522e-01
+t= 1.5e-05   Newton Raphson solver converged: ||solution|| = 3.46580e-01
+t= 2e-05     Newton Raphson solver converged: ||solution|| = 3.46639e-01
+t= 2.5e-05   Newton Raphson solver converged: ||solution|| = 3.46698e-01


### PR DESCRIPTION
This PR adds a simple melt front propagation simulation example: A solid piece of metal is heated with a laser heat source and melts. The solid and liquid phases have different thermal properties.
![Screenshot from 2021-05-26 10-24-34](https://user-images.githubusercontent.com/75663764/119629318-343a7d00-be0e-11eb-920c-ac39f2ab8109.png)

A couple of changes come with this addition:
- add user input for Gusarov laser
- restructure `LaserHeatSourceGusarov` so it can be used in a `dealii::Function`
- add a source field function and compute heat source vector