### PR TITLE
Add domain size and initial temperature param

### DIFF
--- a/simulations/melt_front_propagation/melt_front_propagation.hpp
+++ b/simulations/melt_front_propagation/melt_front_propagation.hpp
@@ -35,12 +35,6 @@ namespace MeltPoolDG::Simulation::MeltFrontPropagation
   using namespace dealii;
   using namespace MeltPoolDG::Simulation;
 
-  static constexpr double x_max = 0.6e-3;
-  static constexpr double y_max = 0.2e-3;
-  static constexpr double z_max = 0.2e-3;
-
-  static constexpr double T_0 = 1000.0;
-
   template <int dim>
   class InitialLevelSet : public Function<dim>
   {
@@ -89,14 +83,54 @@ namespace MeltPoolDG::Simulation::MeltFrontPropagation
   template <int dim>
   class SimulationMeltFrontPropagation : public SimulationBase<dim>
   {
+  private:
+    double x_min = 0.0;
+    double x_max = 0.0;
+    double y_min = 0.0;
+    double y_max = 0.0;
+    double z_min = 0.0;
+    double z_max = 0.0;
+    double T_0   = 0.0;
+
   public:
     SimulationMeltFrontPropagation(std::string parameter_file, const MPI_Comm mpi_communicator)
       : SimulationBase<dim>(parameter_file, mpi_communicator)
     {}
 
     void
+    add_simulation_specific_parameters(dealii::ParameterHandler &prm) override
+    {
+      prm.enter_subsection("simulation specific parameters");
+      {
+        prm.add_parameter("domain x min", x_min, "minimum x coordinate of simulation domain");
+        prm.add_parameter("domain x max", x_max, "maximum x coordinate of simulation domain");
+        prm.add_parameter("domain z min", z_min, "minimum z coordinate of simulation domain");
+        prm.add_parameter("domain z max", z_max, "maximum z coordinate of simulation domain");
+        if constexpr (dim == 3)
+          {
+            prm.add_parameter("domain y min", y_min, "minimum y coordinate of simulation domain");
+            prm.add_parameter("domain y max", y_max, "maximum y coordinate of simulation domain");
+          }
+        prm.add_parameter("initial temperature", T_0);
+      }
+      prm.leave_subsection();
+    }
+
+    void
     create_spatial_discretization() override
     {
+      AssertThrow(
+        x_min < x_max,
+        ExcMessage("The upper bound of the domain must be greater than the lower bound! Abort..."));
+      AssertThrow(
+        z_min < z_max,
+        ExcMessage("The upper bound of the domain must be greater than the lower bound! Abort..."));
+      if constexpr (dim == 3)
+        AssertThrow(
+          y_min < y_max,
+          ExcMessage(
+            "The upper bound of the domain must be greater than the lower bound! Abort..."));
+
       if constexpr (dim == 1)
         {
           this->triangulation = std::make_shared<parallel::shared::Triangulation<1>>(

--- a/simulations/melt_front_propagation/melt_front_propagation_moving_interface_gauss.json
+++ b/simulations/melt_front_propagation/melt_front_propagation_moving_interface_gauss.json
@@ -14,6 +14,13 @@
     "problem name": "heat_transfer",
     "verbosity level": "2"
   },
+  "simulation specific parameters": {
+    "domain x min": "0.0",
+    "domain x max": "0.6e-3",
+    "domain z min": "-0.2e-3",
+    "domain z max": "0.2e-3",
+    "initial temperature": "1000.0"
+  },
   "heat": {
     "heat velocity": "-1",
     "heat solidification": "true",

--- a/simulations/melt_front_propagation/melt_front_propagation_static_gauss_amr.json
+++ b/simulations/melt_front_propagation/melt_front_propagation_static_gauss_amr.json
@@ -14,6 +14,13 @@
     "problem name": "heat_transfer",
     "verbosity level": "2"
   },
+  "simulation specific parameters": {
+    "domain x min": "0.0",
+    "domain x max": "0.6e-3",
+    "domain z min": "0.0",
+    "domain z max": "0.2e-3",
+    "initial temperature": "1000.0"
+  },
   "heat": {
     "heat solidification": "true",
     "heat solver rel tolerance": "1e-12",

--- a/simulations/melt_front_propagation/melt_front_propagation_static_gusarov.json
+++ b/simulations/melt_front_propagation/melt_front_propagation_static_gusarov.json
@@ -14,6 +14,13 @@
     "problem name": "heat_transfer",
     "verbosity level": "2"
   },
+  "simulation specific parameters": {
+    "domain x min": "0.0",
+    "domain x max": "0.6e-3",
+    "domain z min": "0.0",
+    "domain z max": "0.2e-3",
+    "initial temperature": "1000.0"
+  },
   "heat": {
     "heat solidification": "true",
     "heat solver rel tolerance": "1e-12",

--- a/simulations/melt_front_propagation/melt_front_propagation_static_gusarov_amr.json
+++ b/simulations/melt_front_propagation/melt_front_propagation_static_gusarov_amr.json
@@ -14,6 +14,13 @@
     "problem name": "heat_transfer",
     "verbosity level": "2"
   },
+  "simulation specific parameters": {
+    "domain x min": "0.0",
+    "domain x max": "0.6e-3",
+    "domain z min": "0.0",
+    "domain z max": "0.2e-3",
+    "initial temperature": "1000.0"
+  },
   "heat": {
     "heat solidification": "true",
     "heat solver rel tolerance": "1e-12",

--- a/simulations/melt_front_propagation/melt_front_propagation_static_interface_gauss.json
+++ b/simulations/melt_front_propagation/melt_front_propagation_static_interface_gauss.json
@@ -14,6 +14,13 @@
     "problem name": "heat_transfer",
     "verbosity level": "2"
   },
+  "simulation specific parameters": {
+    "domain x min": "0.0",
+    "domain x max": "0.6e-3",
+    "domain z min": "-0.2e-3",
+    "domain z max": "0.2e-3",
+    "initial temperature": "1000.0"
+  },
   "heat": {
     "heat velocity": "-1",
     "heat solidification": "true",

--- a/simulations/melt_front_propagation/melt_pool_tfi_static_interface_gauss.json
+++ b/simulations/melt_front_propagation/melt_pool_tfi_static_interface_gauss.json
@@ -54,6 +54,13 @@
     "laser gauss laser beam radius": "0.06e-3",
     "laser gauss absorptivity": "0.5"
   },
+  "simulation specific parameters": {
+    "domain x min": "0.0",
+    "domain x max": "0.6e-3",
+    "domain z min": "-0.2e-3",
+    "domain z max": "0.2e-3",
+    "initial temperature": "1000.0"
+  },
   "melt pool": {
     "mp set velocity to zero in solid": "false",
     "mp do melt pool": "true",

--- a/simulations/melt_front_propagation/melt_pool_tfi_static_interface_gauss_no_solidification.json
+++ b/simulations/melt_front_propagation/melt_pool_tfi_static_interface_gauss_no_solidification.json
@@ -51,6 +51,13 @@
     "laser gauss laser beam radius": "0.06e-3",
     "laser gauss absorptivity": "0.5"
   },
+  "simulation specific parameters": {
+    "domain x min": "0.0",
+    "domain x max": "0.6e-3",
+    "domain z min": "-0.2e-3",
+    "domain z max": "0.2e-3",
+    "initial temperature": "1000.0"
+  },
   "melt pool": {
     "mp set velocity to zero in solid": "false",
     "mp do melt pool": "true",

--- a/simulations/melt_front_propagation/melt_pool_tfi_static_interface_gauss_recoil_pressure.json
+++ b/simulations/melt_front_propagation/melt_pool_tfi_static_interface_gauss_recoil_pressure.json
@@ -56,6 +56,13 @@
     "laser gauss laser beam radius": "0.06e-3",
     "laser gauss absorptivity": "0.5"
   },
+  "simulation specific parameters": {
+    "domain x min": "0.0",
+    "domain x max": "0.6e-3",
+    "domain z min": "-0.2e-3",
+    "domain z max": "0.2e-3",
+    "initial temperature": "1000.0"
+  },
   "melt pool": {
     "mp do melt pool": "true",
     "mp do heat transfer": "true",

--- a/tests/melt_front_propagation_moving_interface_gauss.json
+++ b/tests/melt_front_propagation_moving_interface_gauss.json
@@ -8,6 +8,13 @@
     "problem name": "heat_transfer",
     "verbosity level": "0"
   },
+  "simulation specific parameters": {
+    "domain x min": "0.0",
+    "domain x max": "0.6e-3",
+    "domain z min": "-0.2e-3",
+    "domain z max": "0.2e-3",
+    "initial temperature": "1000.0"
+  },
   "time stepping": {
     "start time": "0.0",
     "time step size": "1e-5",

--- a/tests/melt_front_propagation_static_gusarov.json
+++ b/tests/melt_front_propagation_static_gusarov.json
@@ -14,6 +14,13 @@
     "end time": "0.015",
     "max n steps": "5"
   },
+  "simulation specific parameters": {
+    "domain x min": "0.0",
+    "domain x max": "0.6e-3",
+    "domain z min": "0.0",
+    "domain z max": "0.2e-3",
+    "initial temperature": "1000.0"
+  },
   "heat": {
     "heat solidification": "true",
     "heat solver rel tolerance": "1e-12",

--- a/tests/melt_front_propagation_static_gusarov_amr.json
+++ b/tests/melt_front_propagation_static_gusarov_amr.json
@@ -14,6 +14,13 @@
     "end time": "0.015",
     "max n steps": "5"
   },
+  "simulation specific parameters": {
+    "domain x min": "0.0",
+    "domain x max": "0.6e-3",
+    "domain z min": "0.0",
+    "domain z max": "0.2e-3",
+    "initial temperature": "1000.0"
+  },
   "heat": {
     "heat solidification": "true",
     "heat solver rel tolerance": "1e-12",

--- a/tests/melt_front_propagation_static_interface_gauss.json
+++ b/tests/melt_front_propagation_static_interface_gauss.json
@@ -14,6 +14,13 @@
     "end time": "0.015",
     "max n steps": "5"
   },
+  "simulation specific parameters": {
+    "domain x min": "0.0",
+    "domain x max": "0.6e-3",
+    "domain z min": "-0.2e-3",
+    "domain z max": "0.2e-3",
+    "initial temperature": "1000.0"
+  },
   "heat": {
     "heat velocity": "-1",
     "heat solidification": "true",

--- a/tests/melt_pool_tfi_static_interface_gauss.json
+++ b/tests/melt_pool_tfi_static_interface_gauss.json
@@ -17,11 +17,6 @@
     "end time": "0.015",
     "max n steps": "5"
   },
-  "melt pool": {
-    "mp set velocity to zero in solid": "false",
-    "mp do melt pool": "true",
-    "mp do heat transfer": "true"
-  },
   "Navier-Stokes": {
     "adaflo": {
       "Navier-Stokes": {
@@ -58,6 +53,18 @@
     "laser impact type": "interface",
     "laser gauss laser beam radius": "0.06e-3",
     "laser gauss absorptivity": "0.5"
+  },
+  "simulation specific parameters": {
+    "domain x min": "0.0",
+    "domain x max": "0.6e-3",
+    "domain z min": "-0.2e-3",
+    "domain z max": "0.2e-3",
+    "initial temperature": "1000.0"
+  },
+  "melt pool": {
+    "mp set velocity to zero in solid": "false",
+    "mp do melt pool": "true",
+    "mp do heat transfer": "true"
   },
   "material": {
     "material first capacity": "0",

--- a/tests/melt_pool_tfi_static_interface_gauss_no_solidification.json
+++ b/tests/melt_pool_tfi_static_interface_gauss_no_solidification.json
@@ -51,6 +51,13 @@
     "laser gauss laser beam radius": "0.06e-3",
     "laser gauss absorptivity": "0.5"
   },
+  "simulation specific parameters": {
+    "domain x min": "0.0",
+    "domain x max": "0.6e-3",
+    "domain z min": "-0.2e-3",
+    "domain z max": "0.2e-3",
+    "initial temperature": "1000.0"
+  },
   "melt pool": {
     "mp do heat transfer": "true",
     "mp do melt pool": "true",


### PR DESCRIPTION
I'm working on a more complex simulation example and stared by generalizing the melt_front_propagation case. I noticed I need to define a several new boundary conditions and decided to create a new case instead of using melt_front_propagation... 

I thought we can use these additional parameters, anyway.