### PR TITLE
Evaporation model refactor

### DIFF
--- a/include/meltpooldg/evaporation/evaporation_model_base.hpp
+++ b/include/meltpooldg/evaporation/evaporation_model_base.hpp
@@ -7,9 +7,18 @@
 
 namespace MeltPoolDG::Evaporation
 {
+  /**
+   * Base class for implementing different models to compute the evaporative
+   * mass flux.
+   */
   class EvaporationModelBase
   {
   public:
+    /**
+     *                                                    .
+     * Base function to compute the evaporative mass flux m in kg/(m^2 s) for
+     * a given temperature value @p T.
+     */
     virtual double
     local_compute_evaporative_mass_flux(const double T) = 0;
   };

--- a/include/meltpooldg/evaporation/evaporation_model_base.hpp
+++ b/include/meltpooldg/evaporation/evaporation_model_base.hpp
@@ -1,0 +1,16 @@
+/* ---------------------------------------------------------------------
+ *
+ * Author: Magdalena Schreter, UIBK/TUM, January 2021
+ *
+ * ---------------------------------------------------------------------*/
+#pragma once
+
+namespace MeltPoolDG::Evaporation
+{
+  class EvaporationModelBase
+  {
+  public:
+    virtual double
+    local_compute_evaporative_mass_flux(const double T) = 0;
+  };
+} // namespace MeltPoolDG::Evaporation

--- a/include/meltpooldg/evaporation/evaporation_model_hardt_wondra.hpp
+++ b/include/meltpooldg/evaporation/evaporation_model_hardt_wondra.hpp
@@ -1,0 +1,67 @@
+/* ---------------------------------------------------------------------
+ *
+ * Author: Magdalena Schreter, UIBK/TUM, June 2021
+ *
+ * ---------------------------------------------------------------------*/
+#pragma once
+#include <meltpooldg/evaporation/evaporation_model_base.hpp>
+
+namespace MeltPoolDG::Evaporation
+{
+  /**
+   * This class implements the evaporative mass flux as presented in
+   *
+   * Hardt, S., & Wondra, F. (2008). Evaporation model for interfacial flows
+   * based on a continuum-field representation of the source terms.
+   * Journal of Computational Physics, 227(11), 5871-5895.
+   * DOI: 10.1016/j.jcp.2008.02.020
+   *
+   * It is derived from the Schrage's theory and incorporates a linear relationship
+   * between the evaporation heat or mass ﬂux and the temperature difference at the
+   * interface. It is valid in case of small deviations from equilibrium
+   *
+   * (T_i - T_v)/T_v << 1
+   *
+   * with T_i the interface temperature and T_v the boiling (saturation) temperature.
+   *
+   * The evaporative mass transfer coefficient according to Schrage's theory can be
+   * computed as
+   *
+   *            2χ_v    h_v    ρ_v
+   * α_v = -----------------------------
+   *                   _____        1.5
+   *        (2 - χ_v) √2πR_s  ( T_v )
+   *
+   * where χ_v is the evaporation coefficient, h_v (J/kg) the latent heat of evaporation,
+   * ρ_v the vapor density and R_s the specific gas constant (J/(kgK)). Marek and Schraub
+   * reported evaporation coefficients to be between 1e−3 and 1.
+   *
+   */
+  class EvaporationModelHardtWondra : public EvaporationModelBase
+  {
+  private:
+    const double evaporative_mass_transfer_coefficient;
+    const double boiling_temperature;
+
+  public:
+    EvaporationModelHardtWondra(const double evaporation_coefficient,
+                                const double latent_heat_of_evaporation,
+                                const double density_vapor,
+                                const double molar_mass_vapor,
+                                const double boiling_temperature);
+
+    EvaporationModelHardtWondra(const double evaporative_mass_transfer_coefficient,
+                                const double boiling_temperature);
+
+    /*
+     * According to Schrage's theory the evaporative mass flux at the interface is computed
+     * as follows
+     *  .
+     *  m = α_v < T - T_v >
+     *
+     *  with the evaporative mass transfer coefficient α_v  and the heaviside function <...>.
+     */
+    double
+    local_compute_evaporative_mass_flux(const double T) final;
+  };
+} // namespace MeltPoolDG::Evaporation

--- a/include/meltpooldg/evaporation/evaporation_model_recoil_pressure.hpp
+++ b/include/meltpooldg/evaporation/evaporation_model_recoil_pressure.hpp
@@ -1,0 +1,55 @@
+/* ---------------------------------------------------------------------
+ *
+ * Author: Magdalena Schreter, UIBK/TUM, June 2021
+ *
+ * ---------------------------------------------------------------------*/
+#pragma once
+#include <meltpooldg/evaporation/evaporation_model_base.hpp>
+
+namespace MeltPoolDG::Evaporation
+{
+  /**
+   * This class implements the evaporative mass flux computed from the
+   * recoil pressure as presented in, e.g.,
+   *
+   * S.A. Khairallah, A.T. Anderson, A. Rubenchik, W.E. King,
+   * Laser powder-bed fusion additive manufacturing: Physics of complex
+   * melt flow and formation mechanisms of pores, spatter, and denudation
+   * zones, Acta Mater. 108 (2016) 36–45.
+   * DOI: 10.1016/j.actamat.2016.02.014.
+   *
+   */
+  template <int dim>
+  class EvaporationModelRecoilPressure : public EvaporationModelBase
+  {
+  private:
+    const double boiling_temperature;
+    const double pressure_constant;
+    const double temperature_constant;
+    const double mass_flux_scale_factor;
+
+    // according to Meier 2020
+    const double cs = 1.0;  // sticking coefficient                 @todo introduce parameter
+    const double Cm = 1e-3; // molar_mass/(2*pi*molar_gas_constant) @todo introduce parameter
+
+  public:
+    EvaporationModelRecoilPressure(const double boiling_temperature,
+                                   const double pressure_constant,
+                                   const double temperature_constant,
+                                   const double mass_flux_scale_factor = 1.0);
+
+    /*
+     * The evaporative mass flux is computed as
+     *
+     *                                  ______
+     *                                 /  M
+     * .                              /-------
+     * m(T) = 0.82 · c_s  · p_r(T) · √  2πR T
+     *
+     * where c_s is the sticking coefficient, p_r(T) the recoil pressure,
+     * M the molar mass, R the molar gas constant and T the temperature.
+     */
+    double
+    local_compute_evaporative_mass_flux(const double T) final;
+  };
+} // namespace MeltPoolDG::Evaporation

--- a/include/meltpooldg/utilities/physical_constants.hpp
+++ b/include/meltpooldg/utilities/physical_constants.hpp
@@ -6,8 +6,6 @@
 #pragma once
 namespace MeltPoolDG::PhysicalConstants
 {
-  using namespace dealii;
-
   constexpr double universal_gas_constant    = 8.31446261815324; // J/(mol K)
   constexpr double stefan_boltzmann_constant = 5.670374419e-8;   // W/(m² K^4)
 } // namespace MeltPoolDG::PhysicalConstants

--- a/source/evaporation/evaporation_model_hardt_wondra.cpp
+++ b/source/evaporation/evaporation_model_hardt_wondra.cpp
@@ -1,0 +1,39 @@
+#include <deal.II/base/numbers.h>
+
+#include <meltpooldg/evaporation/evaporation_model_hardt_wondra.hpp>
+#include <meltpooldg/utilities/physical_constants.hpp>
+
+#include <cmath>
+
+namespace MeltPoolDG::Evaporation
+{
+  EvaporationModelHardtWondra::EvaporationModelHardtWondra(const double evaporation_coefficient,
+                                                           const double latent_heat_of_evaporation,
+                                                           const double density_vapor,
+                                                           const double molar_mass_vapor,
+                                                           const double boiling_temperature)
+    : evaporative_mass_transfer_coefficient(
+        2. * evaporation_coefficient * latent_heat_of_evaporation * density_vapor /
+        ((2. - evaporation_coefficient) *
+         std::sqrt(2. * dealii::numbers::PI * PhysicalConstants::universal_gas_constant /
+                   molar_mass_vapor) *
+         std::pow(boiling_temperature, 1.5)))
+    , boiling_temperature(boiling_temperature)
+  {}
+
+  EvaporationModelHardtWondra::EvaporationModelHardtWondra(
+    const double evaporative_mass_transfer_coefficient,
+    const double boiling_temperature)
+    : evaporative_mass_transfer_coefficient(evaporative_mass_transfer_coefficient)
+    , boiling_temperature(boiling_temperature)
+  {}
+
+  double
+  EvaporationModelHardtWondra::local_compute_evaporative_mass_flux(const double T)
+  {
+    return (T >= boiling_temperature) ?
+             evaporative_mass_transfer_coefficient * (T - boiling_temperature) :
+             0.0;
+  }
+
+} // namespace MeltPoolDG::Evaporation

--- a/source/evaporation/evaporation_model_recoil_pressure.cpp
+++ b/source/evaporation/evaporation_model_recoil_pressure.cpp
@@ -1,0 +1,34 @@
+#include <meltpooldg/evaporation/evaporation_model_recoil_pressure.hpp>
+#include <meltpooldg/melt_pool/recoil_pressure_operation.hpp>
+
+namespace MeltPoolDG::Evaporation
+{
+  template <int dim>
+  EvaporationModelRecoilPressure<dim>::EvaporationModelRecoilPressure(
+    const double boiling_temperature,
+    const double pressure_constant,
+    const double temperature_constant,
+    const double mass_flux_scale_factor)
+    : boiling_temperature(boiling_temperature)
+    , pressure_constant(pressure_constant)
+    , temperature_constant(temperature_constant)
+    , mass_flux_scale_factor(mass_flux_scale_factor)
+  {}
+
+  template <int dim>
+  double
+  EvaporationModelRecoilPressure<dim>::local_compute_evaporative_mass_flux(const double T)
+  {
+    return (T >= boiling_temperature) ?
+             mass_flux_scale_factor * 0.82 * cs *
+               MeltPool::RecoilPressureOperation<dim>::compute_recoil_pressure_coefficient(
+                 T, pressure_constant, temperature_constant, boiling_temperature) *
+               std::sqrt(Cm / T) :
+             0.0;
+  }
+
+  template class EvaporationModelRecoilPressure<1>;
+  template class EvaporationModelRecoilPressure<2>;
+  template class EvaporationModelRecoilPressure<3>;
+
+} // namespace MeltPoolDG::Evaporation

--- a/source/evaporation/evaporation_operation.cpp
+++ b/source/evaporation/evaporation_operation.cpp
@@ -1,5 +1,7 @@
 #include <deal.II/numerics/vector_tools.h>
 
+#include <meltpooldg/evaporation/evaporation_model_hardt_wondra.hpp>
+#include <meltpooldg/evaporation/evaporation_model_recoil_pressure.hpp>
 #include <meltpooldg/evaporation/evaporation_operation.hpp>
 #include <meltpooldg/melt_pool/recoil_pressure_operation.hpp>
 #include <meltpooldg/utilities/physical_constants.hpp>
@@ -525,15 +527,13 @@ namespace MeltPoolDG::Evaporation
     const double &temperature_constant,
     const double &boiling_temperature)
   {
-    // according to Meier 2020
-    const double cs = 1.0;  // sticking coefficent
-    const double Cm = 1e-3; // molar_mass/(2*pi*molar_gas_constant)
-    return (T >= boiling_temperature) ?
-             evaporation_data.evaporative_mass_flux_scale_factor * 0.82 * cs *
-               MeltPool::RecoilPressureOperation<dim>::compute_recoil_pressure_coefficient(
-                 T, pressure_constant, temperature_constant, boiling_temperature) *
-               std::sqrt(Cm / T) :
-             0.0;
+    EvaporationModelRecoilPressure<dim> evapor_model(
+      boiling_temperature,
+      pressure_constant,
+      temperature_constant,
+      evaporation_data.evaporative_mass_flux_scale_factor);
+
+    return evapor_model.local_compute_evaporative_mass_flux(T);
   }
 
   /**
@@ -543,9 +543,10 @@ namespace MeltPoolDG::Evaporation
   inline double
   EvaporationOperation<dim>::compute_temperature_dependent_mass_flux_rate(const double &T)
   {
-    return (T >= evaporation_data.boiling_temperature) ?
-             evaporation_mass_transfer_coefficient * (T - evaporation_data.boiling_temperature) :
-             0.0;
+    EvaporationModelHardtWondra evapor_model(evaporation_mass_transfer_coefficient,
+                                             evaporation_data.boiling_temperature);
+
+    return evapor_model.local_compute_evaporative_mass_flux(T);
   }
 
   template class EvaporationOperation<1>;


### PR DESCRIPTION
This PR is part of a comprehensive refactoring (referencing #213) of the evaporation operations. It introduces an `EvaporationModelBase` class and derived classes. The interface to the actual `EvaporationOperation` is still work in progress.
