### PR TITLE
Enable DEAL_II_DEPRECATED_EARLY per default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,6 +84,12 @@ add_library(${libName} ${sources})
 
 deal_ii_setup_target(${libName})
 
+
+if(${DEAL_II_VERSION_MAJOR} GREATER_EQUAL 10)
+  message("-- Enabling early deprecation via #define PUBLIC DEAL_II_DEPRECATED_EARLY=[[deprecated]]" )
+  add_compile_definitions(${libName} PUBLIC DEAL_II_DEPRECATED_EARLY=[[deprecated]])
+endif()
+
 # ##############################################################################
 # create executable
 # ##############################################################################

--- a/source/reinitialization/olsson_operator.cpp
+++ b/source/reinitialization/olsson_operator.cpp
@@ -216,7 +216,7 @@ namespace MeltPoolDG::Reinitialization
           {
             psi.reinit(cell);
             psi.read_dof_values_plain(src);
-            psi.evaluate(true, true);
+            psi.evaluate(EvaluationFlags::values | EvaluationFlags::gradients);
 
             normal_vector.reinit(cell);
             normal_vector.read_dof_values_plain(this->normal_vec);


### PR DESCRIPTION
~... depends on https://github.com/dealii/dealii/pull/12383.~

The reason for making this change is to be able to handle depredations as early as possible, however, the official Docker image is compiled without `DEAL_II_DEPRECATED_EARLY` enabled so that one needs to shift the responsibility to the user code.