### PR TITLE
Fix melt front propagation laser direction

### DIFF
--- a/include/meltpooldg/heat/laser_heat_source_gusarov.hpp
+++ b/include/meltpooldg/heat/laser_heat_source_gusarov.hpp
@@ -19,9 +19,9 @@ namespace MeltPoolDG::Heat
    * This class implements the laser heat source model of Gusarov et al. (2009).
    * DOI: 10.1115/1.3109245
    *
-   *                       2*R
-   *                      <--->
-   *                      | | |
+   *   ^ dim-1             2*R
+   *   |                  <--->
+   *   ----> x            | | |
    *                      | | |  laser beam
    *                      | | |     power
    *                      | | |
@@ -33,6 +33,7 @@ namespace MeltPoolDG::Heat
    *                 +++        +++            |
    *                     ++++++                v
    *
+   * The laser beam is direction is assumed to be in the negative dim-1 direction.
    */
   template <int dim>
   class LaserHeatSourceGusarov : public LaserHeatSourceBase<dim>

--- a/include/meltpooldg/simulations/melt_front_propagation/melt_front_propagation.hpp
+++ b/include/meltpooldg/simulations/melt_front_propagation/melt_front_propagation.hpp
@@ -103,8 +103,8 @@ namespace MeltPoolDG::Simulation::MeltFrontPropagation
           std::vector<unsigned> refinements(2, 1);
           refinements[0] = 3;
           // create mesh
-          const Point<2> left(0, 0);
-          const Point<2> right(x_max, y_max);
+          const Point<2> left(0, -z_max);
+          const Point<2> right(x_max, 0);
           GridGenerator::subdivided_hyper_rectangle(*this->triangulation, refinements, left, right);
           this->triangulation->refine_global(this->parameters.base.global_refinements);
         }
@@ -117,7 +117,7 @@ namespace MeltPoolDG::Simulation::MeltFrontPropagation
           refinements[1] = 3;
           // create mesh
           const Point<3> left(0, 0, 0);
-          const Point<3> right(x_max, y_max, z_max);
+          const Point<3> right(x_max, y_max, -z_max);
           GridGenerator::subdivided_hyper_rectangle(*this->triangulation, refinements, left, right);
           this->triangulation->refine_global(this->parameters.base.global_refinements);
         }

--- a/include/meltpooldg/simulations/melt_front_propagation/melt_front_propagation_static_gusarov.json
+++ b/include/meltpooldg/simulations/melt_front_propagation/melt_front_propagation_static_gusarov.json
@@ -19,7 +19,7 @@
     "heat nlsolve residual tolerance": "1e-8"
   },
   "laser": {
-    "laser power": "30.",
+    "laser power": "5.",
     "laser center": "0.0,0.0",
     "laser do move": "false",
     "laser heat source model": "Gusarov",

--- a/tests/melt_front_propagation_static_gusarov.json
+++ b/tests/melt_front_propagation_static_gusarov.json
@@ -19,7 +19,7 @@
     "heat nlsolve residual tolerance": "1e-8"
   },
   "laser": {
-    "laser power": "30.",
+    "laser power": "5.",
     "laser center": "0.0,0.0",
     "laser do move": "false",
     "laser heat source model": "Gusarov",

--- a/tests/melt_front_propagation_static_gusarov.mpirun=4.output
+++ b/tests/melt_front_propagation_static_gusarov.mpirun=4.output
@@ -1,5 +1,5 @@
-t= 5e-06     Newton Raphson solver converged: ||solution|| = 3.46465e-01
-t= 1e-05     Newton Raphson solver converged: ||solution|| = 3.46522e-01
-t= 1.5e-05   Newton Raphson solver converged: ||solution|| = 3.46580e-01
-t= 2e-05     Newton Raphson solver converged: ||solution|| = 3.46639e-01
-t= 2.5e-05   Newton Raphson solver converged: ||solution|| = 3.46698e-01
+t= 5e-06     Newton Raphson solver converged: ||solution|| = 3.46470e-01
+t= 1e-05     Newton Raphson solver converged: ||solution|| = 3.46530e-01
+t= 1.5e-05   Newton Raphson solver converged: ||solution|| = 3.46591e-01
+t= 2e-05     Newton Raphson solver converged: ||solution|| = 3.46653e-01
+t= 2.5e-05   Newton Raphson solver converged: ||solution|| = 3.46715e-01

--- a/tests/melt_front_propagation_static_gusarov_amr.mpirun=4.output
+++ b/tests/melt_front_propagation_static_gusarov_amr.mpirun=4.output
@@ -1,5 +1,5 @@
-t= 5e-06     Newton Raphson solver converged: ||solution|| = 3.46522e-01
-t= 1e-05     Newton Raphson solver converged: ||solution|| = 3.46580e-01
-t= 1.5e-05   Newton Raphson solver converged: ||solution|| = 3.46608e-01
-t= 2e-05     Newton Raphson solver converged: ||solution|| = 3.46637e-01
-t= 2.5e-05   Newton Raphson solver converged: ||solution|| = 3.46666e-01
+t= 5e-06     Newton Raphson solver converged: ||solution|| = 3.46780e-01
+t= 1e-05     Newton Raphson solver converged: ||solution|| = 3.47179e-01
+t= 1.5e-05   Newton Raphson solver converged: ||solution|| = 3.47606e-01
+t= 2e-05     Newton Raphson solver converged: ||solution|| = 3.48057e-01
+t= 2.5e-05   Newton Raphson solver converged: ||solution|| = 3.48530e-01


### PR DESCRIPTION
This PR fixes the domain of the melt front simulation, so that the laser heat soure acts opon the material correctly.
Fyi @mschreter 