### PR TITLE
Add simulation and test for melt front propagation with AMR

### DIFF
--- a/include/meltpooldg/simulations/melt_front_propagation/melt_front_propagation_static_gusarov_amr.json
+++ b/include/meltpooldg/simulations/melt_front_propagation/melt_front_propagation_static_gusarov_amr.json
@@ -1,0 +1,54 @@
+{
+  "base": {
+    "application name": "melt_front_propagation",
+    "degree": "1",
+    "dimension": "2",
+    "do print parameters": "false",
+    "global refinements": "4",
+    "problem name": "heat_transfer",
+    "verbosity level": "2"
+  },
+  "heat": {
+    "heat start time": "0.0",
+    "heat time step size": "5e-6",
+    "heat end time": "0.015",
+    "heat max n steps": "3000",
+    "heat solidification": "true",
+    "heat solver rel tolerance": "1e-12",
+    "heat solver preconditioner type": "ILU",
+    "heat nlsolve residual tolerance": "1e-8"
+  },
+  "laser": {
+    "laser power": "30.",
+    "laser center": "0.0,0.0",
+    "laser do move": "false",
+    "laser heat source model": "Gusarov",
+    "laser gusarov laser beam radius": "0.06e-3",
+    "laser gusarov reflectivity": "0.7",
+    "laser gusarov extinction coefficient": "60.0e3",
+    "laser gusarov layer thickness": "0.05e-3"
+  },
+  "material": {
+    "material second conductivity": "55.563",
+    "material second capacity": "460.0",
+    "material second density": "7850.0",
+    "material solid conductivity": "17.0",
+    "material solid capacity": "700.0",
+    "material solid density": "7850.0",
+    "material solidus temperature": "1966.0",
+    "material liquidus temperature": "1974.0"
+  },
+  "adaptive meshing": {
+    "do amr": "true",
+    "do not modify boundary cells": "false",
+    "upper perc to refine": " 0.1",
+    "lower perc to coarsen": "0.1",
+    "max grid refinement level": "6",
+    "every n step": "1"
+  },
+  "paraview": {
+    "paraview do output": "true",
+    "paraview directory": "output_amr",
+    "paraview filename": "melt_front_propagation_static_gusarov"
+  }
+}

--- a/tests/melt_front_propagation_static_gusarov_amr.json
+++ b/tests/melt_front_propagation_static_gusarov_amr.json
@@ -1,0 +1,52 @@
+{
+  "base": {
+    "application name": "melt_front_propagation",
+    "degree": "1",
+    "dimension": "2",
+    "do print parameters": "false",
+    "global refinements": "4",
+    "problem name": "heat_transfer",
+    "verbosity level": "0"
+  },
+  "heat": {
+    "heat start time": "0.0",
+    "heat time step size": "5e-6",
+    "heat end time": "0.015",
+    "heat max n steps": "5",
+    "heat solidification": "true",
+    "heat solver rel tolerance": "1e-12",
+    "heat solver preconditioner type": "ILU",
+    "heat nlsolve residual tolerance": "1e-8"
+  },
+  "laser": {
+    "laser power": "30.",
+    "laser center": "0.0,0.0",
+    "laser do move": "false",
+    "laser heat source model": "Gusarov",
+    "laser gusarov laser beam radius": "0.06e-3",
+    "laser gusarov reflectivity": "0.7",
+    "laser gusarov extinction coefficient": "60.0e3",
+    "laser gusarov layer thickness": "0.05e-3"
+  },
+  "material": {
+    "material second conductivity": "55.563",
+    "material second capacity": "460.0",
+    "material second density": "7850.0",
+    "material solid conductivity": "17.0",
+    "material solid capacity": "700.0",
+    "material solid density": "7850.0",
+    "material solidus temperature": "1966.0",
+    "material liquidus temperature": "1974.0"
+  },
+  "adaptive meshing": {
+    "do amr": "true",
+    "do not modify boundary cells": "false",
+    "upper perc to refine": " 0.1",
+    "lower perc to coarsen": "0.1",
+    "max grid refinement level": "6",
+    "every n step": "1"
+  },
+  "paraview": {
+    "paraview do output": "false"
+  }
+}

--- a/tests/melt_front_propagation_static_gusarov_amr.mpirun=4.output
+++ b/tests/melt_front_propagation_static_gusarov_amr.mpirun=4.output
@@ -1,0 +1,5 @@
+t= 5e-06     Newton Raphson solver converged: ||solution|| = 3.46522e-01
+t= 1e-05     Newton Raphson solver converged: ||solution|| = 3.46580e-01
+t= 1.5e-05   Newton Raphson solver converged: ||solution|| = 3.46608e-01
+t= 2e-05     Newton Raphson solver converged: ||solution|| = 3.46637e-01
+t= 2.5e-05   Newton Raphson solver converged: ||solution|| = 3.46666e-01


### PR DESCRIPTION
Since I already worked on this we can benefit from the test case. #201, #203
![animation_amr](https://user-images.githubusercontent.com/75663764/119786742-c905af00-bed0-11eb-85fc-478391d11f43.gif)
