### PR TITLE
Fix DEAL_II_DEPRECATED_EARLY stuff

### DIFF
--- a/source/advection_diffusion/advection_diffusion_operator.cpp
+++ b/source/advection_diffusion/advection_diffusion_operator.cpp
@@ -161,11 +161,12 @@ namespace MeltPoolDG::AdvectionDiffusion
         for (unsigned int cell = cell_range.first; cell < cell_range.second; ++cell)
           {
             advected_field.reinit(cell);
-            advected_field.gather_evaluate(src, true, true);
+            advected_field.gather_evaluate(src,
+                                           EvaluationFlags::values | EvaluationFlags::gradients);
 
             velocity.reinit(cell);
             velocity.read_dof_values_plain(advection_velocity);
-            velocity.evaluate(true, false);
+            velocity.evaluate(EvaluationFlags::values);
 
             for (unsigned int q_index = 0; q_index < advected_field.n_q_points; ++q_index)
               {
@@ -179,7 +180,8 @@ namespace MeltPoolDG::AdvectionDiffusion
                 advected_field.submit_gradient(this->d_tau * theta * data.diffusivity * grad_phi,
                                                q_index);
               }
-            advected_field.integrate_scatter(true, true, dst);
+            advected_field.integrate_scatter(EvaluationFlags::values | EvaluationFlags::gradients,
+                                             dst);
           }
       },
       dst,
@@ -208,11 +210,12 @@ namespace MeltPoolDG::AdvectionDiffusion
         for (unsigned int cell = macro_cells.first; cell < macro_cells.second; ++cell)
           {
             advected_field.reinit(cell);
-            advected_field.gather_evaluate(src, true, true);
+            advected_field.gather_evaluate(src,
+                                           EvaluationFlags::values | EvaluationFlags::gradients);
 
             velocity.reinit(cell);
             velocity.read_dof_values_plain(advection_velocity);
-            velocity.evaluate(true, false);
+            velocity.evaluate(EvaluationFlags::values);
 
             for (unsigned int q_index = 0; q_index < advected_field.n_q_points; ++q_index)
               {
@@ -229,7 +232,8 @@ namespace MeltPoolDG::AdvectionDiffusion
                                                q_index);
               }
 
-            advected_field.integrate_scatter(true, true, dst);
+            advected_field.integrate_scatter(EvaluationFlags::values | EvaluationFlags::gradients,
+                                             dst);
           }
       },
       dst,

--- a/source/curvature/curvature_operator.cpp
+++ b/source/curvature/curvature_operator.cpp
@@ -119,7 +119,7 @@ namespace MeltPoolDG::Curvature
           {
             curvature.reinit(cell);
             curvature.read_dof_values_plain(src);
-            curvature.evaluate(true, true);
+            curvature.evaluate(EvaluationFlags::values | EvaluationFlags::gradients);
 
             for (unsigned int q_index = 0; q_index < curvature.n_q_points; ++q_index)
               {
@@ -127,7 +127,7 @@ namespace MeltPoolDG::Curvature
                 curvature.submit_gradient(damping * curvature.get_gradient(q_index), q_index);
               }
 
-            curvature.integrate_scatter(true, true, dst);
+            curvature.integrate_scatter(EvaluationFlags::values | EvaluationFlags::gradients, dst);
           }
       },
       dst,
@@ -152,7 +152,7 @@ namespace MeltPoolDG::Curvature
 
             normal_vector.reinit(cell);
             normal_vector.read_dof_values_plain(src);
-            normal_vector.evaluate(true, false);
+            normal_vector.evaluate(EvaluationFlags::values);
 
             for (unsigned int q_index = 0; q_index < curvature.n_q_points; ++q_index)
               {
@@ -162,7 +162,7 @@ namespace MeltPoolDG::Curvature
                 curvature.submit_gradient(n_phi, q_index);
               }
 
-            curvature.integrate_scatter(false, true, dst);
+            curvature.integrate_scatter(EvaluationFlags::gradients, dst);
           }
       },
       dst,

--- a/source/evaporation/evaporation_operation.cpp
+++ b/source/evaporation/evaporation_operation.cpp
@@ -151,15 +151,15 @@ namespace MeltPoolDG::Evaporation
 
         ls.reinit(cell);
         ls.read_dof_values(level_set_as_heaviside);
-        ls.evaluate(true, true);
+        ls.evaluate(EvaluationFlags::values | EvaluationFlags::gradients);
 
         normal_vec.reinit(cell);
         normal_vec.read_dof_values(normal_vector);
-        normal_vec.evaluate(true, false);
+        normal_vec.evaluate(EvaluationFlags::values);
 
         evap_flux.reinit(cell);
         evap_flux.read_dof_values(evaporative_mass_flux);
-        evap_flux.evaluate(true, false);
+        evap_flux.evaluate(EvaluationFlags::values);
 
         for (unsigned int q_index = 0; q_index < ls.n_q_points; ++q_index)
           {
@@ -266,13 +266,13 @@ namespace MeltPoolDG::Evaporation
           {
             heaviside.reinit(cell);
             heaviside.read_dof_values_plain(level_set_as_heaviside);
-            heaviside.evaluate(false, true);
+            heaviside.evaluate(EvaluationFlags::gradients);
 
             mass_flux.reinit(cell);
 
             evap_flux.reinit(cell);
             evap_flux.read_dof_values_plain(evaporative_mass_flux);
-            evap_flux.evaluate(true, false);
+            evap_flux.evaluate(EvaluationFlags::values);
 
             for (unsigned int q_index = 0; q_index < mass_flux.n_q_points; ++q_index)
               {
@@ -292,7 +292,7 @@ namespace MeltPoolDG::Evaporation
                   }
               }
 
-            mass_flux.integrate_scatter(true, false, mass_balance_rhs);
+            mass_flux.integrate_scatter(EvaluationFlags::values, mass_balance_rhs);
           }
       },
       mass_balance_rhs,

--- a/source/evaporation/evaporation_operation_marching_cube.cpp
+++ b/source/evaporation/evaporation_operation_marching_cube.cpp
@@ -59,11 +59,11 @@ namespace MeltPoolDG::Evaporation
 
         normal_vec.reinit(cell);
         normal_vec.read_dof_values(normal_vector);
-        normal_vec.evaluate(true, false);
+        normal_vec.evaluate(EvaluationFlags::values);
 
         evap_flux.reinit(cell);
         evap_flux.read_dof_values(evaporative_mass_flux);
-        evap_flux.evaluate(true, false);
+        evap_flux.evaluate(EvaluationFlags::values);
 
         for (unsigned int q_index = 0; q_index < ls.n_q_points; ++q_index)
           {

--- a/source/flow/surface_tension_operation.cpp
+++ b/source/flow/surface_tension_operation.cpp
@@ -35,12 +35,12 @@ namespace MeltPoolDG::Flow
           {
             level_set.reinit(cell);
             level_set.read_dof_values_plain(level_set_as_heaviside);
-            level_set.evaluate(false, true);
+            level_set.evaluate(EvaluationFlags::gradients);
 
             surface_tension.reinit(cell);
 
             curvature.reinit(cell);
-            curvature.gather_evaluate(curvature_vec, true, false);
+            curvature.gather_evaluate(curvature_vec, EvaluationFlags::values);
 
             for (unsigned int q_index = 0; q_index < surface_tension.n_q_points; ++q_index)
               {
@@ -49,7 +49,7 @@ namespace MeltPoolDG::Flow
                                                curvature.get_value(q_index),
                                              q_index);
               }
-            surface_tension.integrate_scatter(true, false, force_rhs);
+            surface_tension.integrate_scatter(EvaluationFlags::values, force_rhs);
           }
       },
       force_rhs,
@@ -124,21 +124,21 @@ namespace MeltPoolDG::Flow
           {
             level_set.reinit(cell);
             level_set.read_dof_values_plain(level_set_as_heaviside);
-            level_set.evaluate(false, true);
+            level_set.evaluate(EvaluationFlags::gradients);
 
             surface_tension.reinit(cell);
 
             curvature.reinit(cell);
             curvature.read_dof_values_plain(solution_curvature);
-            curvature.evaluate(true, false);
+            curvature.evaluate(EvaluationFlags::values);
 
             normal_vec.reinit(cell);
             normal_vec.read_dof_values_plain(solution_normal_vector);
-            normal_vec.evaluate(true, false);
+            normal_vec.evaluate(EvaluationFlags::values);
 
             temperature_val.reinit(cell);
             temperature_val.read_dof_values_plain(temperature);
-            temperature_val.evaluate(true, true);
+            temperature_val.evaluate(EvaluationFlags::values | EvaluationFlags::gradients);
 
             for (unsigned int q_index = 0; q_index < surface_tension.n_q_points; ++q_index)
               {
@@ -173,7 +173,7 @@ namespace MeltPoolDG::Flow
                                                temp_surf_ten * delta,
                                              q_index);
               }
-            surface_tension.integrate_scatter(true, false, force_rhs);
+            surface_tension.integrate_scatter(EvaluationFlags::values, force_rhs);
           }
       },
       force_rhs,

--- a/source/flow/two_phase_flow_problem.cpp
+++ b/source/flow/two_phase_flow_problem.cpp
@@ -659,7 +659,7 @@ namespace MeltPoolDG::Flow
           {
             ls_values.reinit(cell);
             ls_values.read_dof_values_plain(src);
-            ls_values.evaluate(true, false);
+            ls_values.evaluate(EvaluationFlags::values);
 
             for (unsigned int q = 0; q < ls_values.n_q_points; ++q)
               {
@@ -756,7 +756,7 @@ namespace MeltPoolDG::Flow
                 force[dim - 1] -= gravity * flow_operation->get_density(cell, q);
                 force_values.submit_value(force, q);
               }
-            force_values.integrate_scatter(true, false, vec);
+            force_values.integrate_scatter(EvaluationFlags::values, vec);
           }
       },
       vec,

--- a/source/heat/heat_transfer_operator.cpp
+++ b/source/heat/heat_transfer_operator.cpp
@@ -454,35 +454,38 @@ namespace MeltPoolDG::Heat
       {
         temp_vals.reinit(cell);
         temp_vals.read_dof_values_plain(temperature);
-        temp_vals.evaluate(true, true);
+        temp_vals.evaluate(EvaluationFlags::values | EvaluationFlags::gradients);
 
         temp_vals_old.reinit(cell);
         temp_vals_old.read_dof_values_plain(src); // = temperature_old
-        temp_vals_old.evaluate(true, false);
+        temp_vals_old.evaluate(EvaluationFlags::values);
 
         heat_source_vals.reinit(cell);
         heat_source_vals.read_dof_values_plain(heat_source);
-        heat_source_vals.evaluate(true, false);
+        heat_source_vals.evaluate(EvaluationFlags::values);
 
         if (velocity)
           {
             velocity_vals.reinit(cell);
             velocity_vals.read_dof_values_plain(*velocity);
-            velocity_vals.evaluate(true, false);
+            velocity_vals.evaluate(EvaluationFlags::values);
           }
 
         if (level_set_as_heaviside)
           {
             ls_vals.reinit(cell);
             ls_vals.read_dof_values_plain(*level_set_as_heaviside);
-            ls_vals.evaluate(true, evapor_data);
+            if (evapor_data)
+              ls_vals.evaluate(EvaluationFlags::values | EvaluationFlags::gradients);
+            else
+              ls_vals.evaluate(EvaluationFlags::values);
           }
 
         if (evaporative_mass_flux)
           {
             evapor_vals.reinit(cell);
             evapor_vals.read_dof_values_plain(*evaporative_mass_flux);
-            evapor_vals.evaluate(true, false);
+            evapor_vals.evaluate(EvaluationFlags::values);
           }
 
         for (unsigned int q_index = 0; q_index < temp_vals.n_q_points; ++q_index)
@@ -543,7 +546,7 @@ namespace MeltPoolDG::Heat
             temp_vals.submit_gradient(-1.0 * val_grad,
                                       q_index); // -1 since residual is moved to rhs
           }
-        temp_vals.integrate_scatter(true, true, dst);
+        temp_vals.integrate_scatter(EvaluationFlags::values | EvaluationFlags::gradients, dst);
       }
   }
 
@@ -563,7 +566,7 @@ namespace MeltPoolDG::Heat
       {
         dQ_dT.reinit(face);
         dQ_dT.read_dof_values_plain(temperature);
-        dQ_dT.evaluate(true, false);
+        dQ_dT.evaluate(EvaluationFlags::values);
 
         const types::boundary_id bc_index = matrix_free.get_boundary_id(face);
 
@@ -605,7 +608,7 @@ namespace MeltPoolDG::Heat
 
             dQ_dT.submit_value(temp, q_index);
           }
-        dQ_dT.integrate_scatter(true, false, dst);
+        dQ_dT.integrate_scatter(EvaluationFlags::values, dst);
       }
   }
 
@@ -685,32 +688,37 @@ namespace MeltPoolDG::Heat
     VectorizedArray<number> d_rho_cp_dT       = 0.0;
     VectorizedArray<number> d_conductivity_dT = 0.0;
 
-    temp_vals.evaluate(true, true);
+    temp_vals.evaluate(EvaluationFlags::values | EvaluationFlags::gradients);
 
     if (do_reinit_cells)
       {
         if (velocity)
           {
             velocity_vals.reinit(temp_vals.get_current_cell_index());
-            velocity_vals.gather_evaluate(*velocity, true, false);
+            velocity_vals.gather_evaluate(*velocity, EvaluationFlags::values);
           }
 
         if (level_set_as_heaviside)
           {
             ls_vals.reinit(temp_vals.get_current_cell_index());
-            ls_vals.gather_evaluate(*level_set_as_heaviside, true, evapor_data);
+            if (evapor_data)
+              ls_vals.gather_evaluate(*level_set_as_heaviside,
+                                      EvaluationFlags::values | EvaluationFlags::gradients);
+            else
+              ls_vals.gather_evaluate(*level_set_as_heaviside, EvaluationFlags::values);
           }
 
         if (data.solidification)
           {
             temp_old_vals.reinit(temp_vals.get_current_cell_index());
-            temp_old_vals.gather_evaluate(temperature_old, true, false);
+            temp_old_vals.gather_evaluate(temperature_old, EvaluationFlags::values);
           }
 
         if (data.solidification || evapor_data)
           {
             temp_lin_vals.reinit(temp_vals.get_current_cell_index());
-            temp_lin_vals.gather_evaluate(temperature, true, true);
+            temp_lin_vals.gather_evaluate(temperature,
+                                          EvaluationFlags::values | EvaluationFlags::gradients);
           }
       }
 
@@ -772,7 +780,7 @@ namespace MeltPoolDG::Heat
         temp_vals.submit_value(val, q_index);
         temp_vals.submit_gradient(val_grad, q_index);
       }
-    temp_vals.integrate(true, true);
+    temp_vals.integrate(EvaluationFlags::values | EvaluationFlags::gradients);
   }
 
   template <int dim, typename number>
@@ -782,12 +790,12 @@ namespace MeltPoolDG::Heat
     FEFaceIntegrator<dim, 1, number> &temp_vals,
     const bool                        do_reinit_face) const
   {
-    dQ_dT.evaluate(true, false);
+    dQ_dT.evaluate(EvaluationFlags::values);
 
     if (do_reinit_face)
       {
         temp_vals.reinit(dQ_dT.get_current_cell_index());
-        temp_vals.gather_evaluate(temperature, true, false);
+        temp_vals.gather_evaluate(temperature, EvaluationFlags::values);
       }
 
     const types::boundary_id bc_index =
@@ -815,7 +823,7 @@ namespace MeltPoolDG::Heat
 
         dQ_dT.submit_value(temp, q_index);
       }
-    dQ_dT.integrate(true, false);
+    dQ_dT.integrate(EvaluationFlags::values);
   }
 
   template <int dim, typename number>

--- a/source/level_set/level_set_operator_with_phase_change.cpp
+++ b/source/level_set/level_set_operator_with_phase_change.cpp
@@ -79,14 +79,15 @@ namespace MeltPoolDG::LevelSet
         for (unsigned int cell = cell_range.first; cell < cell_range.second; ++cell)
           {
             advected_field.reinit(cell);
-            advected_field.gather_evaluate(src, true, true);
+            advected_field.gather_evaluate(src,
+                                           EvaluationFlags::values | EvaluationFlags::gradients);
 
             flow_vel.reinit(cell);
-            flow_vel.gather_evaluate(advection_velocity, true, false);
+            flow_vel.gather_evaluate(advection_velocity, EvaluationFlags::values);
 
             evapor_vel.reinit(cell);
             evapor_vel.read_dof_values_plain(evapor_velocity);
-            evapor_vel.evaluate(true, false);
+            evapor_vel.evaluate(EvaluationFlags::values);
 
             for (unsigned int q_index = 0; q_index < advected_field.n_q_points; ++q_index)
               {
@@ -98,7 +99,7 @@ namespace MeltPoolDG::LevelSet
                                  grad_phi);
                 advected_field.submit_value(phi + this->d_tau * theta * velocity_grad_phi, q_index);
               }
-            advected_field.integrate_scatter(true, false, dst);
+            advected_field.integrate_scatter(EvaluationFlags::values, dst);
           }
       },
       dst,
@@ -138,15 +139,15 @@ namespace MeltPoolDG::LevelSet
           {
             advected_field.reinit(cell);
             advected_field.read_dof_values_plain(src);
-            advected_field.evaluate(true, true);
+            advected_field.evaluate(EvaluationFlags::values | EvaluationFlags::gradients);
 
             flow_vel.reinit(cell);
             flow_vel.read_dof_values_plain(advection_velocity);
-            flow_vel.evaluate(true, false);
+            flow_vel.evaluate(EvaluationFlags::values);
 
             evapor_vel.reinit(cell);
             evapor_vel.read_dof_values_plain(evapor_velocity);
-            evapor_vel.evaluate(true, false);
+            evapor_vel.evaluate(EvaluationFlags::values);
 
             for (unsigned int q_index = 0; q_index < advected_field.n_q_points; ++q_index)
               {
@@ -161,7 +162,7 @@ namespace MeltPoolDG::LevelSet
                                             q_index);
               }
 
-            advected_field.integrate_scatter(true, false, dst);
+            advected_field.integrate_scatter(EvaluationFlags::values, dst);
           }
       },
       dst,

--- a/source/melt_pool/recoil_pressure_operation.cpp
+++ b/source/melt_pool/recoil_pressure_operation.cpp
@@ -45,14 +45,11 @@ namespace MeltPoolDG::MeltPool
         for (unsigned int cell = macro_cells.first; cell < macro_cells.second; ++cell)
           {
             level_set.reinit(cell);
-            level_set.gather_evaluate(level_set_as_heaviside, false, true);
-            // level_set.evaluate(false, true);
-            // level_set.read_dof_values_plain(level_set_as_heaviside);
-            // level_set.evaluate(false, true);
+            level_set.gather_evaluate(level_set_as_heaviside, EvaluationFlags::gradients);
 
             temperature_val.reinit(cell);
             temperature_val.read_dof_values_plain(temperature);
-            temperature_val.evaluate(true, false);
+            temperature_val.evaluate(EvaluationFlags::values);
 
             recoil_pressure.reinit(cell);
 
@@ -69,7 +66,7 @@ namespace MeltPoolDG::MeltPool
                                                level_set.get_gradient(q_index),
                                              q_index);
               }
-            recoil_pressure.integrate_scatter(true, false, force_rhs);
+            recoil_pressure.integrate_scatter(EvaluationFlags::values, force_rhs);
           }
       },
       force_rhs,

--- a/source/normal_vector/normal_vector_operator.cpp
+++ b/source/normal_vector/normal_vector_operator.cpp
@@ -117,7 +117,7 @@ namespace MeltPoolDG::NormalVector
         for (unsigned int cell = cell_range.first; cell < cell_range.second; ++cell)
           {
             normal.reinit(cell);
-            normal.gather_evaluate(src, true, true);
+            normal.gather_evaluate(src, EvaluationFlags::values | EvaluationFlags::gradients);
 
             for (unsigned int q_index = 0; q_index < normal.n_q_points; ++q_index)
               {
@@ -125,7 +125,7 @@ namespace MeltPoolDG::NormalVector
                 normal.submit_gradient(damping * normal.get_gradient(q_index), q_index);
               }
 
-            normal.integrate_scatter(true, true, dst);
+            normal.integrate_scatter(EvaluationFlags::values | EvaluationFlags::gradients, dst);
           }
       },
       dst,
@@ -152,12 +152,12 @@ namespace MeltPoolDG::NormalVector
 
             level_set.reinit(cell);
             level_set.read_dof_values_plain(src);
-            level_set.evaluate(false, true);
+            level_set.evaluate(EvaluationFlags::gradients);
 
             for (unsigned int q_index = 0; q_index < normal_vector.n_q_points; ++q_index)
               normal_vector.submit_value(level_set.get_gradient(q_index), q_index);
 
-            normal_vector.integrate_scatter(true, false, dst);
+            normal_vector.integrate_scatter(EvaluationFlags::values, dst);
           }
       },
       dst,

--- a/source/reinitialization/olsson_operator.cpp
+++ b/source/reinitialization/olsson_operator.cpp
@@ -150,11 +150,11 @@ namespace MeltPoolDG::Reinitialization
         for (unsigned int cell = cell_range.first; cell < cell_range.second; ++cell)
           {
             levelset.reinit(cell);
-            levelset.gather_evaluate(src, true, true);
+            levelset.gather_evaluate(src, EvaluationFlags::values | EvaluationFlags::gradients);
 
             normal_vector.reinit(cell);
             normal_vector.read_dof_values_plain(this->normal_vec);
-            normal_vector.evaluate(true, false);
+            normal_vector.evaluate(EvaluationFlags::values);
 
             for (unsigned int q_index = 0; q_index < levelset.n_q_points; q_index++)
               {
@@ -172,7 +172,7 @@ namespace MeltPoolDG::Reinitialization
                                          q_index);
               }
 
-            levelset.integrate_scatter(true, true, dst);
+            levelset.integrate_scatter(EvaluationFlags::values | EvaluationFlags::gradients, dst);
           }
       },
       dst,
@@ -220,7 +220,7 @@ namespace MeltPoolDG::Reinitialization
 
             normal_vector.reinit(cell);
             normal_vector.read_dof_values_plain(this->normal_vec);
-            normal_vector.evaluate(true, false);
+            normal_vector.evaluate(EvaluationFlags::values);
 
             for (unsigned int q_index = 0; q_index < psi.n_q_points; ++q_index)
               {
@@ -235,7 +235,7 @@ namespace MeltPoolDG::Reinitialization
                                     q_index);
               }
 
-            psi.integrate_scatter(false, true, dst);
+            psi.integrate_scatter(EvaluationFlags::gradients, dst);
           }
       },
       dst,


### PR DESCRIPTION
"Noticed" while working on #223. I actually expected that these will give us trouble once `DEAL_II_DEPRECATED_EARLY` have been converted to `DEAL_II_DEPRECATED` directly after the deal.II release. But this did not happen, since we have forgot to add the `DEAL_II_DEPRECATED_EARLY` label. It has been fixed in https://github.com/dealii/dealii/pull/12350 so that the bools are available one more year...