### PR TITLE
Add interface laser heat source

### DIFF
--- a/include/meltpooldg/heat/heat_transfer_operation.hpp
+++ b/include/meltpooldg/heat/heat_transfer_operation.hpp
@@ -106,5 +106,8 @@ namespace MeltPoolDG::Heat
 
     VectorType &
     get_heat_source();
+
+    const VectorType &
+    get_level_set_as_heaviside() const;
   };
 } // namespace MeltPoolDG::Heat

--- a/include/meltpooldg/heat/heat_transfer_problem.hpp
+++ b/include/meltpooldg/heat/heat_transfer_problem.hpp
@@ -12,6 +12,8 @@
 #include <deal.II/lac/generic_linear_algebra.h>
 
 #include <meltpooldg/heat/heat_transfer_operation.hpp>
+#include <meltpooldg/heat/laser.hpp>
+#include <meltpooldg/heat/laser_heat_source_base.hpp>
 #include <meltpooldg/interface/problem_base.hpp>
 #include <meltpooldg/interface/scratch_data.hpp>
 #include <meltpooldg/utilities/postprocessor.hpp>
@@ -50,6 +52,9 @@ namespace MeltPoolDG::Heat
     std::shared_ptr<ScratchData<dim>>           scratch_data;
     std::shared_ptr<HeatTransferOperation<dim>> heat_operation;
     std::shared_ptr<Postprocessor<dim>>         post_processor;
+
+    std::shared_ptr<Heat::LaserOperation<dim>>      laser_operation;
+    std::shared_ptr<Heat::LaserHeatSourceBase<dim>> laser_heat_source_operation;
 
   public:
     HeatTransferProblem() = default;

--- a/include/meltpooldg/heat/laser_heat_source_base.hpp
+++ b/include/meltpooldg/heat/laser_heat_source_base.hpp
@@ -17,7 +17,7 @@ namespace MeltPoolDG::Heat
   {
   public:
     /**
-     * Compute a DoF vector of the heat source.
+     * Compute a DoF vector of the heat source for volumetric laser.
      */
     void
     compute_volumetric_heat_source(VectorType &            heat_source_vector,
@@ -28,11 +28,34 @@ namespace MeltPoolDG::Heat
                                    bool                    zero_out = true) const;
 
     /**
+     * Compute a DoF vector of the heat source for interface laser.
+     */
+    virtual void
+    compute_interface_heat_source(VectorType &            heat_source_vector,
+                                  const ScratchData<dim> &scratch_data,
+                                  unsigned int            temp_dof_idx,
+                                  double                  laser_power,
+                                  const Point<dim> &      laser_position,
+                                  const VectorType &      level_set_heaviside,
+                                  unsigned int            ls_dof_idx,
+                                  bool                    zero_out = true) const = 0;
+
+    /**
      * Local volumetric heat source
      */
     virtual double
     local_compute_volumetric_heat_source(const Point<dim> &position,
                                          const Point<dim> &laser_position,
                                          double            power) const = 0;
+
+    /**
+     * Local interface heat source at two-phase interface
+     */
+    virtual double
+    local_compute_interface_heat_source(const Point<dim> &            position,
+                                        const Point<dim> &            laser_position,
+                                        double                        power,
+                                        const Tensor<1, dim, double> &normal_vector,
+                                        double                        delta_value) const = 0;
   };
 } // namespace MeltPoolDG::Heat

--- a/include/meltpooldg/heat/laser_heat_source_base.hpp
+++ b/include/meltpooldg/heat/laser_heat_source_base.hpp
@@ -17,7 +17,7 @@ namespace MeltPoolDG::Heat
   {
   public:
     /**
-     * Compute a DoF vector of the heat source for volumetric laser.
+     * Compute a DoF vector of the volumetric heat source.
      */
     void
     compute_volumetric_heat_source(VectorType &            heat_source_vector,
@@ -28,17 +28,17 @@ namespace MeltPoolDG::Heat
                                    bool                    zero_out = true) const;
 
     /**
-     * Compute a DoF vector of the heat source for interface laser.
+     * Compute a DoF vector of the interfacial heat source.
      */
     virtual void
-    compute_interface_heat_source(VectorType &            heat_source_vector,
-                                  const ScratchData<dim> &scratch_data,
-                                  unsigned int            temp_dof_idx,
-                                  double                  laser_power,
-                                  const Point<dim> &      laser_position,
-                                  const VectorType &      level_set_heaviside,
-                                  unsigned int            ls_dof_idx,
-                                  bool                    zero_out = true) const = 0;
+    compute_interfacial_heat_source(VectorType &            heat_source_vector,
+                                    const ScratchData<dim> &scratch_data,
+                                    unsigned int            temp_dof_idx,
+                                    double                  laser_power,
+                                    const Point<dim> &      laser_position,
+                                    const VectorType &      level_set_heaviside,
+                                    unsigned int            ls_dof_idx,
+                                    bool                    zero_out = true) const = 0;
 
     /**
      * Local volumetric heat source
@@ -52,10 +52,10 @@ namespace MeltPoolDG::Heat
      * Local interface heat source at two-phase interface
      */
     virtual double
-    local_compute_interface_heat_source(const Point<dim> &            position,
-                                        const Point<dim> &            laser_position,
-                                        double                        power,
-                                        const Tensor<1, dim, double> &normal_vector,
-                                        double                        delta_value) const = 0;
+    local_compute_interfacial_heat_source(const Point<dim> &            position,
+                                          const Point<dim> &            laser_position,
+                                          double                        power,
+                                          const Tensor<1, dim, double> &normal_vector,
+                                          double                        delta_value) const = 0;
   };
 } // namespace MeltPoolDG::Heat

--- a/include/meltpooldg/heat/laser_heat_source_gauss.hpp
+++ b/include/meltpooldg/heat/laser_heat_source_gauss.hpp
@@ -13,11 +13,22 @@ namespace MeltPoolDG::Heat
   /**
    * Spherical gauss laser heat source.
    *
+   * Volumetric case:
    * local volumetric heat source p (W/m^3):
-   * p = absorptivity * p_peak * exp( -2 ||x - laser_center||^2 / laser_radius^2 ) [1]
+   * p = absorptivity * p_peak * exp( -2 ||x - laser_center||^2 / laser_radius^2 )
    *
    * with peak laser power density p_peak:
    * p_peak = laser_power / ( laser_radius * sqrt(pi/2) )^3
+   *
+   * Interface case:
+   * p = absorptivity * < -interface_normal * laser_direction > * p_peak *
+   * exp( -2 ||x - laser_center||^2 / laser_radius^2 ) delta_function [1]
+   *
+   * with peak laser power density p_peak:
+   * p_peak = laser_power / ( laser_radius^2 * pi/2 )
+   *
+   * The z-axis (= axis of the laser beam) is assumed to correspond to negative dim-1 coordinate.
+   *
    *
    * [1] Meier, C., Fuchs, S. L., Hart, A. J., & Wall, W. A. (2021). A novel smoothed particle
    * hydrodynamics formulation for thermo-capillary phase change problems with focus on metal
@@ -38,24 +49,64 @@ namespace MeltPoolDG::Heat
                                          const Point<dim> &laser_position,
                                          double            power) const final;
 
+    /**
+     * interface heat source
+     */
+    double
+    local_compute_interface_heat_source(const Point<dim> &            position,
+                                        const Point<dim> &            laser_position,
+                                        double                        power,
+                                        const Tensor<1, dim, double> &normal_vector,
+                                        double                        delta_value) const final;
+
+    /**
+     * Compute a DoF vector of the heat source for interface laser.
+     */
+    void
+    compute_interface_heat_source(VectorType &            heat_source_vector,
+                                  const ScratchData<dim> &scratch_data,
+                                  unsigned int            temp_dof_idx,
+                                  double                  laser_power,
+                                  const Point<dim> &      laser_position,
+                                  const VectorType &      level_set_heaviside,
+                                  unsigned int            ls_dof_idx,
+                                  bool                    zero_out = true) const;
+
   private:
     /*
-     * Laser power density.
+     * Laser power density in volumetric case.
      * returns: power * exp( -2 radius^2 / laser_radius^2 ) / ( laser_radius * sqrt(pi/2) )^3
      */
     double
-    power_density(double radius, double power) const;
+    power_density_volumetric(double radius, double power) const;
+
+    /*
+     * Laser power density in interface case.
+     * returns: power * exp( -2 radius^2 / laser_radius^2 ) / ( laser_radius^2 * pi/2 )
+     */
+    double
+    power_density_interface(double radius, double power) const;
 
     const LaserData<double>::GaussData data;
 
     /*
-     * Factor between peak power density and total laser power:
+     * Factor between peak power density and total laser power in volumetric case:
      * p_peak = laser_power * peak_power_density_factor
      *
-     * peak_power_density_factor = 1 / ( laser_radius * sqrt(pi/2) )^3
+     * vol_peak_power_density_factor = 1 / ( laser_radius * sqrt(pi/2) )^3
      *
      * So that laser_power = int_R^3 p dx
      */
-    const double peak_power_density_factor;
+    const double vol_peak_power_density_factor;
+
+    /*
+     * Factor between peak power density and total laser power in interface case:
+     * p_peak = laser_power * peak_power_density_factor
+     *
+     * surf_peak_power_density_factor = 1 / ( laser_radius^2 * pi/2 )
+     *
+     * So that laser_power = int_R^2 p dx
+     */
+    const double surf_peak_power_density_factor;
   };
 } // namespace MeltPoolDG::Heat

--- a/include/meltpooldg/heat/laser_heat_source_gauss.hpp
+++ b/include/meltpooldg/heat/laser_heat_source_gauss.hpp
@@ -53,24 +53,24 @@ namespace MeltPoolDG::Heat
      * interface heat source
      */
     double
-    local_compute_interface_heat_source(const Point<dim> &            position,
-                                        const Point<dim> &            laser_position,
-                                        double                        power,
-                                        const Tensor<1, dim, double> &normal_vector,
-                                        double                        delta_value) const final;
+    local_compute_interfacial_heat_source(const Point<dim> &            position,
+                                          const Point<dim> &            laser_position,
+                                          double                        power,
+                                          const Tensor<1, dim, double> &normal_vector,
+                                          double                        delta_value) const final;
 
     /**
      * Compute a DoF vector of the heat source for interface laser.
      */
     void
-    compute_interface_heat_source(VectorType &            heat_source_vector,
-                                  const ScratchData<dim> &scratch_data,
-                                  unsigned int            temp_dof_idx,
-                                  double                  laser_power,
-                                  const Point<dim> &      laser_position,
-                                  const VectorType &      level_set_heaviside,
-                                  unsigned int            ls_dof_idx,
-                                  bool                    zero_out = true) const;
+    compute_interfacial_heat_source(VectorType &            heat_source_vector,
+                                    const ScratchData<dim> &scratch_data,
+                                    unsigned int            temp_dof_idx,
+                                    double                  laser_power,
+                                    const Point<dim> &      laser_position,
+                                    const VectorType &      level_set_heaviside,
+                                    unsigned int            ls_dof_idx,
+                                    bool                    zero_out = true) const;
 
   private:
     /*
@@ -85,7 +85,7 @@ namespace MeltPoolDG::Heat
      * returns: power * exp( -2 radius^2 / laser_radius^2 ) / ( laser_radius^2 * pi/2 )
      */
     double
-    power_density_interface(double radius, double power) const;
+    power_density_interfacial(double radius, double power) const;
 
     const LaserData<double>::GaussData data;
 

--- a/include/meltpooldg/heat/laser_heat_source_gusarov.hpp
+++ b/include/meltpooldg/heat/laser_heat_source_gusarov.hpp
@@ -61,21 +61,21 @@ namespace MeltPoolDG::Heat
                                          double            power) const final;
 
     void
-    compute_interface_heat_source(VectorType &            heat_source_vector,
-                                  const ScratchData<dim> &scratch_data,
-                                  unsigned int            temp_dof_idx,
-                                  double                  laser_power,
-                                  const Point<dim> &      laser_position,
-                                  const VectorType &      level_set_heaviside,
-                                  unsigned int            ls_dof_idx,
-                                  bool                    zero_out = true) const final;
+    compute_interfacial_heat_source(VectorType &            heat_source_vector,
+                                    const ScratchData<dim> &scratch_data,
+                                    unsigned int            temp_dof_idx,
+                                    double                  laser_power,
+                                    const Point<dim> &      laser_position,
+                                    const VectorType &      level_set_heaviside,
+                                    unsigned int            ls_dof_idx,
+                                    bool                    zero_out = true) const final;
 
     double
-    local_compute_interface_heat_source(const Point<dim> &            position,
-                                        const Point<dim> &            laser_position,
-                                        double                        power,
-                                        const Tensor<1, dim, double> &normal_vector,
-                                        double                        delta_value) const final;
+    local_compute_interfacial_heat_source(const Point<dim> &            position,
+                                          const Point<dim> &            laser_position,
+                                          double                        power,
+                                          const Tensor<1, dim, double> &normal_vector,
+                                          double                        delta_value) const final;
 
   private:
     /**

--- a/include/meltpooldg/heat/laser_heat_source_gusarov.hpp
+++ b/include/meltpooldg/heat/laser_heat_source_gusarov.hpp
@@ -60,6 +60,23 @@ namespace MeltPoolDG::Heat
                                          const Point<dim> &laser_position,
                                          double            power) const final;
 
+    void
+    compute_interface_heat_source(VectorType &            heat_source_vector,
+                                  const ScratchData<dim> &scratch_data,
+                                  unsigned int            temp_dof_idx,
+                                  double                  laser_power,
+                                  const Point<dim> &      laser_position,
+                                  const VectorType &      level_set_heaviside,
+                                  unsigned int            ls_dof_idx,
+                                  bool                    zero_out = true) const final;
+
+    double
+    local_compute_interface_heat_source(const Point<dim> &            position,
+                                        const Point<dim> &            laser_position,
+                                        double                        power,
+                                        const Tensor<1, dim, double> &normal_vector,
+                                        double                        delta_value) const final;
+
   private:
     /**
      * Equation (26) corrected to match Figure 5 of Gusarov et al. (2009)

--- a/include/meltpooldg/interface/parameters.hpp
+++ b/include/meltpooldg/interface/parameters.hpp
@@ -172,7 +172,7 @@ namespace MeltPoolDG
     bool        do_move                            = false;
     number      scan_speed                         = 0.0;
     bool        variable_properties_over_interface = false;
-    std::string impact                             = "volumetric";
+    std::string impact_type                        = "volumetric";
     std::string heat_source_model                  = "Gusarov";
     struct GusarovData
     {

--- a/include/meltpooldg/interface/parameters.hpp
+++ b/include/meltpooldg/interface/parameters.hpp
@@ -172,6 +172,7 @@ namespace MeltPoolDG
     bool        do_move                            = false;
     number      scan_speed                         = 0.0;
     bool        variable_properties_over_interface = false;
+    std::string impact                             = "volumetric";
     std::string heat_source_model                  = "Gusarov";
     struct GusarovData
     {

--- a/include/meltpooldg/simulations/melt_front_propagation/melt_front_propagation.hpp
+++ b/include/meltpooldg/simulations/melt_front_propagation/melt_front_propagation.hpp
@@ -42,33 +42,27 @@ namespace MeltPoolDG::Simulation::MeltFrontPropagation
   static constexpr double T_0 = 1000.0;
 
   template <int dim>
-  class LaserHeatSourceFunction : public Function<dim>
+  class InitialLevelSetHeaviside : public Function<dim>
   {
   public:
-    LaserHeatSourceFunction(const LaserData<double> &laser_data)
+    InitialLevelSetHeaviside(const double z_level, const double eps)
       : Function<dim>()
-      , center(MeltPoolDG::UtilityFunctions::convert_string_coords_to_point<dim>(laser_data.center))
-      , power(laser_data.power)
-    {
-      if (laser_data.heat_source_model == "Gusarov")
-        laser_model = std::make_unique<Heat::LaserHeatSourceGusarov<dim>>(laser_data.gusarov);
-      else if (laser_data.heat_source_model == "Gauss")
-        laser_model = std::make_unique<Heat::LaserHeatSourceGauss<dim>>(laser_data.gauss);
-      else
-        AssertThrow(false, ExcMessage("Unknown laser heat source model! Abort..."));
-    }
+      , z_level(z_level)
+      , eps(eps)
+    {}
 
     double
     value(const Point<dim> &p, const unsigned int /*component*/) const
     {
-      return laser_model->local_compute_volumetric_heat_source(p, center, power);
+      const auto z = p[dim - 1];
+      return UtilityFunctions::CharacteristicFunctions::heaviside(z_level - z, eps);
     }
 
   private:
-    std::unique_ptr<Heat::LaserHeatSourceBase<dim>> laser_model;
-    Point<dim>                                      center;
-    const double                                    power;
+    const double z_level;
+    const double eps;
   };
+
 
   template <int dim>
   class SimulationMeltFrontPropagation : public SimulationBase<dim>
@@ -100,26 +94,69 @@ namespace MeltPoolDG::Simulation::MeltFrontPropagation
         {
           this->triangulation =
             std::make_shared<parallel::distributed::Triangulation<2>>(this->mpi_communicator);
-          std::vector<unsigned> refinements(2, 1);
-          refinements[0] = 3;
-          // create mesh
-          const Point<2> left(0, -z_max);
-          const Point<2> right(x_max, 0);
-          GridGenerator::subdivided_hyper_rectangle(*this->triangulation, refinements, left, right);
-          this->triangulation->refine_global(this->parameters.base.global_refinements);
+
+          if (!this->parameters.heat.two_phase)
+            {
+              std::vector<unsigned> refinements(2, 1);
+              refinements[0] = 3;
+              // create mesh
+              const Point<2> left(0, -z_max);
+              const Point<2> right(x_max, 0);
+              GridGenerator::subdivided_hyper_rectangle(*this->triangulation,
+                                                        refinements,
+                                                        left,
+                                                        right);
+              this->triangulation->refine_global(this->parameters.base.global_refinements);
+            }
+          else
+            {
+              std::vector<unsigned> refinements(2, 1);
+              refinements[0] = 3;
+              refinements[1] = 2;
+              // create mesh
+              const Point<2> left(0, -z_max);
+              const Point<2> right(x_max, z_max);
+              GridGenerator::subdivided_hyper_rectangle(*this->triangulation,
+                                                        refinements,
+                                                        left,
+                                                        right);
+              this->triangulation->refine_global(this->parameters.base.global_refinements);
+            }
         }
       else if constexpr (dim == 3)
         {
           this->triangulation =
             std::make_shared<parallel::distributed::Triangulation<3>>(this->mpi_communicator);
-          std::vector<unsigned int> refinements(3, 1);
-          refinements[0] = 3;
-          refinements[1] = 3;
-          // create mesh
-          const Point<3> left(0, 0, 0);
-          const Point<3> right(x_max, y_max, -z_max);
-          GridGenerator::subdivided_hyper_rectangle(*this->triangulation, refinements, left, right);
-          this->triangulation->refine_global(this->parameters.base.global_refinements);
+
+          if (!this->parameters.heat.two_phase)
+            {
+              std::vector<unsigned int> refinements(3, 1);
+              refinements[0] = 3;
+              refinements[1] = 3;
+              // create mesh
+              const Point<3> left(0, 0, 0);
+              const Point<3> right(x_max, y_max, -z_max);
+              GridGenerator::subdivided_hyper_rectangle(*this->triangulation,
+                                                        refinements,
+                                                        left,
+                                                        right);
+              this->triangulation->refine_global(this->parameters.base.global_refinements);
+            }
+          else
+            {
+              std::vector<unsigned int> refinements(3, 1);
+              refinements[0] = 3;
+              refinements[1] = 3;
+              refinements[2] = 2;
+              // create mesh
+              const Point<3> left(0, 0, z_max);
+              const Point<3> right(x_max, y_max, -z_max);
+              GridGenerator::subdivided_hyper_rectangle(*this->triangulation,
+                                                        refinements,
+                                                        left,
+                                                        right);
+              this->triangulation->refine_global(this->parameters.base.global_refinements);
+            }
         }
       else
         AssertThrow(false, ExcMessage("Impossible dimension! Abort ..."));
@@ -149,8 +186,12 @@ namespace MeltPoolDG::Simulation::MeltFrontPropagation
     {
       this->attach_initial_condition(std::make_shared<Functions::ConstantFunction<dim>>(T_0),
                                      "heat_transfer");
-      this->attach_source_field(
-        std::make_shared<LaserHeatSourceFunction<dim>>(this->parameters.laser), "heat_transfer");
+      if (this->parameters.heat.two_phase)
+        this->attach_initial_condition(std::make_shared<InitialLevelSetHeaviside<dim>>(0.0,
+                                                                                       z_max / 5),
+                                       "prescribed_level_set");
+      this->attach_velocity_field(std::make_shared<Functions::ZeroFunction<dim>>(dim),
+                                  "heat_transfer");
     }
   };
 } // namespace MeltPoolDG::Simulation::MeltFrontPropagation

--- a/include/meltpooldg/simulations/melt_front_propagation/melt_front_propagation_static_interface_gauss.json
+++ b/include/meltpooldg/simulations/melt_front_propagation/melt_front_propagation_static_interface_gauss.json
@@ -1,0 +1,50 @@
+{
+  "base": {
+    "application name": "melt_front_propagation",
+    "degree": "1",
+    "dimension": "2",
+    "do print parameters": "false",
+    "global refinements": "5",
+    "problem name": "heat_transfer",
+    "verbosity level": "2"
+  },
+  "heat": {
+    "heat start time": "0.0",
+    "heat time step size": "1e-4",
+    "heat end time": "0.015",
+    "heat max n steps": "150",
+    "heat velocity": "-1",
+    "heat solidification": "true",
+    "heat two phase": "true",
+    "heat solver rel tolerance": "1e-12",
+    "heat solver preconditioner type": "ILU",
+    "heat nlsolve residual tolerance": "1e-8"
+  },
+  "laser": {
+    "laser power": "10.",
+    "laser center": "0.0,0.0",
+    "laser do move": "false",
+    "laser heat source model": "Gauss",
+    "laser impact": "interface",
+    "laser gauss laser beam radius": "0.06e-3",
+    "laser gauss absorptivity": "0.5"
+  },
+  "material": {
+    "material first capacity": "0",
+    "material first conductivity": "10",
+    "material first density": "74.30",
+    "material second conductivity": "55.563",
+    "material second capacity": "460.0",
+    "material second density": "7850.0",
+    "material solid conductivity": "17.0",
+    "material solid capacity": "700.0",
+    "material solid density": "7850.0",
+    "material solidus temperature": "1966.0",
+    "material liquidus temperature": "1974.0"
+  },
+  "paraview": {
+    "paraview do output": "true",
+    "paraview directory": "output",
+    "paraview filename": "melt_front_propagation_static_surface_gauss"
+  }
+}

--- a/include/meltpooldg/simulations/melt_front_propagation/melt_front_propagation_static_interface_gauss.json
+++ b/include/meltpooldg/simulations/melt_front_propagation/melt_front_propagation_static_interface_gauss.json
@@ -25,7 +25,7 @@
     "laser center": "0.0,0.0",
     "laser do move": "false",
     "laser heat source model": "Gauss",
-    "laser impact": "interface",
+    "laser impact type": "interface",
     "laser gauss laser beam radius": "0.06e-3",
     "laser gauss absorptivity": "0.5"
   },

--- a/source/heat/heat_transfer_operation.cpp
+++ b/source/heat/heat_transfer_operation.cpp
@@ -264,6 +264,10 @@ namespace MeltPoolDG::Heat
   const VectorType &
   HeatTransferOperation<dim>::get_level_set_as_heaviside() const
   {
+    Assert(
+      level_set_as_heaviside,
+      ExcMessage(
+        "You requested the level set vector from the heat operation, which is a nullptr. You must provide a valid level_set_as_heaviside pointer to the heat operation."));
     return *level_set_as_heaviside;
   }
 

--- a/source/heat/heat_transfer_operation.cpp
+++ b/source/heat/heat_transfer_operation.cpp
@@ -260,6 +260,13 @@ namespace MeltPoolDG::Heat
     return heat_source;
   }
 
+  template <int dim>
+  const VectorType &
+  HeatTransferOperation<dim>::get_level_set_as_heaviside() const
+  {
+    return *level_set_as_heaviside;
+  }
+
   template class HeatTransferOperation<1>;
   template class HeatTransferOperation<2>;
   template class HeatTransferOperation<3>;

--- a/source/heat/heat_transfer_problem.cpp
+++ b/source/heat/heat_transfer_problem.cpp
@@ -49,7 +49,7 @@ namespace MeltPoolDG::Heat
           {
             laser_operation->move_laser(dt);
 
-            if (base_in->parameters.laser.impact == "volumetric")
+            if (base_in->parameters.laser.impact_type == "volumetric")
               laser_heat_source_operation->compute_volumetric_heat_source(
                 heat_operation->get_heat_source(),
                 *scratch_data,
@@ -57,8 +57,8 @@ namespace MeltPoolDG::Heat
                 laser_operation->get_laser_power(),
                 laser_operation->get_laser_position(),
                 true /* zero_out */);
-            else if (base_in->parameters.laser.impact == "interface")
-              laser_heat_source_operation->compute_interface_heat_source(
+            else if (base_in->parameters.laser.impact_type == "interface")
+              laser_heat_source_operation->compute_interfacial_heat_source(
                 heat_operation->get_heat_source(),
                 *scratch_data,
                 temp_dof_idx,

--- a/source/heat/heat_transfer_problem.cpp
+++ b/source/heat/heat_transfer_problem.cpp
@@ -10,6 +10,8 @@
 
 #include <deal.II/numerics/error_estimator.h>
 
+#include <meltpooldg/heat/laser_heat_source_gauss.hpp>
+#include <meltpooldg/heat/laser_heat_source_gusarov.hpp>
 #include <meltpooldg/utilities/amr.hpp>
 #include <meltpooldg/utilities/generic_data_out.hpp>
 
@@ -29,11 +31,6 @@ namespace MeltPoolDG::Heat
         scratch_data->get_pcout() << "t= " << std::setw(10) << std::left
                                   << time_iterator.get_current_time();
 
-        if (const auto source_field_function = base_in->get_source_field("heat_transfer"))
-          compute_field_vector(heat_operation->get_heat_source(),
-                               temp_dof_idx,
-                               *source_field_function);
-
         if (const auto velocity_field_function = base_in->get_velocity_field("heat_transfer"))
           compute_field_vector(velocity, velocity_dof_idx, *velocity_field_function);
 
@@ -41,6 +38,38 @@ namespace MeltPoolDG::Heat
           compute_field_vector(level_set_as_heaviside,
                                level_set_dof_idx,
                                *base_in->get_initial_condition("prescribed_level_set"));
+
+        if (const auto source_field_function = base_in->get_source_field("heat_transfer"))
+          compute_field_vector(heat_operation->get_heat_source(),
+                               temp_dof_idx,
+                               *source_field_function);
+        // TODO: Atm the laser heat source will overwrite the heat source field function if both are
+        // given. Instead they should be added.
+        if (laser_operation)
+          {
+            laser_operation->move_laser(dt);
+
+            if (base_in->parameters.laser.impact == "volumetric")
+              laser_heat_source_operation->compute_volumetric_heat_source(
+                heat_operation->get_heat_source(),
+                *scratch_data,
+                temp_dof_idx,
+                laser_operation->get_laser_power(),
+                laser_operation->get_laser_position(),
+                true /* zero_out */);
+            else if (base_in->parameters.laser.impact == "interface")
+              laser_heat_source_operation->compute_interface_heat_source(
+                heat_operation->get_heat_source(),
+                *scratch_data,
+                temp_dof_idx,
+                laser_operation->get_laser_power(),
+                laser_operation->get_laser_position(),
+                heat_operation->get_level_set_as_heaviside(),
+                level_set_dof_idx,
+                true /* zero_out */);
+            else
+              AssertThrow(false, ExcMessage("Unknown laser impact type! Abort..."));
+          }
 
         heat_operation->solve(dt);
 
@@ -154,6 +183,33 @@ namespace MeltPoolDG::Heat
                              level_set_dof_idx,
                              *base_in->get_initial_condition("prescribed_level_set"));
         level_set_as_heaviside_ptr = &level_set_as_heaviside;
+      }
+
+    if (base_in->parameters.laser.power > 0.0)
+      {
+        /*
+         *  initialize the laser operation class
+         */
+        laser_operation = std::make_shared<Heat::LaserOperation<dim>>(*scratch_data,
+                                                                      base_in->parameters.laser,
+                                                                      base_in->parameters.material);
+        laser_operation->set_initial_condition(base_in->parameters.heat.time_stepping.start_time);
+
+        if (base_in->parameters.laser.heat_source_model == "Gusarov")
+          {
+            laser_heat_source_operation = std::make_shared<Heat::LaserHeatSourceGusarov<dim>>(
+              base_in->parameters.laser.gusarov);
+          }
+        else if (base_in->parameters.laser.heat_source_model == "Gauss")
+          {
+            laser_heat_source_operation =
+              std::make_shared<Heat::LaserHeatSourceGauss<dim>>(base_in->parameters.laser.gauss);
+          }
+        else
+          AssertThrow(false,
+                      ExcMessage(
+                        "No requested laser model found. Please speficy the "
+                        "heat source model in the laser section of the input parameters."));
       }
 
     /*

--- a/source/heat/laser.cpp
+++ b/source/heat/laser.cpp
@@ -19,8 +19,8 @@ namespace MeltPoolDG::Heat
   {
     current_time = start_time;
     compute_laser_intensity();
-    scratch_data.get_pcout(1) << "current laser position: " << laser_position << std::endl;
-    scratch_data.get_pcout(1) << "current laser intensity: " << laser_intensity << std::endl;
+    scratch_data.get_pcout() << "current laser position: " << laser_position << std::endl;
+    scratch_data.get_pcout() << "current laser intensity: " << laser_intensity << std::endl;
   }
 
   template <int dim>
@@ -35,8 +35,8 @@ namespace MeltPoolDG::Heat
     // 2) update intensity of the laser
     compute_laser_intensity();
 
-    scratch_data.get_pcout(1) << "current laser position: " << laser_position << std::endl;
-    scratch_data.get_pcout(1) << "current laser intensity: " << laser_intensity << std::endl;
+    scratch_data.get_pcout() << "current laser position: " << laser_position << std::endl;
+    scratch_data.get_pcout() << "current laser intensity: " << laser_intensity << std::endl;
   }
 
   template <int dim>

--- a/source/heat/laser.cpp
+++ b/source/heat/laser.cpp
@@ -19,8 +19,8 @@ namespace MeltPoolDG::Heat
   {
     current_time = start_time;
     compute_laser_intensity();
-    scratch_data.get_pcout() << "current laser position: " << laser_position << std::endl;
-    scratch_data.get_pcout() << "current laser intensity: " << laser_intensity << std::endl;
+    scratch_data.get_pcout(1) << "current laser position: " << laser_position << std::endl;
+    scratch_data.get_pcout(1) << "current laser intensity: " << laser_intensity << std::endl;
   }
 
   template <int dim>
@@ -35,8 +35,8 @@ namespace MeltPoolDG::Heat
     // 2) update intensity of the laser
     compute_laser_intensity();
 
-    scratch_data.get_pcout() << "current laser position: " << laser_position << std::endl;
-    scratch_data.get_pcout() << "current laser intensity: " << laser_intensity << std::endl;
+    scratch_data.get_pcout(1) << "current laser position: " << laser_position << std::endl;
+    scratch_data.get_pcout(1) << "current laser intensity: " << laser_intensity << std::endl;
   }
 
   template <int dim>

--- a/source/heat/laser_heat_source_gauss.cpp
+++ b/source/heat/laser_heat_source_gauss.cpp
@@ -27,7 +27,7 @@ namespace MeltPoolDG::Heat
 
   template <int dim>
   double
-  LaserHeatSourceGauss<dim>::local_compute_interface_heat_source(
+  LaserHeatSourceGauss<dim>::local_compute_interfacial_heat_source(
     const Point<dim> &            position,
     const Point<dim> &            laser_position,
     double                        power,
@@ -48,19 +48,19 @@ namespace MeltPoolDG::Heat
       projection_factor = 0.0;
 
     return data.absorptivity * projection_factor * delta_value *
-           power_density_interface(distance, power);
+           power_density_interfacial(distance, power);
   }
 
   template <int dim>
   void
-  LaserHeatSourceGauss<dim>::compute_interface_heat_source(VectorType &heat_source_vector,
-                                                           const ScratchData<dim> &scratch_data,
-                                                           const unsigned int      temp_dof_idx,
-                                                           const double            laser_power,
-                                                           const Point<dim> &      laser_position,
-                                                           const VectorType & level_set_heaviside,
-                                                           const unsigned int ls_dof_idx,
-                                                           const bool         zero_out) const
+  LaserHeatSourceGauss<dim>::compute_interfacial_heat_source(VectorType &heat_source_vector,
+                                                             const ScratchData<dim> &scratch_data,
+                                                             const unsigned int      temp_dof_idx,
+                                                             const double            laser_power,
+                                                             const Point<dim> &      laser_position,
+                                                             const VectorType & level_set_heaviside,
+                                                             const unsigned int ls_dof_idx,
+                                                             const bool         zero_out) const
   {
     if (zero_out)
       scratch_data.initialize_dof_vector(heat_source_vector, temp_dof_idx);
@@ -76,7 +76,8 @@ namespace MeltPoolDG::Heat
     FEValues<dim> ls_heaviside_eval(
       scratch_data.get_mapping(),
       scratch_data.get_dof_handler(ls_dof_idx).get_fe(),
-      Quadrature<dim>(scratch_data.get_dof_handler(ls_dof_idx).get_fe().get_unit_support_points()),
+      Quadrature<dim>(
+        scratch_data.get_dof_handler(temp_dof_idx).get_fe().get_unit_support_points()),
       update_gradients);
 
     const unsigned int dofs_per_cell =
@@ -105,14 +106,15 @@ namespace MeltPoolDG::Heat
                     heat_source_vector[local_dof_indices[q]] = 0.0;
                     continue;
                   }
+                // TODO: use computed normal vector
                 const Tensor<1, dim, double> normal_vector = grad_ls_heaviside[q] / delta_value;
 
                 const double temp =
-                  local_compute_interface_heat_source(heat_source_eval.quadrature_point(q),
-                                                      laser_position,
-                                                      laser_power,
-                                                      normal_vector,
-                                                      delta_value);
+                  local_compute_interfacial_heat_source(heat_source_eval.quadrature_point(q),
+                                                        laser_position,
+                                                        laser_power,
+                                                        normal_vector,
+                                                        delta_value);
                 heat_source_vector[local_dof_indices[q]] = temp;
               }
           }
@@ -130,7 +132,7 @@ namespace MeltPoolDG::Heat
 
   template <int dim>
   double
-  LaserHeatSourceGauss<dim>::power_density_interface(double radius, double power) const
+  LaserHeatSourceGauss<dim>::power_density_interfacial(double radius, double power) const
   {
     const double s          = radius / data.laser_beam_radius;
     const double peak_power = power * surf_peak_power_density_factor;

--- a/source/heat/laser_heat_source_gauss.cpp
+++ b/source/heat/laser_heat_source_gauss.cpp
@@ -6,8 +6,10 @@ namespace MeltPoolDG::Heat
   template <int dim>
   LaserHeatSourceGauss<dim>::LaserHeatSourceGauss(const LaserData<double>::GaussData &data_in)
     : data(data_in)
-    , peak_power_density_factor(1. /
-                                std::pow(data.laser_beam_radius * std::sqrt(numbers::PI / 2), 3))
+    , vol_peak_power_density_factor(
+        1. / std::pow(data.laser_beam_radius * std::sqrt(numbers::PI / 2), 3))
+    , surf_peak_power_density_factor(
+        1. / (data.laser_beam_radius * data.laser_beam_radius * numbers::PI / 2))
   {
     AssertThrow(data.laser_beam_radius > 0.0,
                 ExcMessage("The laser beam radius must be greater than zero! Abort.."));
@@ -20,15 +22,118 @@ namespace MeltPoolDG::Heat
                                                                   const double      power) const
   {
     const double distance = position.distance(laser_position);
-    return data.absorptivity * power_density(distance, power);
+    return data.absorptivity * power_density_volumetric(distance, power);
   }
 
   template <int dim>
   double
-  LaserHeatSourceGauss<dim>::power_density(const double radius, const double power) const
+  LaserHeatSourceGauss<dim>::local_compute_interface_heat_source(
+    const Point<dim> &            position,
+    const Point<dim> &            laser_position,
+    double                        power,
+    const Tensor<1, dim, double> &normal_vector,
+    double                        delta_value) const
+  {
+    // only consider distance in x (2D) or x and y (3D) direction. Disregard distance in dim-1
+    // direction.
+    Point<dim - 1> distance_vector;
+    distance_vector[0] = position[0] - laser_position[0];
+    if constexpr (dim == 3)
+      distance_vector[1] = position[1] - laser_position[1];
+    const double distance = distance_vector.norm();
+
+    // assume laser direction coincides with the negative dim-1 direction
+    double projection_factor = normal_vector * -Point<dim>::unit_vector(dim - 1);
+    if (projection_factor < 0.0)
+      projection_factor = 0.0;
+
+    return data.absorptivity * projection_factor * delta_value *
+           power_density_interface(distance, power);
+  }
+
+  template <int dim>
+  void
+  LaserHeatSourceGauss<dim>::compute_interface_heat_source(VectorType &heat_source_vector,
+                                                           const ScratchData<dim> &scratch_data,
+                                                           const unsigned int      temp_dof_idx,
+                                                           const double            laser_power,
+                                                           const Point<dim> &      laser_position,
+                                                           const VectorType & level_set_heaviside,
+                                                           const unsigned int ls_dof_idx,
+                                                           const bool         zero_out) const
+  {
+    if (zero_out)
+      scratch_data.initialize_dof_vector(heat_source_vector, temp_dof_idx);
+
+    FEValues<dim> heat_source_eval(
+      scratch_data.get_mapping(),
+      scratch_data.get_dof_handler(temp_dof_idx).get_fe(),
+      Quadrature<dim>(
+        scratch_data.get_dof_handler(temp_dof_idx).get_fe().get_unit_support_points()),
+      update_quadrature_points);
+
+    level_set_heaviside.update_ghost_values();
+    FEValues<dim> ls_heaviside_eval(
+      scratch_data.get_mapping(),
+      scratch_data.get_dof_handler(ls_dof_idx).get_fe(),
+      Quadrature<dim>(scratch_data.get_dof_handler(ls_dof_idx).get_fe().get_unit_support_points()),
+      update_gradients);
+
+    const unsigned int dofs_per_cell =
+      scratch_data.get_dof_handler(temp_dof_idx).get_fe().n_dofs_per_cell();
+    std::vector<types::global_dof_index> local_dof_indices(dofs_per_cell);
+    // TODO: find a better way to interpolate the (level-set dependent) laser heat source onto the
+    // heat source dof vector. Problem: if ls-degree=1, its gradient may be discontinuous!
+    for (const auto &cell : scratch_data.get_dof_handler(temp_dof_idx).active_cell_iterators())
+      {
+        if (cell->is_locally_owned())
+          {
+            cell->get_dof_indices(local_dof_indices);
+
+            heat_source_eval.reinit(cell);
+            ls_heaviside_eval.reinit(cell);
+
+            std::vector<dealii::Tensor<1, dim, double>> grad_ls_heaviside(
+              ls_heaviside_eval.n_quadrature_points);
+            ls_heaviside_eval.get_function_gradients(level_set_heaviside, grad_ls_heaviside);
+
+            for (const auto q : heat_source_eval.quadrature_point_indices())
+              {
+                const double delta_value = grad_ls_heaviside[q].norm();
+                if (delta_value == 0.0)
+                  {
+                    heat_source_vector[local_dof_indices[q]] = 0.0;
+                    continue;
+                  }
+                const Tensor<1, dim, double> normal_vector = grad_ls_heaviside[q] / delta_value;
+
+                const double temp =
+                  local_compute_interface_heat_source(heat_source_eval.quadrature_point(q),
+                                                      laser_position,
+                                                      laser_power,
+                                                      normal_vector,
+                                                      delta_value);
+                heat_source_vector[local_dof_indices[q]] = temp;
+              }
+          }
+      }
+  }
+
+  template <int dim>
+  double
+  LaserHeatSourceGauss<dim>::power_density_volumetric(const double radius, const double power) const
   {
     const double s          = radius / data.laser_beam_radius;
-    const double peak_power = power * peak_power_density_factor;
+    const double peak_power = power * vol_peak_power_density_factor;
+    return peak_power * std::exp(-2. * s * s);
+  }
+
+  template <int dim>
+  double
+  LaserHeatSourceGauss<dim>::power_density_interface(double radius, double power) const
+  {
+    const double s          = radius / data.laser_beam_radius;
+    const double peak_power = power * surf_peak_power_density_factor;
     return peak_power * std::exp(-2. * s * s);
   }
 

--- a/source/heat/laser_heat_source_gusarov.cpp
+++ b/source/heat/laser_heat_source_gusarov.cpp
@@ -66,6 +66,47 @@ namespace MeltPoolDG::Heat
     // clang-format on
   }
 
+  template <int dim>
+  void
+  LaserHeatSourceGusarov<dim>::compute_interface_heat_source(VectorType &heat_source_vector,
+                                                             const ScratchData<dim> &scratch_data,
+                                                             unsigned int            temp_dof_idx,
+                                                             double                  laser_power,
+                                                             const Point<dim> &      laser_position,
+                                                             const VectorType &level_set_heaviside,
+                                                             unsigned int      ls_dof_idx,
+                                                             bool              zero_out) const
+  {
+    (void)heat_source_vector;
+    (void)scratch_data;
+    (void)temp_dof_idx;
+    (void)laser_power;
+    (void)laser_position;
+    (void)level_set_heaviside;
+    (void)ls_dof_idx;
+    (void)zero_out;
+    throw ExcMessage(
+      "The Gurasov laser heat source model is not suited for surface impact! Abort..");
+  }
+
+  template <int dim>
+  double
+  LaserHeatSourceGusarov<dim>::local_compute_interface_heat_source(
+    const Point<dim> &            position,
+    const Point<dim> &            laser_position,
+    double                        power,
+    const Tensor<1, dim, double> &normal_vector,
+    double                        delta_value) const
+  {
+    (void)position;
+    (void)laser_position;
+    (void)power;
+    (void)normal_vector;
+    (void)delta_value;
+    throw ExcMessage(
+      "The Gurasov laser heat source model is not suited for surface impact! Abort..");
+  }
+
   template class LaserHeatSourceGusarov<1>;
   template class LaserHeatSourceGusarov<2>;
   template class LaserHeatSourceGusarov<3>;

--- a/source/heat/laser_heat_source_gusarov.cpp
+++ b/source/heat/laser_heat_source_gusarov.cpp
@@ -68,14 +68,15 @@ namespace MeltPoolDG::Heat
 
   template <int dim>
   void
-  LaserHeatSourceGusarov<dim>::compute_interface_heat_source(VectorType &heat_source_vector,
-                                                             const ScratchData<dim> &scratch_data,
-                                                             unsigned int            temp_dof_idx,
-                                                             double                  laser_power,
-                                                             const Point<dim> &      laser_position,
-                                                             const VectorType &level_set_heaviside,
-                                                             unsigned int      ls_dof_idx,
-                                                             bool              zero_out) const
+  LaserHeatSourceGusarov<dim>::compute_interfacial_heat_source(
+    VectorType &            heat_source_vector,
+    const ScratchData<dim> &scratch_data,
+    unsigned int            temp_dof_idx,
+    double                  laser_power,
+    const Point<dim> &      laser_position,
+    const VectorType &      level_set_heaviside,
+    unsigned int            ls_dof_idx,
+    bool                    zero_out) const
   {
     (void)heat_source_vector;
     (void)scratch_data;
@@ -91,7 +92,7 @@ namespace MeltPoolDG::Heat
 
   template <int dim>
   double
-  LaserHeatSourceGusarov<dim>::local_compute_interface_heat_source(
+  LaserHeatSourceGusarov<dim>::local_compute_interfacial_heat_source(
     const Point<dim> &            position,
     const Point<dim> &            laser_position,
     double                        power,

--- a/source/interface/parameters.cpp
+++ b/source/interface/parameters.cpp
@@ -602,8 +602,8 @@ namespace MeltPoolDG
                         laser.gusarov.layer_thickness,
                         "Layer thickness");
       prm.add_parameter(
-        "laser impact",
-        laser.impact,
+        "laser impact type",
+        laser.impact_type,
         "Laser impact model. volumetric: volumetric heat source | surface: surface heat source at two-phase interface.",
         Patterns::Selection("volumetric|interface"));
       prm.add_parameter("laser gauss laser beam radius",

--- a/source/interface/parameters.cpp
+++ b/source/interface/parameters.cpp
@@ -601,6 +601,11 @@ namespace MeltPoolDG
       prm.add_parameter("laser gusarov layer thickness",
                         laser.gusarov.layer_thickness,
                         "Layer thickness");
+      prm.add_parameter(
+        "laser impact",
+        laser.impact,
+        "Laser impact model. volumetric: volumetric heat source | surface: surface heat source at two-phase interface.",
+        Patterns::Selection("volumetric|interface"));
       prm.add_parameter("laser gauss laser beam radius",
                         laser.gauss.laser_beam_radius,
                         "Laser beam radius.");

--- a/source/melt_pool/melt_pool_operation.cpp
+++ b/source/melt_pool/melt_pool_operation.cpp
@@ -86,8 +86,9 @@ namespace MeltPoolDG::MeltPool
           }
         else
           AssertThrow(false,
-                      ExcMessage("No requested laser model found. Please speficy the "
-                                 "heat source model in the laser section of the input parameters."))
+                      ExcMessage(
+                        "No requested laser model found. Please speficy the "
+                        "heat source model in the laser section of the input parameters."));
       }
   }
 

--- a/tests/melt_front_propagation_static_gusarov.mpirun=4.output
+++ b/tests/melt_front_propagation_static_gusarov.mpirun=4.output
@@ -1,5 +1,17 @@
-t= 5e-06     Newton Raphson solver converged: ||solution|| = 3.46470e-01
-t= 1e-05     Newton Raphson solver converged: ||solution|| = 3.46530e-01
-t= 1.5e-05   Newton Raphson solver converged: ||solution|| = 3.46591e-01
-t= 2e-05     Newton Raphson solver converged: ||solution|| = 3.46653e-01
-t= 2.5e-05   Newton Raphson solver converged: ||solution|| = 3.46715e-01
+current laser position: 0 0
+current laser intensity: 1
+t= 5e-06     current laser position: 0 0
+current laser intensity: 1
+Newton Raphson solver converged: ||solution|| = 3.46470e-01
+t= 1e-05     current laser position: 0 0
+current laser intensity: 1
+Newton Raphson solver converged: ||solution|| = 3.46530e-01
+t= 1.5e-05   current laser position: 0 0
+current laser intensity: 1
+Newton Raphson solver converged: ||solution|| = 3.46591e-01
+t= 2e-05     current laser position: 0 0
+current laser intensity: 1
+Newton Raphson solver converged: ||solution|| = 3.46653e-01
+t= 2.5e-05   current laser position: 0 0
+current laser intensity: 1
+Newton Raphson solver converged: ||solution|| = 3.46715e-01

--- a/tests/melt_front_propagation_static_gusarov_amr.mpirun=4.output
+++ b/tests/melt_front_propagation_static_gusarov_amr.mpirun=4.output
@@ -1,5 +1,17 @@
-t= 5e-06     Newton Raphson solver converged: ||solution|| = 3.46780e-01
-t= 1e-05     Newton Raphson solver converged: ||solution|| = 3.47179e-01
-t= 1.5e-05   Newton Raphson solver converged: ||solution|| = 3.47606e-01
-t= 2e-05     Newton Raphson solver converged: ||solution|| = 3.48057e-01
-t= 2.5e-05   Newton Raphson solver converged: ||solution|| = 3.48530e-01
+current laser position: 0 0
+current laser intensity: 1
+t= 5e-06     current laser position: 0 0
+current laser intensity: 1
+Newton Raphson solver converged: ||solution|| = 3.46780e-01
+t= 1e-05     current laser position: 0 0
+current laser intensity: 1
+Newton Raphson solver converged: ||solution|| = 3.47179e-01
+t= 1.5e-05   current laser position: 0 0
+current laser intensity: 1
+Newton Raphson solver converged: ||solution|| = 3.47606e-01
+t= 2e-05     current laser position: 0 0
+current laser intensity: 1
+Newton Raphson solver converged: ||solution|| = 3.48057e-01
+t= 2.5e-05   current laser position: 0 0
+current laser intensity: 1
+Newton Raphson solver converged: ||solution|| = 3.48530e-01

--- a/tests/melt_front_propagation_static_interface_gauss.json
+++ b/tests/melt_front_propagation_static_interface_gauss.json
@@ -1,0 +1,48 @@
+{
+  "base": {
+    "application name": "melt_front_propagation",
+    "degree": "1",
+    "dimension": "2",
+    "do print parameters": "false",
+    "global refinements": "5",
+    "problem name": "heat_transfer",
+    "verbosity level": "0"
+  },
+  "heat": {
+    "heat start time": "0.0",
+    "heat time step size": "1e-4",
+    "heat end time": "0.015",
+    "heat max n steps": "5",
+    "heat velocity": "-1",
+    "heat solidification": "true",
+    "heat two phase": "true",
+    "heat solver rel tolerance": "1e-12",
+    "heat solver preconditioner type": "ILU",
+    "heat nlsolve residual tolerance": "1e-8"
+  },
+  "laser": {
+    "laser power": "10.",
+    "laser center": "0.0,0.0",
+    "laser do move": "false",
+    "laser heat source model": "Gauss",
+    "laser impact": "interface",
+    "laser gauss laser beam radius": "0.06e-3",
+    "laser gauss absorptivity": "0.5"
+  },
+  "material": {
+    "material first capacity": "0",
+    "material first conductivity": "10",
+    "material first density": "74.30",
+    "material second conductivity": "55.563",
+    "material second capacity": "460.0",
+    "material second density": "7850.0",
+    "material solid conductivity": "17.0",
+    "material solid capacity": "700.0",
+    "material solid density": "7850.0",
+    "material solidus temperature": "1966.0",
+    "material liquidus temperature": "1974.0"
+  },
+  "paraview": {
+    "paraview do output": "false"
+  }
+}

--- a/tests/melt_front_propagation_static_interface_gauss.json
+++ b/tests/melt_front_propagation_static_interface_gauss.json
@@ -25,7 +25,7 @@
     "laser center": "0.0,0.0",
     "laser do move": "false",
     "laser heat source model": "Gauss",
-    "laser impact": "interface",
+    "laser impact type": "interface",
     "laser gauss laser beam radius": "0.06e-3",
     "laser gauss absorptivity": "0.5"
   },

--- a/tests/melt_front_propagation_static_interface_gauss.mpirun=4.output
+++ b/tests/melt_front_propagation_static_interface_gauss.mpirun=4.output
@@ -1,5 +1,17 @@
-t= 0.0001    Newton Raphson solver converged: ||solution|| = 4.91192e-01
-t= 0.0002    Newton Raphson solver converged: ||solution|| = 4.92553e-01
-t= 0.0003    Newton Raphson solver converged: ||solution|| = 4.93945e-01
-t= 0.0004    Newton Raphson solver converged: ||solution|| = 4.95355e-01
-t= 0.0005    Newton Raphson solver converged: ||solution|| = 4.96774e-01
+current laser position: 0 0
+current laser intensity: 1
+t= 0.0001    current laser position: 0 0
+current laser intensity: 1
+Newton Raphson solver converged: ||solution|| = 4.91192e-01
+t= 0.0002    current laser position: 0 0
+current laser intensity: 1
+Newton Raphson solver converged: ||solution|| = 4.92553e-01
+t= 0.0003    current laser position: 0 0
+current laser intensity: 1
+Newton Raphson solver converged: ||solution|| = 4.93945e-01
+t= 0.0004    current laser position: 0 0
+current laser intensity: 1
+Newton Raphson solver converged: ||solution|| = 4.95355e-01
+t= 0.0005    current laser position: 0 0
+current laser intensity: 1
+Newton Raphson solver converged: ||solution|| = 4.96774e-01

--- a/tests/melt_front_propagation_static_interface_gauss.mpirun=4.output
+++ b/tests/melt_front_propagation_static_interface_gauss.mpirun=4.output
@@ -1,0 +1,5 @@
+t= 0.0001    Newton Raphson solver converged: ||solution|| = 4.91192e-01
+t= 0.0002    Newton Raphson solver converged: ||solution|| = 4.92553e-01
+t= 0.0003    Newton Raphson solver converged: ||solution|| = 4.93945e-01
+t= 0.0004    Newton Raphson solver converged: ||solution|| = 4.95355e-01
+t= 0.0005    Newton Raphson solver converged: ||solution|| = 4.96774e-01


### PR DESCRIPTION
This PR adds an alternative laser heat source impact model that only acts on the level-set interface. 

For the Gauss laser model this is implemented according to the SPH paper. 
The interface laser model is not compatible with the Gusarov laser model, so there is an assent. 

The laser heat source of any kind is now applied to the heat_source dof-vector by `HeatTransferProblem::run()`. 

A case and test has been added to the melt front propagation simulation, that includes a prescribed level-set. The domain has been expanded by a gaseous domain in positive dim-1 direction.

~~This PR includes #232. I'll rebase after #232 is merged.~~