### PR TITLE
Refactor evaporative mass flux computation

### DIFF
--- a/include/meltpooldg/evaporation/evaporation_mass_flux_operator_base.hpp
+++ b/include/meltpooldg/evaporation/evaporation_mass_flux_operator_base.hpp
@@ -1,0 +1,33 @@
+/* ---------------------------------------------------------------------
+ *
+ * Author: Magdalena Schreter, Peter Münch, UIBK/TUM, May 2021
+ *
+ * ---------------------------------------------------------------------*/
+#pragma once
+
+#include <deal.II/lac/la_parallel_block_vector.h>
+#include <deal.II/lac/la_parallel_vector.h>
+
+#include <meltpooldg/interface/scratch_data.hpp>
+
+namespace MeltPoolDG::Evaporation
+{
+  using namespace dealii;
+
+  /**
+   *                               .
+   * For a given evaporation model m(T) fill a DoF-Vector for the
+   * evaporative mass flux.
+   */
+  template <int dim>
+  class EvaporationMassFluxOperatorBase
+  {
+  private:
+    using VectorType = LinearAlgebra::distributed::Vector<double>;
+
+  public:
+    virtual void
+    compute_evaporative_mass_flux(VectorType &      evaporative_mass_flux,
+                                  const VectorType &temperature) const = 0;
+  };
+} // namespace MeltPoolDG::Evaporation

--- a/include/meltpooldg/evaporation/evaporation_mass_flux_operator_continuous.hpp
+++ b/include/meltpooldg/evaporation/evaporation_mass_flux_operator_continuous.hpp
@@ -1,0 +1,46 @@
+/* ---------------------------------------------------------------------
+ *
+ * Author: Magdalena Schreter, Peter Münch, UIBK/TUM, May 2021
+ *
+ * ---------------------------------------------------------------------*/
+#pragma once
+
+#include <deal.II/lac/la_parallel_block_vector.h>
+#include <deal.II/lac/la_parallel_vector.h>
+
+#include <meltpooldg/evaporation/evaporation_mass_flux_operator_base.hpp>
+#include <meltpooldg/evaporation/evaporation_model_base.hpp>
+#include <meltpooldg/interface/scratch_data.hpp>
+
+namespace MeltPoolDG::Evaporation
+{
+  using namespace dealii;
+
+  /**
+   *                               .
+   * For a given evaporation model m(T) fill a DoF-Vector for the
+   * evaporative mass flux.
+   */
+  template <int dim>
+  class EvaporationMassFluxOperatorContinuous : public EvaporationMassFluxOperatorBase<dim>
+  {
+  private:
+    using VectorType = LinearAlgebra::distributed::Vector<double>;
+
+    const ScratchData<dim> &    scratch_data;
+    const EvaporationModelBase &evaporation_model;
+    const unsigned int          temp_dof_idx;
+
+  public:
+    EvaporationMassFluxOperatorContinuous(const ScratchData<dim> &    scratch_data,
+                                          const EvaporationModelBase &evaporation_model,
+                                          const unsigned int          temp_dof_idx);
+
+    /**
+     * DOCU: TODO
+     */
+    void
+    compute_evaporative_mass_flux(VectorType &      evaporative_mass_flux,
+                                  const VectorType &temperature) const final;
+  };
+} // namespace MeltPoolDG::Evaporation

--- a/include/meltpooldg/evaporation/evaporation_mass_flux_operator_continuous.hpp
+++ b/include/meltpooldg/evaporation/evaporation_mass_flux_operator_continuous.hpp
@@ -18,8 +18,7 @@ namespace MeltPoolDG::Evaporation
 
   /**
    *                               .
-   * For a given evaporation model m(T) fill a DoF-Vector for the
-   * evaporative mass flux.
+   * DOCU: TODO
    */
   template <int dim>
   class EvaporationMassFluxOperatorContinuous : public EvaporationMassFluxOperatorBase<dim>

--- a/include/meltpooldg/evaporation/evaporation_mass_flux_operator_interface_value.hpp
+++ b/include/meltpooldg/evaporation/evaporation_mass_flux_operator_interface_value.hpp
@@ -1,0 +1,54 @@
+/* ---------------------------------------------------------------------
+ *
+ * Author: Magdalena Schreter, Peter Münch, UIBK/TUM, May 2021
+ *
+ * ---------------------------------------------------------------------*/
+#pragma once
+
+#include <deal.II/lac/la_parallel_block_vector.h>
+#include <deal.II/lac/la_parallel_vector.h>
+
+#include <meltpooldg/evaporation/evaporation_mass_flux_operator_base.hpp>
+#include <meltpooldg/evaporation/evaporation_model_base.hpp>
+#include <meltpooldg/interface/scratch_data.hpp>
+
+namespace MeltPoolDG::Evaporation
+{
+  using namespace dealii;
+
+  /**
+   *
+   * DOCU: TODO
+   */
+  template <int dim>
+  class EvaporationMassFluxOperatorInterfaceValue : public EvaporationMassFluxOperatorBase<dim>
+  {
+  private:
+    using VectorType      = LinearAlgebra::distributed::Vector<double>;
+    using BlockVectorType = LinearAlgebra::distributed::BlockVector<double>;
+
+    const ScratchData<dim> &    scratch_data;
+    const EvaporationModelBase &evaporation_model;
+    const VectorType &          level_set_as_heaviside;
+    const VectorType &          distance;
+    const BlockVectorType &     normal_vector;
+    const unsigned int          ls_dof_idx;
+    const unsigned int          temp_dof_idx;
+
+  public:
+    EvaporationMassFluxOperatorInterfaceValue(const ScratchData<dim> &    scratch_data,
+                                              const EvaporationModelBase &evaporation_model,
+                                              const VectorType &          level_set_as_heaviside,
+                                              const VectorType &          distance,
+                                              const BlockVectorType &     normal_vector,
+                                              const unsigned int          ls_dof_idx,
+                                              const unsigned int          temp_dof_idx);
+
+    /**
+     * DOCU: TODO
+     */
+    void
+    compute_evaporative_mass_flux(VectorType &      evaporative_mass_flux,
+                                  const VectorType &temperature) const final;
+  };
+} // namespace MeltPoolDG::Evaporation

--- a/include/meltpooldg/evaporation/evaporation_model_base.hpp
+++ b/include/meltpooldg/evaporation/evaporation_model_base.hpp
@@ -20,6 +20,6 @@ namespace MeltPoolDG::Evaporation
      * a given temperature value @p T.
      */
     virtual double
-    local_compute_evaporative_mass_flux(const double T) = 0;
+    local_compute_evaporative_mass_flux(const double T) const = 0;
   };
 } // namespace MeltPoolDG::Evaporation

--- a/include/meltpooldg/evaporation/evaporation_model_hardt_wondra.hpp
+++ b/include/meltpooldg/evaporation/evaporation_model_hardt_wondra.hpp
@@ -62,6 +62,6 @@ namespace MeltPoolDG::Evaporation
      *  with the evaporative mass transfer coefficient α_v  and the heaviside function <...>.
      */
     double
-    local_compute_evaporative_mass_flux(const double T) final;
+    local_compute_evaporative_mass_flux(const double T) const final;
   };
 } // namespace MeltPoolDG::Evaporation

--- a/include/meltpooldg/evaporation/evaporation_model_recoil_pressure.hpp
+++ b/include/meltpooldg/evaporation/evaporation_model_recoil_pressure.hpp
@@ -50,6 +50,6 @@ namespace MeltPoolDG::Evaporation
      * M the molar mass, R the molar gas constant and T the temperature.
      */
     double
-    local_compute_evaporative_mass_flux(const double T) final;
+    local_compute_evaporative_mass_flux(const double T) const final;
   };
 } // namespace MeltPoolDG::Evaporation

--- a/include/meltpooldg/evaporation/evaporation_operation.hpp
+++ b/include/meltpooldg/evaporation/evaporation_operation.hpp
@@ -8,6 +8,8 @@
 #include <deal.II/lac/la_parallel_block_vector.h>
 #include <deal.II/lac/la_parallel_vector.h>
 
+#include <meltpooldg/evaporation/evaporation_mass_flux_operator_base.hpp>
+#include <meltpooldg/evaporation/evaporation_model_base.hpp>
 #include <meltpooldg/interface/scratch_data.hpp>
 #include <meltpooldg/interface/simulationbase.hpp>
 #include <meltpooldg/utilities/generic_data_out.hpp>
@@ -63,9 +65,8 @@ namespace MeltPoolDG::Evaporation
     /*
      * optional: temperature-dependent evaporation
      */
-    const VectorType *temperature;
-    const double      temp_dof_idx;
-    double            evaporation_mass_transfer_coefficient = 0.0;
+    mutable const VectorType *temperature;
+    double                    temp_dof_idx;
     /**
      * evaporative mass flux
      */
@@ -79,6 +80,9 @@ namespace MeltPoolDG::Evaporation
      */
     VectorType evaporation_velocity;
 
+    std::shared_ptr<EvaporationModelBase>                 evapor_model;
+    std::shared_ptr<EvaporationMassFluxOperatorBase<dim>> evapor_mass_flux_operator;
+
   public:
     EvaporationOperation(const std::shared_ptr<const ScratchData<dim>> &scratch_data_in,
                          const VectorType &                             level_set_as_heaviside_in,
@@ -91,20 +95,26 @@ namespace MeltPoolDG::Evaporation
                          const VectorType *                             temperature  = nullptr,
                          const unsigned int                             temp_dof_idx = 0);
 
-    void
-    reinit();
 
-
+    /*
+     * This function enables to set the pointer to the temperature vector separately from the
+     * constructor
+     */
     void
-    compute_evaporative_mass_flux_from_temperature_const_over_interface(const VectorType &distance);
+    register_temperature_vector(const VectorType *temperature, const unsigned int temp_dof_idx);
 
+    /*
+     * Set the evaporative mass flux model
+     */
     void
-    compute_evaporative_mass_flux_from_temperature(
-      const VectorType & temperature,
-      const unsigned int temp_dof_idx,
-      const double &     boiling_temperature  = 0.0, //@todo: remove from meltpool
-      const double &     pressure_constant    = 0.0,
-      const double &     temperature_constant = 0.0);
+    register_evaporative_mass_flux_model(const RecoilPressureData<double> &recoil_data,
+                                         const VectorType &                distance);
+    /*
+     * Compute DoF vector holding evaporative mass flux depending on the given evaporation model
+     * and the evaporation mass flux operator for computing the distribution across the interface.
+     */
+    void
+    compute_evaporative_mass_flux();
 
     void
     compute_evaporation_velocity(
@@ -116,6 +126,8 @@ namespace MeltPoolDG::Evaporation
                                      const unsigned int pressure_quad_idx,
                                      bool               zero_out);
 
+    void
+    reinit();
     /*
      * attach functions
      */
@@ -151,24 +163,5 @@ namespace MeltPoolDG::Evaporation
 
     VectorType &
     get_evaporative_mass_flux();
-
-  private:
-    /**
-     * @todo
-     * !!!!!!!! HARD CODED PARAMETERS !!!!!!!!!!!!! --> this function will be replaced when the heat
-     * equation is implemented anyhow
-     */
-    inline double
-    compute_temperature_dependent_mass_flux_rate_from_recoil_pressure(
-      const double &T,
-      const double &pressure_constant,
-      const double &temperature_constant,
-      const double &boiling_temperature);
-
-    /**
-     *  According to Hardt and Wondra
-     */
-    inline double
-    compute_temperature_dependent_mass_flux_rate(const double &T);
   };
 } // namespace MeltPoolDG::Evaporation

--- a/include/meltpooldg/interface/parameters.hpp
+++ b/include/meltpooldg/interface/parameters.hpp
@@ -232,11 +232,14 @@ namespace MeltPoolDG
     number      ls_value_liquid                    = 1.0;
     number      ls_value_gas                       = -1.0;
     std::string formulation_source_term_continuity = "diffuse";
-    std::string formulation_evaporative_mass_flux  = "constant"; // todo: recoil_pressure Schrage
-    number      coefficient                        = 0.0;
-    number      latent_heat_of_evaporation         = 0.0;
-    number      molar_mass                         = 0.0;
-    number      boiling_temperature                = 0.0;
+    std::string formulation_evaporative_mass_flux_over_interface =
+      "continuous"; // not needed if evaporation_model == "constant"
+    std::string evaporation_model =
+      "constant"; // @todo: instead of constant --> temperature-independent ?
+    number coefficient                = 0.0;
+    number latent_heat_of_evaporation = 0.0;
+    number molar_mass                 = 0.0;
+    number boiling_temperature        = 0.0;
   };
 
   template <typename number = double>

--- a/include/meltpooldg/simulations/evaporating_droplet/evaporating_droplet_with_heat.json
+++ b/include/meltpooldg/simulations/evaporating_droplet/evaporating_droplet_with_heat.json
@@ -60,7 +60,7 @@
     "heat nlsolve max nonlinear iterations": "15"
   },
   "evaporation": {
-    "evapor formulation evaporative mass flux": "temperature dependent",
+    "evapor evaporation model": "Hardt Wondra",
     "evapor evaporative mass flux": "0.000000",
     "evapor boiling temperature": "1.",
     "evapor molar mass": "0.01801528",

--- a/include/meltpooldg/simulations/film_boiling/film_boiling_gibou_amr.json
+++ b/include/meltpooldg/simulations/film_boiling/film_boiling_gibou_amr.json
@@ -72,7 +72,7 @@
     "curv implementation": "meltpooldg"
   },
   "evaporation": {
-    "evapor formulation evaporative mass flux": "temperature dependent",
+    "evapor evaporation model": "Hardt Wondra",
     "evapor evaporative mass flux": "0.0",
     "evapor boiling temperature": "500.",
     "evapor molar mass": "0.01801528",

--- a/include/meltpooldg/simulations/stefans_problem/stefans_problem1_with_flow_and_heat.json
+++ b/include/meltpooldg/simulations/stefans_problem/stefans_problem1_with_flow_and_heat.json
@@ -82,7 +82,7 @@
     "curv implementation": "meltpooldg"
   },
   "evaporation": {
-    "evapor formulation evaporative mass flux": "temperature dependent",
+    "evapor evaporation model": "Hardt Wondra",
     "evapor evaporative mass flux": "0.0",
     "evapor boiling temperature": "373.15",
     "evapor molar mass": "0.01801528",

--- a/include/meltpooldg/simulations/stefans_problem/stefans_problem1_with_flow_and_heat_1d.json
+++ b/include/meltpooldg/simulations/stefans_problem/stefans_problem1_with_flow_and_heat_1d.json
@@ -82,7 +82,7 @@
     "curv implementation": "meltpooldg"
   },
   "evaporation": {
-    "evapor formulation evaporative mass flux": "temperature dependent",
+    "evapor evaporation model": "Hardt Wondra",
     "evapor evaporative mass flux": "0.0",
     "evapor boiling temperature": "373.15",
     "evapor molar mass": "0.01801528",

--- a/include/meltpooldg/simulations/stefans_problem/stefans_problem2_with_flow_and_heat_amr.json
+++ b/include/meltpooldg/simulations/stefans_problem/stefans_problem2_with_flow_and_heat_amr.json
@@ -81,7 +81,7 @@
     "curv implementation": "meltpooldg"
   },
   "evaporation": {
-    "evapor formulation evaporative mass flux": "temperature dependent",
+    "evapor evaporation model": "Hardt Wondra",
     "evapor evaporative mass flux": "0.0",
     "evapor boiling temperature": "373.15",
     "evapor molar mass": "0.01801528",

--- a/source/evaporation/evaporation_mass_flux_operator_continous.cpp
+++ b/source/evaporation/evaporation_mass_flux_operator_continous.cpp
@@ -24,21 +24,9 @@ namespace MeltPoolDG::Evaporation
     VectorType &      evaporative_mass_flux,
     const VectorType &temperature) const
   {
-    temperature.update_ghost_values();
-    const unsigned int dofs_per_cell = scratch_data.get_n_dofs_per_cell(temp_dof_idx);
-
-    std::vector<types::global_dof_index> local_dof_indices(dofs_per_cell);
-
-    for (const auto &cell : scratch_data.get_dof_handler(temp_dof_idx).active_cell_iterators())
-      if (cell->is_locally_owned())
-        {
-          cell->get_dof_indices(local_dof_indices);
-          for (unsigned int i = 0; i < dofs_per_cell; ++i)
-            evaporative_mass_flux[local_dof_indices[i]] =
-              evaporation_model.local_compute_evaporative_mass_flux(
-                temperature[local_dof_indices[i]]);
-        }
-    temperature.zero_out_ghost_values();
+    for (unsigned int i = 0; i < evaporative_mass_flux.locally_owned_size(); ++i)
+      evaporative_mass_flux.local_element(i) =
+        evaporation_model.local_compute_evaporative_mass_flux(temperature.local_element(i));
   }
 
   template class EvaporationMassFluxOperatorContinuous<1>;

--- a/source/evaporation/evaporation_mass_flux_operator_continous.cpp
+++ b/source/evaporation/evaporation_mass_flux_operator_continous.cpp
@@ -1,0 +1,47 @@
+#include <deal.II/lac/la_parallel_vector.h>
+
+#include <meltpooldg/evaporation/evaporation_mass_flux_operator_continuous.hpp>
+#include <meltpooldg/interface/scratch_data.hpp>
+
+namespace MeltPoolDG::Evaporation
+{
+  using namespace dealii;
+
+  template <int dim>
+  EvaporationMassFluxOperatorContinuous<dim>::EvaporationMassFluxOperatorContinuous(
+    const ScratchData<dim> &    scratch_data,
+    const EvaporationModelBase &evaporation_model,
+    const unsigned int          temp_dof_idx)
+    : scratch_data(scratch_data)
+    , evaporation_model(evaporation_model)
+    , temp_dof_idx(temp_dof_idx)
+  {}
+
+
+  template <int dim>
+  void
+  EvaporationMassFluxOperatorContinuous<dim>::compute_evaporative_mass_flux(
+    VectorType &      evaporative_mass_flux,
+    const VectorType &temperature) const
+  {
+    temperature.update_ghost_values();
+    const unsigned int dofs_per_cell = scratch_data.get_n_dofs_per_cell(temp_dof_idx);
+
+    std::vector<types::global_dof_index> local_dof_indices(dofs_per_cell);
+
+    for (const auto &cell : scratch_data.get_dof_handler(temp_dof_idx).active_cell_iterators())
+      if (cell->is_locally_owned())
+        {
+          cell->get_dof_indices(local_dof_indices);
+          for (unsigned int i = 0; i < dofs_per_cell; ++i)
+            evaporative_mass_flux[local_dof_indices[i]] =
+              evaporation_model.local_compute_evaporative_mass_flux(
+                temperature[local_dof_indices[i]]);
+        }
+    temperature.zero_out_ghost_values();
+  }
+
+  template class EvaporationMassFluxOperatorContinuous<1>;
+  template class EvaporationMassFluxOperatorContinuous<2>;
+  template class EvaporationMassFluxOperatorContinuous<3>;
+} // namespace MeltPoolDG::Evaporation

--- a/source/evaporation/evaporation_mass_flux_operator_interface_value.cpp
+++ b/source/evaporation/evaporation_mass_flux_operator_interface_value.cpp
@@ -1,0 +1,149 @@
+#include <deal.II/lac/la_parallel_vector.h>
+
+#include <deal.II/numerics/vector_tools.h>
+
+#include <meltpooldg/evaporation/evaporation_mass_flux_operator_interface_value.hpp>
+#include <meltpooldg/interface/scratch_data.hpp>
+
+namespace MeltPoolDG::Evaporation
+{
+  using namespace dealii;
+
+  template <int dim>
+  EvaporationMassFluxOperatorInterfaceValue<dim>::EvaporationMassFluxOperatorInterfaceValue(
+    const ScratchData<dim> &    scratch_data,
+    const EvaporationModelBase &evaporation_model,
+    const VectorType &          level_set_as_heaviside,
+    const VectorType &          distance,
+    const BlockVectorType &     normal_vector,
+    const unsigned int          ls_dof_idx,
+    const unsigned int          temp_dof_idx)
+    : scratch_data(scratch_data)
+    , evaporation_model(evaporation_model)
+    , level_set_as_heaviside(level_set_as_heaviside)
+    , distance(distance)
+    , normal_vector(normal_vector)
+    , ls_dof_idx(ls_dof_idx)
+    , temp_dof_idx(temp_dof_idx)
+  {}
+
+
+  template <int dim>
+  void
+  EvaporationMassFluxOperatorInterfaceValue<dim>::compute_evaporative_mass_flux(
+    VectorType &      evaporative_mass_flux,
+    const VectorType &temperature) const
+  {
+    /*
+     * collect evaluation points
+     */
+    distance.update_ghost_values();
+    normal_vector.update_ghost_values();
+
+    FEValues<dim, dim> ls_values(
+      scratch_data.get_mapping(),
+      scratch_data.get_fe(ls_dof_idx),
+      Quadrature<dim>(scratch_data.get_fe(ls_dof_idx).base_element(0).get_unit_support_points()),
+      update_quadrature_points);
+
+    std::vector<Point<dim>>              evaluation_points;
+    std::vector<types::global_dof_index> dof_indices;
+
+    const unsigned int n_q_points = ls_values.get_quadrature().size();
+
+    // temporary values at cell nodes nodes
+    Vector<double>                       hs_temp(n_q_points);
+    Vector<double>                       distance_temp(n_q_points);
+    std::vector<Vector<double>>          normal_temp(dim, Vector<double>(n_q_points));
+    std::vector<Point<dim>>              normalized_normal_temp(n_q_points, Point<dim>());
+    std::vector<types::global_dof_index> temp_local_dof_indices(n_q_points);
+
+    auto bounding_box    = GridTools::compute_bounding_box(scratch_data.get_triangulation());
+    auto boundary_points = bounding_box.get_boundary_points();
+
+    for (const auto &cell : scratch_data.get_dof_handler(ls_dof_idx).active_cell_iterators())
+      {
+        if (cell->is_locally_owned())
+          {
+            ls_values.reinit(cell);
+
+            cell->get_dof_indices(temp_local_dof_indices);
+
+            cell->get_dof_values(level_set_as_heaviside, hs_temp);
+            cell->get_dof_values(distance, distance_temp);
+            for (unsigned int d = 0; d < dim; ++d)
+              cell->get_dof_values(normal_vector.block(d), normal_temp[d]);
+
+            // normalize normal vector values
+            for (unsigned int d = 0; d < dim; ++d)
+              for (unsigned int q = 0; q < n_q_points; ++q)
+                normalized_normal_temp[q][d] = normal_temp[d][q];
+
+            for (auto &n : normalized_normal_temp)
+              n = n / n.norm();
+
+            for (const auto q : ls_values.quadrature_point_indices())
+              {
+                if (hs_temp[q] < 1.0 && hs_temp[q] > 0.0)
+                  {
+                    // compute corresponding point at level set == 0.0
+
+                    Point<dim> evaluation_point_temp = Point<dim>();
+                    for (unsigned int d = 0; d < dim; ++d)
+                      {
+                        evaluation_point_temp[d] = ls_values.quadrature_point(q)[d] -
+                                                   distance_temp[q] * normalized_normal_temp[q][d];
+
+                        // check if point is outside domain and if so then project it back to the
+                        // domain
+                        if (evaluation_point_temp[d] < boundary_points.first[d])
+                          evaluation_point_temp[d] = boundary_points.first[d];
+                        else if (evaluation_point_temp[d] > boundary_points.second[d])
+                          evaluation_point_temp[d] = boundary_points.second[d];
+                      }
+
+                    evaluation_points.push_back(evaluation_point_temp);
+                    dof_indices.push_back(temp_local_dof_indices[q]);
+                  }
+              }
+          }
+      }
+
+    /*
+     * get temperature values at evaluation points
+     */
+    Utilities::MPI::RemotePointEvaluation<dim, dim> cache;
+
+    temperature.update_ghost_values();
+    const auto temperature_evaluation_values =
+      dealii::VectorTools::point_values<1>(scratch_data.get_mapping(),
+                                           scratch_data.get_dof_handler(temp_dof_idx),
+                                           temperature,
+                                           evaluation_points,
+                                           cache,
+                                           dealii::VectorTools::EvaluationFlags::max);
+    temperature.zero_out_ghost_values();
+
+    Assert(temperature_evaluation_values.size() == evaluation_points.size(),
+           ExcMessage("The size of vectors must match."));
+
+    /*
+     * compute evaporative mass flux
+     */
+    evaporative_mass_flux.zero_out_ghost_values();
+    evaporative_mass_flux = 0.0;
+
+    for (unsigned int i = 0; i < evaluation_points.size(); i++)
+      {
+        evaporative_mass_flux[temp_local_dof_indices[i]] =
+          evaporation_model.local_compute_evaporative_mass_flux(
+            temperature[temp_local_dof_indices[i]]);
+      }
+
+    evaporative_mass_flux.update_ghost_values();
+  }
+
+  template class EvaporationMassFluxOperatorInterfaceValue<1>;
+  template class EvaporationMassFluxOperatorInterfaceValue<2>;
+  template class EvaporationMassFluxOperatorInterfaceValue<3>;
+} // namespace MeltPoolDG::Evaporation

--- a/source/evaporation/evaporation_mass_flux_operator_interface_value.cpp
+++ b/source/evaporation/evaporation_mass_flux_operator_interface_value.cpp
@@ -58,8 +58,8 @@ namespace MeltPoolDG::Evaporation
     std::vector<Point<dim>>              normalized_normal_temp(n_q_points, Point<dim>());
     std::vector<types::global_dof_index> temp_local_dof_indices(n_q_points);
 
-    auto bounding_box    = GridTools::compute_bounding_box(scratch_data.get_triangulation());
-    auto boundary_points = bounding_box.get_boundary_points();
+    const auto bounding_box    = GridTools::compute_bounding_box(scratch_data.get_triangulation());
+    const auto boundary_points = bounding_box.get_boundary_points();
 
     for (const auto &cell : scratch_data.get_dof_handler(ls_dof_idx).active_cell_iterators())
       {

--- a/source/evaporation/evaporation_model_hardt_wondra.cpp
+++ b/source/evaporation/evaporation_model_hardt_wondra.cpp
@@ -1,3 +1,4 @@
+#include <deal.II/base/exceptions.h>
 #include <deal.II/base/numbers.h>
 
 #include <meltpooldg/evaporation/evaporation_model_hardt_wondra.hpp>
@@ -7,6 +8,8 @@
 
 namespace MeltPoolDG::Evaporation
 {
+  using namespace dealii;
+
   EvaporationModelHardtWondra::EvaporationModelHardtWondra(const double evaporation_coefficient,
                                                            const double latent_heat_of_evaporation,
                                                            const double density_vapor,
@@ -19,7 +22,15 @@ namespace MeltPoolDG::Evaporation
                    molar_mass_vapor) *
          std::pow(boiling_temperature, 1.5)))
     , boiling_temperature(boiling_temperature)
-  {}
+  {
+    AssertThrow(std::abs(2. - evaporation_coefficient) > 1e-12,
+                ExcMessage("The evaporation coefficient must not be equal to two."));
+    AssertThrow(molar_mass_vapor > 1e-12, ExcMessage("The molar mass must be larger than zero."));
+    AssertThrow(
+      std::abs(boiling_temperature) > 1e-12,
+      ExcMessage(
+        "The boiling temperature must not be zero to compute the evaporation mass transfer coefficient"));
+  }
 
   EvaporationModelHardtWondra::EvaporationModelHardtWondra(
     const double evaporative_mass_transfer_coefficient,
@@ -29,7 +40,7 @@ namespace MeltPoolDG::Evaporation
   {}
 
   double
-  EvaporationModelHardtWondra::local_compute_evaporative_mass_flux(const double T)
+  EvaporationModelHardtWondra::local_compute_evaporative_mass_flux(const double T) const
   {
     return (T >= boiling_temperature) ?
              evaporative_mass_transfer_coefficient * (T - boiling_temperature) :

--- a/source/evaporation/evaporation_model_recoil_pressure.cpp
+++ b/source/evaporation/evaporation_model_recoil_pressure.cpp
@@ -17,7 +17,7 @@ namespace MeltPoolDG::Evaporation
 
   template <int dim>
   double
-  EvaporationModelRecoilPressure<dim>::local_compute_evaporative_mass_flux(const double T)
+  EvaporationModelRecoilPressure<dim>::local_compute_evaporative_mass_flux(const double T) const
   {
     return (T >= boiling_temperature) ?
              mass_flux_scale_factor * 0.82 * cs *

--- a/source/evaporation/evaporation_operation.cpp
+++ b/source/evaporation/evaporation_operation.cpp
@@ -1,5 +1,7 @@
 #include <deal.II/numerics/vector_tools.h>
 
+#include <meltpooldg/evaporation/evaporation_mass_flux_operator_continuous.hpp>
+#include <meltpooldg/evaporation/evaporation_mass_flux_operator_interface_value.hpp>
 #include <meltpooldg/evaporation/evaporation_model_hardt_wondra.hpp>
 #include <meltpooldg/evaporation/evaporation_model_recoil_pressure.hpp>
 #include <meltpooldg/evaporation/evaporation_operation.hpp>
@@ -46,188 +48,77 @@ namespace MeltPoolDG::Evaporation
     AssertThrow(material.first.density > 0.0 && material.second.density > 0.0,
                 ExcMessage("The materials' densities must be greater than zero! Abort..."));
     reinit();
-    // @todo: provide static function
-    if (evaporation_data.formulation_evaporative_mass_flux.find("temperature dependent") !=
-        std::string::npos)
-      {
-        AssertThrow(
-          std::abs(evaporation_data.boiling_temperature) > 1e-12,
-          ExcMessage(
-            "The boiling temperature must not be zero to compte the evaporation mass transfer coefficient"));
-
-        evaporation_mass_transfer_coefficient =
-          2. * evaporation_data.coefficient * evaporation_data.latent_heat_of_evaporation *
-          material.first.density /
-          ((2. - evaporation_data.coefficient) *
-           std::sqrt(2. * numbers::PI * PhysicalConstants::universal_gas_constant /
-                     evaporation_data.molar_mass) *
-           std::pow(evaporation_data.boiling_temperature, 1.5));
-      }
   }
 
   template <int dim>
   void
-  EvaporationOperation<dim>::reinit()
+  EvaporationOperation<dim>::register_temperature_vector(const VectorType * temperature,
+                                                         const unsigned int temp_dof_idx_)
   {
-    scratch_data->initialize_dof_vector(
-      evaporative_mass_flux, ls_hanging_nodes_dof_idx); // @todo: evapor_dof_idx/temp_dof_idx
-    scratch_data->initialize_dof_vector(evaporation_velocity, evapor_vel_dof_idx);
+    temperature  = temperature;
+    temp_dof_idx = temp_dof_idx_;
+  }
+
+  //@todo move to constructor
+  template <int dim>
+  void
+  EvaporationOperation<dim>::register_evaporative_mass_flux_model(
+    const RecoilPressureData<double> &recoil_data,
+    const VectorType &                distance)
+  {
+    /*                 .
+     * local operation m(T)
+     */
+    //@todo: add asserts of parameters
+    if (evaporation_data.evaporation_model == "constant")
+      { /* do nothing --> no model has to be set up */
+      }
+    else if (evaporation_data.evaporation_model == "recoil pressure")
+      evapor_model = std::make_shared<EvaporationModelRecoilPressure<dim>>(
+        evaporation_data.boiling_temperature,
+        recoil_data.pressure_constant,
+        recoil_data.temperature_constant,
+        evaporation_data.evaporative_mass_flux_scale_factor);
+    else if (evaporation_data.evaporation_model == "Hardt Wondra")
+      evapor_model =
+        std::make_shared<EvaporationModelHardtWondra>(evaporation_data.coefficient,
+                                                      evaporation_data.latent_heat_of_evaporation,
+                                                      material.first.density,
+                                                      evaporation_data.molar_mass,
+                                                      evaporation_data.boiling_temperature);
+    else
+      AssertThrow(false, ExcNotImplemented());
+    /*
+     * Computation of DoF-Vector
+     */
+    if (evaporation_data.formulation_evaporative_mass_flux_over_interface == "continuous")
+      evapor_mass_flux_operator =
+        std::make_shared<EvaporationMassFluxOperatorContinuous<dim>>(*scratch_data,
+                                                                     *evapor_model,
+                                                                     temp_dof_idx);
+    else if (evaporation_data.formulation_evaporative_mass_flux_over_interface == "interface value")
+      {
+        evapor_mass_flux_operator =
+          std::make_shared<EvaporationMassFluxOperatorInterfaceValue<dim>>(*scratch_data,
+                                                                           *evapor_model,
+                                                                           level_set_as_heaviside,
+                                                                           distance,
+                                                                           normal_vector,
+                                                                           ls_hanging_nodes_dof_idx,
+                                                                           temp_dof_idx);
+      }
+    else if (evaporation_data.formulation_evaporative_mass_flux_over_interface == "line integral")
+      AssertThrow(false, ExcNotImplemented());
   }
 
   template <int dim>
   void
-  EvaporationOperation<dim>::compute_evaporative_mass_flux_from_temperature_const_over_interface(
-    const VectorType &distance)
+  EvaporationOperation<dim>::compute_evaporative_mass_flux()
   {
-    /*
-     * collect evaluation points
-     */
-    distance.update_ghost_values();
-    normal_vector.update_ghost_values();
-
-    FEValues<dim, dim> ls_values(
-      scratch_data->get_mapping(),
-      scratch_data->get_fe(ls_hanging_nodes_dof_idx),
-      Quadrature<dim>(
-        scratch_data->get_fe(ls_hanging_nodes_dof_idx).base_element(0).get_unit_support_points()),
-      update_quadrature_points);
-
-    std::vector<Point<dim>>              evaluation_points;
-    std::vector<types::global_dof_index> dof_indices;
-
-    const unsigned int n_q_points = ls_values.get_quadrature().size();
-
-    // temporary values at cell nodes nodes
-    Vector<double>                       hs_temp(n_q_points);
-    Vector<double>                       distance_temp(n_q_points);
-    std::vector<Vector<double>>          normal_temp(dim, Vector<double>(n_q_points));
-    std::vector<Point<dim>>              normalized_normal_temp(n_q_points, Point<dim>());
-    std::vector<types::global_dof_index> temp_local_dof_indices(n_q_points);
-
-    auto bounding_box    = GridTools::compute_bounding_box(scratch_data->get_triangulation());
-    auto boundary_points = bounding_box.get_boundary_points();
-
-    for (const auto &cell :
-         scratch_data->get_dof_handler(ls_hanging_nodes_dof_idx).active_cell_iterators())
-      {
-        if (cell->is_locally_owned())
-          {
-            ls_values.reinit(cell);
-
-            cell->get_dof_indices(temp_local_dof_indices);
-
-            cell->get_dof_values(level_set_as_heaviside, hs_temp);
-            cell->get_dof_values(distance, distance_temp);
-            for (unsigned int d = 0; d < dim; ++d)
-              cell->get_dof_values(normal_vector.block(d), normal_temp[d]);
-
-            // normalize normal vector values
-            for (unsigned int d = 0; d < dim; ++d)
-              for (unsigned int q = 0; q < n_q_points; ++q)
-                normalized_normal_temp[q][d] = normal_temp[d][q];
-
-            for (auto &n : normalized_normal_temp)
-              n = n / n.norm();
-
-            for (const auto q : ls_values.quadrature_point_indices())
-              {
-                if (hs_temp[q] < 1.0 && hs_temp[q] > 0.0)
-                  {
-                    // compute corresponding point at level set == 0.0
-
-                    Point<dim> evaluation_point_temp = Point<dim>();
-                    for (unsigned int d = 0; d < dim; ++d)
-                      {
-                        evaluation_point_temp[d] = ls_values.quadrature_point(q)[d] -
-                                                   distance_temp[q] * normalized_normal_temp[q][d];
-
-                        // check if point is outside domain and if so then project it back to the
-                        // domain
-                        if (evaluation_point_temp[d] < boundary_points.first[d])
-                          evaluation_point_temp[d] = boundary_points.first[d];
-                        else if (evaluation_point_temp[d] > boundary_points.second[d])
-                          evaluation_point_temp[d] = boundary_points.second[d];
-                      }
-
-                    evaluation_points.push_back(evaluation_point_temp);
-                    dof_indices.push_back(temp_local_dof_indices[q]);
-                  }
-              }
-          }
-      }
-
-    /*
-     * get temperature values at evaluation points
-     */
-    Utilities::MPI::RemotePointEvaluation<dim, dim> cache;
-
-    temperature->update_ghost_values();
-    const auto temperature_evaluation_values =
-      dealii::VectorTools::point_values<1>(scratch_data->get_mapping(),
-                                           scratch_data->get_dof_handler(temp_dof_idx),
-                                           *temperature,
-                                           evaluation_points,
-                                           cache,
-                                           dealii::VectorTools::EvaluationFlags::max);
-    temperature->zero_out_ghost_values();
-
-    Assert(temperature_evaluation_values.size() == evaluation_points.size(),
-           ExcMessage("The size of vectors must match."));
-
-    /*
-     * compute evaporative mass flux
-     */
-    evaporative_mass_flux.zero_out_ghost_values();
-    evaporative_mass_flux = 0.0;
-
-    for (unsigned int i = 0; i < evaluation_points.size(); i++)
-      {
-        evaporative_mass_flux[dof_indices[i]] =
-          (temperature_evaluation_values[i] >= evaporation_data.boiling_temperature) ?
-            evaporation_mass_transfer_coefficient *
-              (temperature_evaluation_values[i] - evaporation_data.boiling_temperature) :
-            0.0;
-      }
-
-    evaporative_mass_flux.update_ghost_values();
-  }
-
-  template <int dim>
-  void
-  EvaporationOperation<dim>::compute_evaporative_mass_flux_from_temperature(
-    const VectorType & temperature,
-    const unsigned int temp_dof_idx,
-    const double &     boiling_temperature,
-    const double &     pressure_constant,
-    const double &     temperature_constant)
-  {
-    temperature.update_ghost_values();
-    const unsigned int dofs_per_cell = scratch_data->get_n_dofs_per_cell(temp_dof_idx);
-
-    std::vector<types::global_dof_index> local_dof_indices(dofs_per_cell);
-
-    for (const auto &cell : scratch_data->get_dof_handler(temp_dof_idx).active_cell_iterators())
-      if (cell->is_locally_owned())
-        {
-          cell->get_dof_indices(local_dof_indices);
-          for (unsigned int i = 0; i < dofs_per_cell; ++i)
-            if (evaporation_data.formulation_evaporative_mass_flux == "temperature dependent")
-              {
-                evaporative_mass_flux[local_dof_indices[i]] =
-                  compute_temperature_dependent_mass_flux_rate(temperature[local_dof_indices[i]]);
-              }
-            else if (evaporation_data.formulation_evaporative_mass_flux ==
-                     "recoil pressure dependent")
-              {
-                evaporative_mass_flux[local_dof_indices[i]] =
-                  compute_temperature_dependent_mass_flux_rate_from_recoil_pressure(
-                    temperature[local_dof_indices[i]],
-                    pressure_constant,
-                    temperature_constant,
-                    boiling_temperature);
-              }
-        }
-    temperature.zero_out_ghost_values();
+    if (evaporation_data.evaporation_model == "constant")
+      evaporative_mass_flux = evaporation_data.evaporative_mass_flux;
+    else
+      evapor_mass_flux_operator->compute_evaporative_mass_flux(evaporative_mass_flux, *temperature);
   }
 
   template <int dim>
@@ -418,6 +309,15 @@ namespace MeltPoolDG::Evaporation
 
   template <int dim>
   void
+  EvaporationOperation<dim>::reinit()
+  {
+    scratch_data->initialize_dof_vector(
+      evaporative_mass_flux, ls_hanging_nodes_dof_idx); // @todo: evapor_dof_idx/temp_dof_idx
+    scratch_data->initialize_dof_vector(evaporation_velocity, evapor_vel_dof_idx);
+  }
+
+  template <int dim>
+  void
   EvaporationOperation<dim>::attach_dim_vectors(
     std::vector<LinearAlgebra::distributed::Vector<double> *> &vectors)
   {
@@ -512,41 +412,6 @@ namespace MeltPoolDG::Evaporation
   EvaporationOperation<dim>::get_evaporative_mass_flux()
   {
     return evaporative_mass_flux;
-  }
-
-  /**
-   * @todo
-   * !!!!!!!! HARD CODED PARAMETERS !!!!!!!!!!!!! --> this function will be replaced when the heat
-   * equation is implemented anyhow
-   */
-  template <int dim>
-  inline double
-  EvaporationOperation<dim>::compute_temperature_dependent_mass_flux_rate_from_recoil_pressure(
-    const double &T,
-    const double &pressure_constant,
-    const double &temperature_constant,
-    const double &boiling_temperature)
-  {
-    EvaporationModelRecoilPressure<dim> evapor_model(
-      boiling_temperature,
-      pressure_constant,
-      temperature_constant,
-      evaporation_data.evaporative_mass_flux_scale_factor);
-
-    return evapor_model.local_compute_evaporative_mass_flux(T);
-  }
-
-  /**
-   *  According to Hardt and Wondra
-   */
-  template <int dim>
-  inline double
-  EvaporationOperation<dim>::compute_temperature_dependent_mass_flux_rate(const double &T)
-  {
-    EvaporationModelHardtWondra evapor_model(evaporation_mass_transfer_coefficient,
-                                             evaporation_data.boiling_temperature);
-
-    return evapor_model.local_compute_evaporative_mass_flux(T);
   }
 
   template class EvaporationOperation<1>;

--- a/source/flow/two_phase_flow_problem.cpp
+++ b/source/flow/two_phase_flow_problem.cpp
@@ -42,27 +42,11 @@ namespace MeltPoolDG::Flow
             level_set_operation.update_normal_vector();
 
             //@todo: shift options to evaporation operation
-            if (melt_pool_operation)
-              evaporation_operation->compute_evaporative_mass_flux_from_temperature(
-                melt_pool_operation->get_temperature(),
-                temp_dof_idx,
-                base_in->parameters.mp.boiling_temperature,
-                base_in->parameters.recoil.pressure_constant,
-                base_in->parameters.recoil.temperature_constant);
-            else if (std::abs(base_in->parameters.evapor.evaporative_mass_flux) >
-                     0.0) // constant value
-              evaporation_operation->get_evaporative_mass_flux() =
-                base_in->parameters.evapor.evaporative_mass_flux;
-            else if (base_in->parameters.evapor.formulation_evaporative_mass_flux ==
-                     "temperature dependent")
-              evaporation_operation->compute_evaporative_mass_flux_from_temperature(
-                heat_operation->get_temperature(), temp_dof_idx);
-            else if (base_in->parameters.evapor.formulation_evaporative_mass_flux ==
-                     "temperature dependent interface const")
-              evaporation_operation
-                ->compute_evaporative_mass_flux_from_temperature_const_over_interface(
-                  level_set_operation.get_distance_to_level_set());
+            evaporation_operation->compute_evaporative_mass_flux();
 
+            /*
+             * compute level set source term
+             */
             if (base_in->parameters.evapor.formulation_source_term_continuity == "diffuse")
               evaporation_operation->compute_evaporation_velocity(
                 base_in->parameters.flow.variable_properties_over_interface);
@@ -91,9 +75,8 @@ namespace MeltPoolDG::Flow
         if (!melt_pool_operation && heat_operation)
           {
             // solve only in case of temperature dependent evaporative mass flux
-            if ((evaporation_operation &&
-                 base_in->parameters.evapor.formulation_evaporative_mass_flux.find(
-                   "temperature dependent") != std::string::npos) ||
+            if ((evaporation_operation && base_in->parameters.evapor.evaporation_model.find(
+                                            "Hardt Wondra") != std::string::npos) ||
                 base_in->parameters.base.problem_name == "two_phase_flow_with_heat_transfer")
               heat_operation->solve(dt);
           }
@@ -370,8 +353,14 @@ namespace MeltPoolDG::Flow
           &heat_operation->get_temperature(),
           temp_dof_idx);
 
-        if (base_in->parameters.evapor.formulation_evaporative_mass_flux ==
-            "temperature dependent interface const")
+        /*
+         * register evaporative heat flux if evaporative mass flux is computed from
+         * temperature value at the interface.
+         *
+         * @todo: adopt for all types of evaporative mass flux computations!!
+         */
+        if (base_in->parameters.evapor.formulation_evaporative_mass_flux_over_interface ==
+            "interface value")
           heat_operation->register_evaporative_mass_flux(
             &evaporation_operation->get_evaporative_mass_flux());
 
@@ -399,6 +388,17 @@ namespace MeltPoolDG::Flow
         temp_quad_idx,
         base_in->parameters.flow.start_time,
         evaporation_operation == nullptr);
+
+
+    if (evaporation_operation)
+      {
+        if (base_in->parameters.base.problem_name == "melt_pool_with_evaporation")
+          evaporation_operation->register_temperature_vector(
+            &melt_pool_operation->get_temperature(), temp_dof_idx);
+
+        evaporation_operation->register_evaporative_mass_flux_model(
+          base_in->parameters.recoil, level_set_operation.get_distance_to_level_set());
+      }
     /*
      *  set initial conditions of all operations
      */
@@ -467,8 +467,7 @@ namespace MeltPoolDG::Flow
      */
     if (base_in->parameters.base.problem_name == "two_phase_flow_with_heat_transfer" ||
         (base_in->parameters.base.problem_name == "two_phase_flow_with_evaporation" &&
-         base_in->parameters.evapor.formulation_evaporative_mass_flux.find(
-           "temperature dependent") != std::string::npos))
+         base_in->parameters.evapor.evaporation_model == "Hardt Wondra"))
       heat_operation->set_initial_condition(*base_in->get_initial_condition("heat_transfer"));
     /*
      * set initial condition of the melt pool class

--- a/source/interface/parameters.cpp
+++ b/source/interface/parameters.cpp
@@ -713,13 +713,18 @@ namespace MeltPoolDG
                         "Select how the additional source term due to evaporation in the"
                         " continuity equation is computed.",
                         Patterns::Selection("diffuse|sharp"));
+      // @todo must be modified
       prm.add_parameter(
-        "evapor formulation evaporative mass flux",
-        evapor.formulation_evaporative_mass_flux,
-        "Choose the formulation how the evaporative mass flux mDot (kg/(m2s)) "
+        "evapor formulation evaporative mass flux over interface",
+        evapor.formulation_evaporative_mass_flux_over_interface,
+        "Choose the formulation how the (local) evaporative mass flux will be converted to a DoF vector."
         "will be calculated.",
-        Patterns::Selection(
-          "constant|temperature dependent|recoil pressure dependent|temperature dependent interface const"));
+        Patterns::Selection("continuous|interface value|line integral"));
+      prm.add_parameter("evapor evaporation model",
+                        evapor.evaporation_model,
+                        "Choose the formulation how the evaporative mass flux mDot (kg/(m2s)) "
+                        "will be calculated.",
+                        Patterns::Selection("constant|recoil pressure|Hardt Wondra"));
       prm.add_parameter("evapor coefficient", evapor.coefficient, "Evaporation coefficient.");
       prm.add_parameter("evapor latent heat of evaporation",
                         evapor.latent_heat_of_evaporation,

--- a/tests/evaporating_droplet_with_heat.json
+++ b/tests/evaporating_droplet_with_heat.json
@@ -61,7 +61,7 @@
     "heat nlsolve max nonlinear iterations": "15"
   },
   "evaporation": {
-    "evapor formulation evaporative mass flux": "temperature dependent",
+    "evapor evaporation model": "Hardt Wondra",
     "evapor evaporative mass flux": "0.000000",
     "evapor boiling temperature": "1.",
     "evapor molar mass": "0.01801528",

--- a/tests/stefans_problem1_with_flow_and_heat.json
+++ b/tests/stefans_problem1_with_flow_and_heat.json
@@ -84,7 +84,7 @@
     "curv damping scale factor": "4"
   },
   "evaporation": {
-    "evapor formulation evaporative mass flux": "temperature dependent",
+    "evapor evaporation model": "Hardt Wondra",
     "evapor evaporative mass flux": "0.0",
     "evapor boiling temperature": "373.15",
     "evapor molar mass": "0.01801528",

--- a/tests/stefans_problem1_with_flow_and_heat_1d.json
+++ b/tests/stefans_problem1_with_flow_and_heat_1d.json
@@ -84,8 +84,7 @@
     "curv implementation": "meltpooldg"
   },
   "evaporation": {
-    "evapor formulation evaporative mass flux": "temperature dependent",
-    "evapor evaporative mass flux": "0.0",
+    "evapor evaporation model": "Hardt Wondra",
     "evapor boiling temperature": "373.15",
     "evapor molar mass": "0.01801528",
     "evapor latent heat of evaporation": "1.e1",

--- a/tests/tests_not_robust/film_boiling.json
+++ b/tests/tests_not_robust/film_boiling.json
@@ -73,7 +73,7 @@
     "curv implementation": "meltpooldg"
   },
   "evaporation": {
-    "evapor formulation evaporative mass flux": "temperature dependent",
+    "evapor evaporation model": "Hardt Wondra",
     "evapor evaporative mass flux": "0.0",
     "evapor boiling temperature": "500.",
     "evapor molar mass": "0.01801528",

--- a/tests/tests_not_robust/stefans_problem2_with_flow_and_heat.json
+++ b/tests/tests_not_robust/stefans_problem2_with_flow_and_heat.json
@@ -84,7 +84,7 @@
     "curv implementation": "meltpooldg"
   },
   "evaporation": {
-    "evapor formulation evaporative mass flux": "temperature dependent",
+    "evapor evaporation model": "Hardt Wondra",
     "evapor evaporative mass flux": "0.0",
     "evapor boiling temperature": "373.15",
     "evapor molar mass": "0.01801528",


### PR DESCRIPTION
This PR splits up the variants to fill the DoF vector for the evaporative mass flux:

- continuous over interface (`evaporation_mass_flux_operator_continuous.hpp`) --> take the value of mDot as it is
- interface value (`evaporation_mass_flux_operator_interface_value.hpp`) --> take the value of mDot at the interface and spread it across the interface

references #213