### PR TITLE
Add solidification to update_phases()

### DIFF
--- a/include/meltpooldg/flow/two_phase_flow_problem.hpp
+++ b/include/meltpooldg/flow/two_phase_flow_problem.hpp
@@ -41,6 +41,13 @@ namespace MeltPoolDG::Flow
 {
   using namespace dealii;
 
+  enum class TwoPhasePropsConsistencyType
+  {
+    sharp,
+    smooth,
+    evaporation
+  };
+
   template <int dim>
   class TwoPhaseFlowProblem : public ProblemBase<dim>
   {
@@ -136,5 +143,7 @@ namespace MeltPoolDG::Flow
     std::shared_ptr<Evaporation::EvaporationOperation<dim>> evaporation_operation = nullptr;
     std::shared_ptr<Heat::HeatTransferOperation<dim>>       heat_operation;
     std::shared_ptr<Postprocessor<dim>>                     post_processor;
+
+    TwoPhasePropsConsistencyType two_phase_props_consistency_type;
   };
 } // namespace MeltPoolDG::Flow

--- a/include/meltpooldg/interface/parameters.hpp
+++ b/include/meltpooldg/interface/parameters.hpp
@@ -283,6 +283,7 @@ namespace MeltPoolDG
       number capacity     = 0.0;
       number conductivity = 0.0;
       number density      = 0.0;
+      number viscosity    = 0.0;
     } solid;
 
     number solidus_temperature  = 0.0;

--- a/include/meltpooldg/melt_pool/melt_pool_operation.hpp
+++ b/include/meltpooldg/melt_pool/melt_pool_operation.hpp
@@ -35,6 +35,9 @@ namespace MeltPoolDG
        *  Parameters
        */
       MeltPoolData<double> mp_data;
+      MaterialData<double> material;
+      const bool           do_mushy_zone;
+      const double         inv_mushy_interval;
 
       std::shared_ptr<Heat::LaserOperation<dim>>      laser_operation;
       std::shared_ptr<RecoilPressureOperation<dim>>   recoil_pressure_operation;
@@ -62,13 +65,13 @@ namespace MeltPoolDG
     public:
       MeltPoolOperation(const std::shared_ptr<ScratchData<dim>> &scratch_data_in,
                         const Parameters<double> &               data_in,
-                        const unsigned int                       ls_dof_idx_in,
+                        unsigned int                             ls_dof_idx_in,
                         VectorType *                             temperature,
-                        const unsigned int                       reinit_dof_idx_in,
-                        const unsigned int                       flow_vel_dof_idx_in,
-                        const unsigned int                       flow_vel_quad_idx_in,
-                        const unsigned int                       temp_dof_idx_in,
-                        const double                             start_time_in);
+                        unsigned int                             reinit_dof_idx_in,
+                        unsigned int                             flow_vel_dof_idx_in,
+                        unsigned int                             flow_vel_quad_idx_in,
+                        unsigned int                             temp_dof_idx_in,
+                        double                                   start_time_in);
 
       void
       set_initial_condition(const VectorType &level_set_as_heaviside, VectorType &level_set);
@@ -139,22 +142,28 @@ namespace MeltPoolDG
       set_melt_pool_parameters(const Parameters<double> &data_in);
 
       /**
-       *  This function determines for a given pair of level set and temperature values, whether
-       * it characterizes a solid state. For this purpose, it is assumed that phi=1 in the liquid
-       * AND the solid domain and phi=0 in the gaseous domain. Thus, if phi=1 and the temperature
-       * is SMALLER than the fusion point, a solid phase is met.
+       * This function determines for a given pair of level set and temperature values the solid
+       * fraction. For this purpose, it is assumed that phi=1 in the liquid AND the solid domain and
+       * phi=1 in the liquid AND the solid domain and phi=0 in the gaseous domain. Thus, if phi=1
+       * and the temperature is SMALLER than the fusion point, a solid phase is met.
+       *
+       * If a mushy zone is considered, this function will return the solid fraction, that is
+       * linearly interpolated between the solidus and liquidus temperature.
        */
-      bool
-      is_solid_region(const double phi_liquid, const double temperature) const;
+      double
+      compute_solid_fraction(double ls_heaviside, double temperature) const;
 
       /**
-       *  This function determines for a given pair of level set and temperature values, whether
-       * it characterizes a liquid state. For this purpose, it is assumed that phi=1 in the liquid
-       * AND the solid domain and phi=0 in the gaseous domain. Thus, if phi=1 and the temperature
-       * is LARGER than the fusion point, a liquid phase is met.
+       *  This function determines for a given pair of level set and temperature values the liquid
+       * fraction. For this purpose, it is assumed that phi=1 in the liquid AND the solid domain and
+       * phi=0 in the gaseous domain. Thus, if phi=1 and the temperature is LARGER than the fusion
+       * point, a liquid phase is met.
+       *
+       * If a mushy zone is considered, this function will return the liquid fraction, that is
+       * linearly interpolated between the solidus and liquidus temperature.
        */
-      bool
-      is_liquid_region(const double phi_liquid, const double temperature) const;
+      double
+      compute_liquid_fraction(double ls_heaviside, double temperature) const;
     };
   } // namespace MeltPool
 } // namespace MeltPoolDG

--- a/include/meltpooldg/utilities/utility_functions.hpp
+++ b/include/meltpooldg/utilities/utility_functions.hpp
@@ -272,7 +272,7 @@ namespace MeltPoolDG
     }
 
     template <typename number>
-    VectorizedArray<number>
+    inline VectorizedArray<number>
     limit_to_bounds(const VectorizedArray<number> &in,
                     const number                   lower_limit,
                     const number                   upper_limit)
@@ -280,6 +280,14 @@ namespace MeltPoolDG
       const auto ub =
         compare_and_apply_mask<SIMDComparison::greater_than>(in, upper_limit, upper_limit, in);
       return compare_and_apply_mask<SIMDComparison::less_than>(ub, lower_limit, lower_limit, ub);
+    }
+
+    template <typename number>
+    inline number
+    limit_to_bounds(const number in, const number lower_limit, const number upper_limit)
+    {
+      const auto ub = in > upper_limit ? upper_limit : in;
+      return ub < lower_limit ? lower_limit : ub;
     }
 
     /**

--- a/simulations/melt_front_propagation/melt_pool_tfi_static_interface_gauss.json
+++ b/simulations/melt_front_propagation/melt_pool_tfi_static_interface_gauss.json
@@ -1,0 +1,107 @@
+{
+  "base": {
+    "application name": "melt_front_propagation",
+    "degree": "1",
+    "dimension": "2",
+    "do print parameters": "false",
+    "global refinements": "5",
+    "problem name": "melt_pool",
+    "verbosity level": "2"
+  },
+  "flow": {
+    "flow start time": "0.0",
+    "flow time step size": "1e-5",
+    "flow end time": "0.015",
+    "flow max n steps": "1500",
+    "flow do melt pool": "true",
+    "flow do heat transfer": "true",
+    "fflow variable properties over interface": "true"
+  },
+  "Navier-Stokes": {
+    "adaflo": {
+      "Navier-Stokes": {
+        "physical type": "incompressible",
+        "dimension": "2",
+        "global refinements": "0",
+        "velocity degree": "2",
+        "Solver": {
+          "linearization scheme": "coupled implicit Newton",
+          "NL max iterations": "10",
+          "NL tolerance": "1.e-9",
+          "lin max iterations": "30",
+          "lin tolerance": "1.e-4",
+          "lin relative tolerance": "1",
+          "lin velocity preconditioner": "ilu scalar",
+          "lin pressure mass preconditioner": "ilu",
+          "lin its before inner solvers": "50"
+        }
+      },
+      "Time stepping": {
+        "scheme": "bdf_2"
+      },
+      "Output options": {
+        "output verbosity": "0",
+        "output walltimes": "0"
+      }
+    }
+  },
+  "laser": {
+    "laser power": "10.",
+    "laser center": "0.0,0.0",
+    "laser do move": "false",
+    "laser heat source model": "Gauss",
+    "laser impact type": "interface",
+    "laser gauss laser beam radius": "0.06e-3",
+    "laser gauss absorptivity": "0.5"
+  },
+  "melt pool": {
+    "mp set velocity to zero in solid": "false"
+  },
+  "material": {
+    "material first capacity": "0",
+    "material first conductivity": "10",
+    "material first density": "74.30",
+    "material first viscosity": "0.0006",
+    "material second conductivity": "55.563",
+    "material second capacity": "460.0",
+    "material second density": "7850.0",
+    "material second viscosity": "0.006",
+    "material solid conductivity": "17.0",
+    "material solid capacity": "700.0",
+    "material solid density": "7850.0",
+    "material solid viscosity": "0.06",
+    "material solidus temperature": "1966.0",
+    "material liquidus temperature": "1974.0"
+  },
+  "levelset": {
+    "ls do reinitialization": "true",
+    "ls artificial diffusivity": "0.0",
+    "ls time integration scheme": "crank_nicolson",
+    "ls do matrix free": "true"
+  },
+  "reinitialization": {
+    "reinit max n steps": "5",
+    "reinit modeltype": "olsson2007",
+    "reinit do matrix free": "true",
+    "reinit scale factor epsilon": "1.0"
+  },
+  "normal vector": {
+    "normal vec damping scale factor": "0.5",
+    "normal vec do matrix free": "true"
+  },
+  "curvature": {
+    "curv do matrix free": "true",
+    "curv damping scale factor": "0.5"
+  },
+  "heat": {
+    "heat solidification": "true",
+    "heat solver rel tolerance": "1e-12",
+    "heat solver preconditioner type": "ILU",
+    "heat nlsolve residual tolerance": "1e-8"
+  },
+  "paraview": {
+    "paraview do output": "true",
+    "paraview directory": "output",
+    "paraview filename": "melt_pool_tfi_static_interface_gauss"
+  }
+}

--- a/simulations/melt_front_propagation/melt_pool_tfi_static_interface_gauss_recoil_pressure.json
+++ b/simulations/melt_front_propagation/melt_pool_tfi_static_interface_gauss_recoil_pressure.json
@@ -1,0 +1,115 @@
+{
+  "base": {
+    "application name": "melt_front_propagation",
+    "degree": "1",
+    "dimension": "2",
+    "do print parameters": "false",
+    "global refinements": "5",
+    "problem name": "melt_pool",
+    "verbosity level": "2",
+    "gravity": "0.0"
+  },
+  "flow": {
+    "flow start time": "0.0",
+    "flow time step size": "1e-5",
+    "flow end time": "0.05",
+    "flow max n steps": "5000",
+    "flow do melt pool": "true",
+    "flow do heat transfer": "true",
+    "flow variable properties over interface": "true",
+    "flow surface tension coefficient": "1.8"
+  },
+  "Navier-Stokes": {
+    "adaflo": {
+      "Navier-Stokes": {
+        "physical type": "incompressible",
+        "dimension": "2",
+        "global refinements": "0",
+        "velocity degree": "2",
+        "Solver": {
+          "linearization scheme": "coupled implicit Newton",
+          "NL max iterations": "10",
+          "NL tolerance": "1.e-9",
+          "lin max iterations": "30",
+          "lin tolerance": "1.e-4",
+          "lin relative tolerance": "1",
+          "lin velocity preconditioner": "ilu scalar",
+          "lin pressure mass preconditioner": "ilu",
+          "lin its before inner solvers": "50"
+        }
+      },
+      "Time stepping": {
+        "scheme": "bdf_2"
+      },
+      "Output options": {
+        "output verbosity": "0",
+        "output walltimes": "0"
+      }
+    }
+  },
+  "laser": {
+    "laser power": "15.",
+    "laser center": "0.3e-3,0.0",
+    "laser do move": "false",
+    "laser heat source model": "Gauss",
+    "laser impact type": "interface",
+    "laser gauss laser beam radius": "0.06e-3",
+    "laser gauss absorptivity": "0.5"
+  },
+  "melt pool": {
+    "mp set velocity to zero in solid": "false",
+    "mp do recoil pressure": "true",
+    "mp boiling temperature": "3000."
+  },
+  "recoil pressure": {
+    "recoil pressure constant": "10000.",
+    "recoil temperature constant": "10000."
+  },
+  "material": {
+    "material first capacity": "0",
+    "material first conductivity": "10",
+    "material first density": "74.30",
+    "material first viscosity": "0.0006",
+    "material second conductivity": "55.563",
+    "material second capacity": "460.0",
+    "material second density": "7850.0",
+    "material second viscosity": "0.006",
+    "material solid conductivity": "17.0",
+    "material solid capacity": "700.0",
+    "material solid density": "7850.0",
+    "material solid viscosity": "1.0",
+    "material solidus temperature": "1966.0",
+    "material liquidus temperature": "1974.0"
+  },
+  "levelset": {
+    "ls do reinitialization": "true",
+    "ls artificial diffusivity": "0.0",
+    "ls time integration scheme": "crank_nicolson",
+    "ls do matrix free": "true"
+  },
+  "reinitialization": {
+    "reinit max n steps": "5",
+    "reinit modeltype": "olsson2007",
+    "reinit do matrix free": "true",
+    "reinit scale factor epsilon": "1.0"
+  },
+  "normal vector": {
+    "normal vec damping scale factor": "0.5",
+    "normal vec do matrix free": "true"
+  },
+  "curvature": {
+    "curv do matrix free": "true",
+    "curv damping scale factor": "0.5"
+  },
+  "heat": {
+    "heat solidification": "true",
+    "heat solver rel tolerance": "1e-12",
+    "heat solver preconditioner type": "ILU",
+    "heat nlsolve residual tolerance": "1e-8"
+  },
+  "paraview": {
+    "paraview do output": "true",
+    "paraview directory": "output_recoil_pressure",
+    "paraview filename": "melt_pool_tfi_static_interface_gauss_recoil_pressure"
+  }
+}

--- a/source/flow/two_phase_flow_problem.cpp
+++ b/source/flow/two_phase_flow_problem.cpp
@@ -379,6 +379,19 @@ namespace MeltPoolDG::Flow
            */
           set_initial_condition(base_in);
         }
+
+    if (base_in->parameters.flow.variable_properties_over_interface == "false")
+      two_phase_props_consistency_type = TwoPhasePropsConsistencyType::sharp;
+    else if (base_in->parameters.flow.variable_properties_over_interface == "true")
+      two_phase_props_consistency_type = TwoPhasePropsConsistencyType::smooth;
+    else if (base_in->parameters.flow.variable_properties_over_interface ==
+             "consistent_with_evaporation")
+      two_phase_props_consistency_type = TwoPhasePropsConsistencyType::evaporation;
+    else
+      AssertThrow(false,
+                  ExcMessage("Unknown variable properties over interface type \"" +
+                             base_in->parameters.flow.variable_properties_over_interface +
+                             "\"! Abort..."));
   }
 
   template <int dim>
@@ -566,19 +579,26 @@ namespace MeltPoolDG::Flow
   TwoPhaseFlowProblem<dim>::update_phases(const VectorType &        ls_as_heaviside,
                                           const Parameters<double> &parameters) const
   {
+    if (parameters.heat.solidification)
+      {
+        AssertThrow(
+          melt_pool_operation,
+          ExcMessage(
+            "If solidifcation is enabled the melt pool operation must be initialized! Abort..."));
+        melt_pool_operation->get_solid().update_ghost_values();
+      }
+
     double dummy;
 
     double mass = 0.0;
 
-    bool variable_props =
-      parameters.flow.variable_properties_over_interface == "true" ||
-      parameters.flow.variable_properties_over_interface == "consistent_with_evaporation";
-
     scratch_data->get_matrix_free().template cell_loop<double, VectorType>(
       [&](const auto &matrix_free, auto &, const auto &ls_as_heaviside, auto macro_cells) {
-        FECellIntegrator<dim, 1, double> ls_values(matrix_free,
+        FECellIntegrator<dim, 1, double>                  ls_values(matrix_free,
                                                    ls_hanging_nodes_dof_idx,
                                                    flow_operation->get_quad_idx_velocity());
+        [[maybe_unused]] FECellIntegrator<dim, 1, double> solid_values(
+          matrix_free, temp_hanging_nodes_dof_idx, flow_operation->get_quad_idx_velocity());
 
         for (unsigned int cell = macro_cells.first; cell < macro_cells.second; ++cell)
           {
@@ -586,20 +606,27 @@ namespace MeltPoolDG::Flow
             ls_values.read_dof_values_plain(ls_as_heaviside);
             ls_values.evaluate(EvaluationFlags::values);
 
+            if (parameters.heat.solidification)
+              {
+                solid_values.reinit(cell);
+                solid_values.read_dof_values_plain(melt_pool_operation->get_solid());
+                solid_values.evaluate(EvaluationFlags::values);
+              }
+
             for (unsigned int q = 0; q < ls_values.n_q_points; ++q)
               {
-                const auto indicator = variable_props ?
-                                         ls_values.get_value(q) :
-                                         UtilityFunctions::heaviside(ls_values.get_value(q), 0.5);
+                const auto indicator =
+                  two_phase_props_consistency_type == TwoPhasePropsConsistencyType::sharp ?
+                    UtilityFunctions::heaviside(ls_values.get_value(q), 0.5) :
+                    ls_values.get_value(q);
 
-                // set density
-                if (parameters.flow.variable_properties_over_interface ==
-                    "consistent_with_evaporation") //@todo: replace by enum
+                // set properties
+                if (two_phase_props_consistency_type == TwoPhasePropsConsistencyType::evaporation)
                   {
                     const double rho_g = parameters.material.first.density;
                     const double rho_l = parameters.material.second.density;
                     flow_operation->get_density(cell, q) =
-                      rho_g / (1. + (rho_g / rho_l - 1) * ls_values.get_value(q));
+                      rho_g / (1. + (rho_g / rho_l - 1) * indicator);
                   }
                 else
                   flow_operation->get_density(cell, q) =
@@ -613,21 +640,59 @@ namespace MeltPoolDG::Flow
                                                 parameters.material.first.viscosity,
                                                 parameters.material.second.viscosity);
 
+                if (parameters.heat.solidification)
+                  {
+                    const auto &solid_fraction = solid_values.get_value(q);
+                    if (!(solid_fraction == VectorizedArray<double>(0.0)))
+                      {
+                        if (solid_fraction == VectorizedArray<double>(1.0))
+                          {
+                            flow_operation->get_density(cell, q) =
+                              parameters.material.solid.density;
+                            flow_operation->get_viscosity(cell, q) =
+                              parameters.material.solid.viscosity;
+                          }
+                        else
+                          {
+                            const auto fluid_density = flow_operation->get_density(cell, q);
+                            flow_operation->get_density(cell, q) =
+                              UtilityFunctions::interpolate_cubic(
+                                solid_fraction, fluid_density, parameters.material.solid.density);
+                            const auto fluid_viscosity = flow_operation->get_viscosity(cell, q);
+                            flow_operation->get_viscosity(cell, q) =
+                              UtilityFunctions::interpolate_cubic(
+                                solid_fraction,
+                                fluid_viscosity,
+                                parameters.material.solid.viscosity);
+                          }
+                      }
+                  }
+
                 // check if no spurious densities or viscosities are computed
-                const double min_density =
+                double min_density =
                   std::min(parameters.material.first.density, parameters.material.second.density);
-                const double max_density =
+                double max_density =
                   std::max(parameters.material.first.density, parameters.material.second.density);
+                if (parameters.heat.solidification)
+                  {
+                    min_density = std::min(min_density, parameters.material.solid.density);
+                    max_density = std::max(max_density, parameters.material.solid.density);
+                  }
 
                 for (auto dens : flow_operation->get_density(cell, q))
                   if (min_density > dens || dens > max_density)
                     std::cout << "WARNING: density does not comply with input:" << dens
                               << std::endl;
 
-                const double min_viscosity = std::min(parameters.material.first.viscosity,
-                                                      parameters.material.second.viscosity);
-                const double max_viscosity = std::max(parameters.material.first.viscosity,
-                                                      parameters.material.second.viscosity);
+                double min_viscosity = std::min(parameters.material.first.viscosity,
+                                                parameters.material.second.viscosity);
+                double max_viscosity = std::max(parameters.material.first.viscosity,
+                                                parameters.material.second.viscosity);
+                if (parameters.heat.solidification)
+                  {
+                    min_viscosity = std::min(min_viscosity, parameters.material.solid.viscosity);
+                    max_viscosity = std::max(max_viscosity, parameters.material.solid.viscosity);
+                  }
 
                 for (auto visc : flow_operation->get_viscosity(cell, q))
                   if (min_viscosity > visc || visc > max_viscosity)

--- a/source/interface/parameters.cpp
+++ b/source/interface/parameters.cpp
@@ -824,6 +824,9 @@ namespace MeltPoolDG
       prm.add_parameter("material solid density",
                         material.solid.density,
                         "density of the solid phase");
+      prm.add_parameter("material solid viscosity",
+                        material.solid.viscosity,
+                        "viscosity of the solid phase");
       prm.add_parameter("material solidus temperature",
                         material.solidus_temperature,
                         "Solidus temperature");

--- a/source/melt_pool/melt_pool_operation.cpp
+++ b/source/melt_pool/melt_pool_operation.cpp
@@ -19,6 +19,10 @@ namespace MeltPoolDG::MeltPool
     const unsigned int                       temp_dof_idx_in,
     const double                             start_time_in)
     : scratch_data(scratch_data_in)
+    , material(data_in.material)
+    , do_mushy_zone(data_in.heat.solidification)
+    , inv_mushy_interval(
+        do_mushy_zone ? 1.0 / (material.liquidus_temperature - material.solidus_temperature) : 0.0)
     , ls_dof_idx(ls_dof_idx_in)
     , reinit_dof_idx(reinit_dof_idx_in)
     , flow_vel_dof_idx(flow_vel_dof_idx_in)
@@ -291,19 +295,16 @@ namespace MeltPoolDG::MeltPool
           for (unsigned int i = 0; i < dofs_per_cell; ++i)
             {
               solid[local_dof_indices[i]] =
-                is_solid_region(level_set_as_heaviside[local_dof_indices[i]],
-                                (*temperature)[local_dof_indices[i]]);
+                compute_solid_fraction(level_set_as_heaviside[local_dof_indices[i]],
+                                       (*temperature)[local_dof_indices[i]]);
               liquid[local_dof_indices[i]] =
-                is_liquid_region(level_set_as_heaviside[local_dof_indices[i]],
-                                 (*temperature)[local_dof_indices[i]]);
+                compute_liquid_fraction(level_set_as_heaviside[local_dof_indices[i]],
+                                        (*temperature)[local_dof_indices[i]]);
             }
         }
 
     liquid.compress(VectorOperation::insert);
     solid.compress(VectorOperation::insert);
-
-    scratch_data->get_constraint(temp_dof_idx).distribute(solid);
-    scratch_data->get_constraint(temp_dof_idx).distribute(liquid);
 
     temperature->zero_out_ghost_values();
     level_set_as_heaviside.zero_out_ghost_values();
@@ -417,27 +418,44 @@ namespace MeltPoolDG::MeltPool
   }
 
   template <int dim>
-  bool
-  MeltPoolOperation<dim>::is_solid_region(const double phi_liquid, const double T) const
+  double
+  MeltPoolOperation<dim>::compute_solid_fraction(const double ls_heaviside, const double T) const
   {
-    if (phi_liquid <= 0.5)
-      return false; // point is gas phase
-    else if (phi_liquid > 0.5 && T >= mp_data.liquid.melting_point)
-      return false; // point is melted
+    if (do_mushy_zone)
+      {
+        return ls_heaviside * UtilityFunctions::limit_to_bounds(
+                                (material.liquidus_temperature - T) * inv_mushy_interval, 0.0, 1.0);
+      }
     else
-      return true;
+      {
+        if (ls_heaviside <= 0.5)
+          return 0.0; // point is gas phase
+        else if (ls_heaviside > 0.5 && T >= mp_data.liquid.melting_point)
+          return 0.0; // point is melted
+        else
+          return 1.0;
+      }
   }
 
   template <int dim>
-  bool
-  MeltPoolOperation<dim>::is_liquid_region(const double phi_liquid, const double T) const
+  double
+  MeltPoolOperation<dim>::compute_liquid_fraction(const double ls_heaviside, const double T) const
   {
-    if (phi_liquid <= 0.5)
-      return false; // point is gas phase
-    else if (phi_liquid > 0.5 && T >= mp_data.liquid.melting_point)
-      return true; // point is melted
+    if (do_mushy_zone)
+      {
+        return ls_heaviside *
+               (1. - UtilityFunctions::limit_to_bounds(
+                       (material.liquidus_temperature - T) * inv_mushy_interval, 0.0, 1.0));
+      }
     else
-      return false; // point is solid
+      {
+        if (ls_heaviside <= 0.5)
+          return 0.0; // point is gas phase
+        else if (ls_heaviside > 0.5 && T >= mp_data.liquid.melting_point)
+          return 1.0; // point is melted
+        else
+          return 0.0;
+      }
   }
 
   template class MeltPoolOperation<1>;


### PR DESCRIPTION
This PR enables solidification informed material parameters in `TwoPhaseFlowProblem::update_phases()`. The melt pool operation's calculation of the solid and liquid fraction has been adapted to consider solidification effects.

The new simulation case's parameters may need some tweaking but the result looks promising already.