### PR TITLE
Introduce a single fill_dof_vector_from_cell_operation()

### DIFF
--- a/include/meltpooldg/utilities/utilityfunctions.hpp
+++ b/include/meltpooldg/utilities/utilityfunctions.hpp
@@ -42,56 +42,18 @@ namespace MeltPoolDG
   namespace UtilityFunctions
   {
     /**
-     * For a given @p matrix_free object, execute scalar-valued @p cell_operation
+     * For a given @p matrix_free object, execute scalar- or vector-valued @p cell_operation
      * on each quadrature point  defined by @p quad_idx and fill them into a
      * DoF-vector @p vec defined by @p dof_idx.
      */
-    template <int dim>
+    template <int dim, int n_components, typename T>
     void
     fill_dof_vector_from_cell_operation(
-      VectorType &                                                              vec,
-      const MatrixFree<dim, double, VectorizedArray<double>> &                  matrix_free,
-      unsigned int                                                              dof_idx,
-      unsigned int                                                              quad_idx,
-      const std::function<const VectorizedArray<double>(const unsigned int cell,
-                                                        const unsigned int q)> &cell_operation)
-    {
-      FECellIntegrator<dim, 1, double> fe_eval(matrix_free, dof_idx, quad_idx);
-
-      MatrixFreeOperators::CellwiseInverseMassMatrix<dim, -1, 1, double, VectorizedArray<double>>
-        inverse_mass_matrix(fe_eval);
-
-      for (unsigned int cell = 0; cell < matrix_free.n_cell_batches(); ++cell)
-        {
-          fe_eval.reinit(cell);
-
-          for (unsigned int q = 0; q < fe_eval.n_q_points; ++q)
-            fe_eval.begin_values()[q] = cell_operation(cell, q);
-
-          inverse_mass_matrix.transform_from_q_points_to_basis(1,
-                                                               fe_eval.begin_values(),
-                                                               fe_eval.begin_dof_values());
-
-          // write values back into global vector
-          fe_eval.set_dof_values(vec);
-        }
-    }
-
-    /**
-     * For a given @p matrix_free object, execute vector-valued @p cell_operation
-     * on each quadrature point  defined by @p quad_idx and fill them into a
-     * DoF-vector @p vec defined by @p dof_idx.
-     */
-    template <int dim, int n_components>
-    void
-    fill_dof_vector_from_cell_operation_vec(
       VectorType &                                            vec,
       const MatrixFree<dim, double, VectorizedArray<double>> &matrix_free,
       unsigned int                                            dof_idx,
       unsigned int                                            quad_idx,
-      const std::function<const Tensor<1, n_components, VectorizedArray<double>>(
-        const unsigned int cell,
-        const unsigned int q)> &                              cell_operation)
+      const T &                                               cell_operation)
     {
       FECellIntegrator<dim, n_components, double> fe_eval(matrix_free, dof_idx, quad_idx);
 
@@ -107,7 +69,23 @@ namespace MeltPoolDG
             {
               const auto temp = cell_operation(cell, q);
               for (int c = 0; c < n_components; ++c)
-                fe_eval.begin_values()[c * fe_eval.n_q_points + q] = temp[c];
+                if constexpr (std::is_same<typename std::remove_const<decltype(temp)>::type,
+                                           VectorizedArray<double>>::value)
+                  {
+                    static_assert(n_components == 1,
+                                  "The path should be only accessed for a single component.");
+                    fe_eval.begin_values()[q] = temp;
+                  }
+                else if constexpr (std::is_same<
+                                     typename std::remove_const<decltype(temp)>::type,
+                                     Tensor<1, n_components, VectorizedArray<double>>>::value)
+                  {
+                    fe_eval.begin_values()[c * fe_eval.n_q_points + q] = temp[c];
+                  }
+                else
+                  {
+                    Assert(false, ExcNotImplemented());
+                  }
             }
 
           inverse_mass_matrix.transform_from_q_points_to_basis(n_components,

--- a/source/evaporation/evaporation_source_terms_continuous.cpp
+++ b/source/evaporation/evaporation_source_terms_continuous.cpp
@@ -129,7 +129,7 @@ namespace MeltPoolDG::Evaporation
      * write interface velocity to dof vector
      */
     if (scratch_data.is_hex_mesh())
-      UtilityFunctions::fill_dof_vector_from_cell_operation_vec<dim, dim>(
+      UtilityFunctions::fill_dof_vector_from_cell_operation<dim, dim>(
         evaporation_velocity,
         scratch_data.get_matrix_free(),
         evapor_vel_dof_idx,

--- a/source/evaporation/evaporation_source_terms_sharp.cpp
+++ b/source/evaporation/evaporation_source_terms_sharp.cpp
@@ -108,7 +108,7 @@ namespace MeltPoolDG::Evaporation
      * write interface velocity to dof vector
      */
     if (scratch_data.is_hex_mesh())
-      UtilityFunctions::fill_dof_vector_from_cell_operation_vec<dim, dim>(
+      UtilityFunctions::fill_dof_vector_from_cell_operation<dim, dim>(
         evaporation_velocity,
         scratch_data.get_matrix_free(),
         evapor_vel_dof_idx,

--- a/source/flow/adaflo_wrapper.cpp
+++ b/source/flow/adaflo_wrapper.cpp
@@ -383,7 +383,7 @@ namespace MeltPoolDG::Flow
     scratch_data.initialize_dof_vector(density, dof_index_parameters);
 
     if (scratch_data.is_hex_mesh())
-      UtilityFunctions::fill_dof_vector_from_cell_operation<dim>(
+      UtilityFunctions::fill_dof_vector_from_cell_operation<dim, 1>(
         density,
         scratch_data.get_matrix_free(),
         dof_index_parameters,
@@ -399,7 +399,7 @@ namespace MeltPoolDG::Flow
      */
     scratch_data.initialize_dof_vector(viscosity, dof_index_parameters);
     if (scratch_data.is_hex_mesh())
-      UtilityFunctions::fill_dof_vector_from_cell_operation<dim>(
+      UtilityFunctions::fill_dof_vector_from_cell_operation<dim, 1>(
         viscosity,
         scratch_data.get_matrix_free(),
         dof_index_parameters,

--- a/source/heat/heat_transfer_operator.cpp
+++ b/source/heat/heat_transfer_operator.cpp
@@ -654,7 +654,7 @@ namespace MeltPoolDG::Heat
       {
         scratch_data.initialize_dof_vector(evapor_heat_source, temp_dof_idx);
         if (!q_vapor.empty() && scratch_data.is_hex_mesh())
-          UtilityFunctions::fill_dof_vector_from_cell_operation<dim>(
+          UtilityFunctions::fill_dof_vector_from_cell_operation<dim, 1>(
             evapor_heat_source,
             scratch_data.get_matrix_free(),
             temp_dof_idx,

--- a/unit_tests/fill_dof_vector_from_cell_operation_vec_01.cc
+++ b/unit_tests/fill_dof_vector_from_cell_operation_vec_01.cc
@@ -55,14 +55,14 @@ test(const unsigned int fe_degree, const unsigned int n_q_points, const unsigned
 
 
   if (n_components == 1)
-    MeltPoolDG::UtilityFunctions::fill_dof_vector_from_cell_operation<dim>(
+    MeltPoolDG::UtilityFunctions::fill_dof_vector_from_cell_operation<dim, 1>(
       solution, matrix_free, 0, 0, [&](const auto cell, const auto q) -> VectorizedArray<double> {
         FECellIntegrator<dim, 1, double> fe_eval(matrix_free);
         fe_eval.reinit(cell);
         return fe_eval.quadrature_point(q)[0];
       });
   else
-    MeltPoolDG::UtilityFunctions::fill_dof_vector_from_cell_operation_vec<dim, dim>(
+    MeltPoolDG::UtilityFunctions::fill_dof_vector_from_cell_operation<dim, dim>(
       solution,
       matrix_free,
       0,


### PR DESCRIPTION
I just wanted to keep this out of PR #229. ~Only the last commit is relevant.~

Pre C++17, one could accomplish the same with specialized template functions. In most cases, the language does not actually adds anything new but "improves" the syntax.