### PR TITLE
Move relevant parameters from flow to melt pool section

### DIFF
--- a/include/meltpooldg/interface/parameters.hpp
+++ b/include/meltpooldg/interface/parameters.hpp
@@ -41,7 +41,7 @@ namespace MeltPoolDG
     number       end_time                = 1.0;
     number       time_step_size          = 0.01;
     unsigned int max_n_steps             = 1000000;
-    std::string  time_integration_scheme = "none";
+    std::string  time_integration_scheme = "none"; // @todo: remove this is operation-dependent
   };
 
   template <typename number = double>
@@ -115,21 +115,13 @@ namespace MeltPoolDG
   template <typename number = double>
   struct FlowData
   {
-    int          velocity_degree                                   = -1;
-    int          velocity_n_q_points_1d                            = -1;
-    number       surface_tension_coefficient                       = 0.0;
-    number       temperature_dependent_surface_tension_coefficient = 0.0;
-    number       surface_tension_reference_temperature             = 0.0;
-    number       surface_tension_coefficient_residual_fraction     = 0.0;
-    std::string  solver_type                                       = "incompressible";
-    number       start_time                                        = 0.0;
-    number       end_time                                          = 1.0;
-    number       time_step_size                                    = 0.05;
-    unsigned int max_n_steps                                       = 1000000;
-    std::string  variable_properties_over_interface                = "false";
-    bool         do_heat_transfer                                  = false;
-    bool         do_evaporation                                    = false;
-    bool         do_melt_pool                                      = false;
+    int         velocity_degree                                   = -1;
+    int         velocity_n_q_points_1d                            = -1;
+    number      surface_tension_coefficient                       = 0.0;
+    number      temperature_dependent_surface_tension_coefficient = 0.0;
+    number      surface_tension_reference_temperature             = 0.0;
+    number      surface_tension_coefficient_residual_fraction     = 0.0;
+    std::string variable_properties_over_interface                = "false";
   };
 
   template <typename number = double>
@@ -211,6 +203,9 @@ namespace MeltPoolDG
   template <typename number = double>
   struct MeltPoolData
   {
+    bool        do_heat_transfer               = false;
+    bool        do_evaporation                 = false;
+    bool        do_melt_pool                   = false;
     std::string melt_pool_center               = "not_initialized";
     bool        set_velocity_to_zero_in_solid  = false;
     bool        set_level_set_to_zero_in_solid = false;
@@ -346,6 +341,7 @@ namespace MeltPoolDG
     ParameterHandler prm;
 
     BaseData<number>               base;
+    TimeSteppingData<number>       time_stepping;
     AdaptiveMeshingData            amr;
     LevelSetData<number>           ls;
     ReinitializationData<number>   reinit;

--- a/simulations/evaporating_droplet/evaporating_droplet.json
+++ b/simulations/evaporating_droplet/evaporating_droplet.json
@@ -9,12 +9,16 @@
   },
   "flow": {
     "flow surface tension coefficient": "0.00",
-    "flow start time": "0.0",
-    "flow end time": "1.0",
-    "flow time step size": "0.005",
-    "flow variable properties over interface": "consistent_with_evaporation",
-    "flow do heat transfer": "true",
-    "flow do evaporation": "true"
+    "flow variable properties over interface": "consistent_with_evaporation"
+  },
+  "time stepping": {
+    "start time": "0.0",
+    "end time": "1.0",
+    "time step size": "0.005"
+  },
+  "melt pool": {
+    "mp do heat transfer": "true",
+    "mp do evaporation": "true"
   },
   "material": {
     "material first viscosity": "0.001",

--- a/simulations/evaporating_droplet/evaporating_droplet_with_heat.json
+++ b/simulations/evaporating_droplet/evaporating_droplet_with_heat.json
@@ -9,14 +9,18 @@
     "verbosity level": "1",
     "do print parameters": "false"
   },
+  "time stepping": {
+    "start time": "0.0",
+    "end time": "2.0",
+    "time step size": "0.001"
+  },
   "flow": {
     "flow surface tension coefficient": "0.1",
-    "flow start time": "0.0",
-    "flow end time": "2.0",
-    "flow time step size": "0.001",
-    "flow variable properties over interface": "consistent_with_evaporation",
-    "flow do heat transfer": "true",
-    "flow do evaporation": "true"
+    "flow variable properties over interface": "consistent_with_evaporation"
+  },
+  "melt pool": {
+    "mp do heat transfer": "true",
+    "mp do evaporation": "true"
   },
   "material": {
     "material first capacity": "200",

--- a/simulations/film_boiling/film_boiling_gibou_amr.json
+++ b/simulations/film_boiling/film_boiling_gibou_amr.json
@@ -9,14 +9,18 @@
     "do print parameters": "false",
     "verbosity level": "1"
   },
+  "time stepping": {
+    "start time": "0.0",
+    "end time": "2.0",
+    "time step size": "0.002"
+  },
   "flow": {
     "flow surface tension coefficient": "0.1",
-    "flow start time": "0.0",
-    "flow end time": "2.0",
-    "flow time step size": "0.002",
-    "flow variable properties over interface": "consistent_with_evaporation",
-    "flow do heat transfer": "true",
-    "flow do evaporation": "true"
+    "flow variable properties over interface": "consistent_with_evaporation"
+  },
+  "melt pool": {
+    "mp do heat transfer": "true",
+    "mp do evaporation": "true"
   },
   "Navier-Stokes": {
     "adaflo": {

--- a/simulations/flow_past_cylinder/flow_past_cylinder.json
+++ b/simulations/flow_past_cylinder/flow_past_cylinder.json
@@ -6,10 +6,12 @@
     "degree": "2"
   },
   "flow": {
-    "flow surface tension coefficient": "0.01",
-    "flow start time": "0.0",
-    "flow end time": "2.0",
-    "flow time step size": "0.02"
+    "flow surface tension coefficient": "0.01"
+  },
+  "time stepping": {
+    "start time": "0.0",
+    "end time": "2.0",
+    "time step size": "0.02"
   },
   "material": {
     "material first viscosity": "0.001",

--- a/simulations/melt_front_propagation/melt_pool_tfi_static_interface_gauss.json
+++ b/simulations/melt_front_propagation/melt_pool_tfi_static_interface_gauss.json
@@ -9,13 +9,13 @@
     "verbosity level": "2"
   },
   "flow": {
-    "flow start time": "0.0",
-    "flow time step size": "1e-5",
-    "flow end time": "0.015",
-    "flow max n steps": "1500",
-    "flow do melt pool": "true",
-    "flow do heat transfer": "true",
     "flow variable properties over interface": "true"
+  },
+  "time stepping": {
+    "start time": "0.0",
+    "time step size": "1e-5",
+    "end time": "0.015",
+    "max n steps": "1500"
   },
   "Navier-Stokes": {
     "adaflo": {
@@ -55,7 +55,9 @@
     "laser gauss absorptivity": "0.5"
   },
   "melt pool": {
-    "mp set velocity to zero in solid": "false"
+    "mp set velocity to zero in solid": "false",
+    "mp do melt pool": "true",
+    "mp do heat transfer": "true"
   },
   "material": {
     "material first capacity": "0",

--- a/simulations/melt_front_propagation/melt_pool_tfi_static_interface_gauss_no_solidification.json
+++ b/simulations/melt_front_propagation/melt_pool_tfi_static_interface_gauss_no_solidification.json
@@ -8,13 +8,11 @@
     "problem name": "melt_pool",
     "verbosity level": "2"
   },
-  "flow": {
-    "flow start time": "0.0",
-    "flow time step size": "1e-4",
-    "flow end time": "0.015",
-    "flow max n steps": "150",
-    "flow do melt pool": "true",
-    "flow do heat transfer": "true"
+  "time stepping": {
+    "start time": "0.0",
+    "time step size": "1e-4",
+    "end time": "0.015",
+    "max n steps": "150"
   },
   "Navier-Stokes": {
     "adaflo": {
@@ -54,7 +52,9 @@
     "laser gauss absorptivity": "0.5"
   },
   "melt pool": {
-    "mp set velocity to zero in solid": "false"
+    "mp set velocity to zero in solid": "false",
+    "mp do melt pool": "true",
+    "mp do heat transfer": "true"
   },
   "material": {
     "material first capacity": "0",

--- a/simulations/melt_front_propagation/melt_pool_tfi_static_interface_gauss_recoil_pressure.json
+++ b/simulations/melt_front_propagation/melt_pool_tfi_static_interface_gauss_recoil_pressure.json
@@ -10,14 +10,14 @@
     "gravity": "0.0"
   },
   "flow": {
-    "flow start time": "0.0",
-    "flow time step size": "1e-5",
-    "flow end time": "0.05",
-    "flow max n steps": "5000",
-    "flow do melt pool": "true",
-    "flow do heat transfer": "true",
     "flow variable properties over interface": "true",
     "flow surface tension coefficient": "1.8"
+  },
+  "time stepping": {
+    "start time": "0.0",
+    "time step size": "1e-5",
+    "end time": "0.05",
+    "max n steps": "5000"
   },
   "Navier-Stokes": {
     "adaflo": {
@@ -57,6 +57,8 @@
     "laser gauss absorptivity": "0.5"
   },
   "melt pool": {
+    "mp do melt pool": "true",
+    "mp do heat transfer": "true",
     "mp set velocity to zero in solid": "false",
     "mp do recoil pressure": "true",
     "mp boiling temperature": "3000."

--- a/simulations/recoil_pressure/recoil_pressure.hpp
+++ b/simulations/recoil_pressure/recoil_pressure.hpp
@@ -132,7 +132,7 @@ namespace MeltPoolDG
         void
         set_boundary_conditions() override
         {
-          if (this->parameters.flow.do_evaporation)
+          if (this->parameters.mp.do_evaporation)
             {
               const types::boundary_id lower_bc = 1;
               const types::boundary_id upper_bc = 2;

--- a/simulations/recoil_pressure/recoil_pressure.json
+++ b/simulations/recoil_pressure/recoil_pressure.json
@@ -8,13 +8,13 @@
     "gravity": "0.0",
     "do print parameters": "true"
   },
+  "time stepping": {
+    "start time": "0.0",
+    "end time": "0.0006",
+    "time step size": "0.000001"
+  },
   "flow": {
-    "flow surface tension coefficient": "1.8",
-    "flow start time": "0.0",
-    "flow end time": "0.0006",
-    "flow time step size": "0.000001",
-    "flow do melt pool": "true",
-    "flow do heat transfer": "true"
+    "flow surface tension coefficient": "1.8"
   },
   "material": {
     "material first capacity": "0",
@@ -41,6 +41,8 @@
     "laser analytical absorptivity gas": "0"
   },
   "melt pool": {
+    "mp do melt pool": "true",
+    "mp do heat transfer": "true",
     "mp domain x min": "-0.0002",
     "mp domain x max": "0.0002",
     "mp domain y min": "-0.0001",

--- a/simulations/recoil_pressure/recoil_pressure_3d.json
+++ b/simulations/recoil_pressure/recoil_pressure_3d.json
@@ -8,13 +8,13 @@
     "gravity": "0.0",
     "do print parameters": "true"
   },
+  "time stepping": {
+    "start time": "0.0",
+    "end time": "0.0006",
+    "time step size": "0.000001"
+  },
   "flow": {
-    "flow surface tension coefficient": "1.8",
-    "flow start time": "0.0",
-    "flow end time": "0.0006",
-    "flow time step size": "0.000001",
-    "flow do melt pool": "true",
-    "flow do heat transfer": "true"
+    "flow surface tension coefficient": "1.8"
   },
   "material": {
     "material first capacity": "0",
@@ -45,7 +45,9 @@
     "mp domain x max": "0.0002",
     "mp domain y min": "-0.0001",
     "mp domain y max": "0.0002",
-    "mp boiling temperature": "3000."
+    "mp boiling temperature": "3000.",
+    "mp do melt pool": "true",
+    "mp do heat transfer": "true"
   },
   "levelset": {
     "ls do reinitialization": "true",

--- a/simulations/rising_bubble/rising_bubble.json
+++ b/simulations/rising_bubble/rising_bubble.json
@@ -7,11 +7,13 @@
     "degree": "1",
     "gravity": "0.98"
   },
+  "time stepping": {
+    "start time": "0.0",
+    "end time": "1.0",
+    "time step size": "0.02"
+  },
   "flow": {
-    "flow surface tension coefficient": "0.0245",
-    "flow start time": "0.0",
-    "flow end time": "1.0",
-    "flow time step size": "0.02"
+    "flow surface tension coefficient": "0.0245"
   },
   "material": {
     "material first density": "1",

--- a/simulations/rising_bubble/rising_bubble_3d.json
+++ b/simulations/rising_bubble/rising_bubble_3d.json
@@ -8,10 +8,12 @@
     "gravity": "0.98"
   },
   "flow": {
-    "flow surface tension coefficient": "0.0245",
-    "flow start time": "0.0",
-    "flow end time": "1.0",
-    "flow time step size": "0.02"
+    "flow surface tension coefficient": "0.0245"
+  },
+  "time stepping": {
+    "start time": "0.0",
+    "end time": "1.0",
+    "time step size": "0.02"
   },
   "material": {
     "material first density": "1",

--- a/simulations/spurious_currents/spurious_currents.json
+++ b/simulations/spurious_currents/spurious_currents.json
@@ -8,10 +8,12 @@
     "gravity": "0.00"
   },
   "flow": {
-    "flow surface tension coefficient": "1.0",
-    "flow start time": "0.0",
-    "flow end time": "0.3",
-    "flow time step size": "0.01"
+    "flow surface tension coefficient": "1.0"
+  },
+  "time stepping": {
+    "start time": "0.0",
+    "end time": "0.3",
+    "time step size": "0.01"
   },
   "material": {
     "material first density": "1.0",

--- a/simulations/stefans_problem/stefans_problem1_with_flow_and_heat.json
+++ b/simulations/stefans_problem/stefans_problem1_with_flow_and_heat.json
@@ -11,12 +11,16 @@
   },
   "flow": {
     "flow surface tension coefficient": "0.0",
-    "flow start time": "0.0",
-    "flow end time": "0.1",
-    "flow time step size": "5.e-4",
-    "flow variable properties over interface": "consistent_with_evaporation",
-    "flow do heat transfer": "true",
-    "flow do evaporation": "true"
+    "flow variable properties over interface": "consistent_with_evaporation"
+  },
+  "time stepping": {
+    "start time": "0.0",
+    "end time": "0.1",
+    "time step size": "5.e-4"
+  },
+  "melt pool": {
+    "mp do heat transfer": "true",
+    "mp do evaporation": "true"
   },
   "material": {
     "material first density": "1.",

--- a/simulations/stefans_problem/stefans_problem1_with_flow_and_heat_1d.json
+++ b/simulations/stefans_problem/stefans_problem1_with_flow_and_heat_1d.json
@@ -11,12 +11,16 @@
   },
   "flow": {
     "flow surface tension coefficient": "0.0",
-    "flow start time": "0.0",
-    "flow end time": "0.1",
-    "flow time step size": "5.e-4",
-    "flow variable properties over interface": "consistent_with_evaporation",
-    "flow do heat transfer": "true",
-    "flow do evaporation": "true"
+    "flow variable properties over interface": "consistent_with_evaporation"
+  },
+  "time stepping": {
+    "start time": "0.0",
+    "end time": "0.1",
+    "time step size": "5.e-4"
+  },
+  "melt pool": {
+    "mp do heat transfer": "true",
+    "mp do evaporation": "true"
   },
   "material": {
     "material first density": "1.",

--- a/simulations/stefans_problem/stefans_problem2_with_flow_and_heat_amr.json
+++ b/simulations/stefans_problem/stefans_problem2_with_flow_and_heat_amr.json
@@ -11,12 +11,16 @@
   },
   "flow": {
     "flow surface tension coefficient": "0.",
-    "flow start time": "0.0",
-    "flow end time": "0.01",
-    "flow time step size": "0.00005",
-    "flow variable properties over interface": "consistent_with_evaporation",
-    "flow do heat transfer": "true",
-    "flow do evaporation": "true"
+    "flow variable properties over interface": "consistent_with_evaporation"
+  },
+  "time stepping": {
+    "start time": "0.0",
+    "end time": "0.01",
+    "time step size": "0.00005"
+  },
+  "melt pool": {
+    "mp do heat transfer": "true",
+    "mp do evaporation": "true"
   },
   "material": {
     "material first density": "0.01",

--- a/simulations/stefans_problem/stefans_problem_with_flow_amr.json
+++ b/simulations/stefans_problem/stefans_problem_with_flow_amr.json
@@ -9,12 +9,16 @@
   },
   "flow": {
     "flow surface tension coefficient": "1.8",
-    "flow start time": "0.0",
-    "flow end time": "0.0006",
-    "flow time step size": "0.000001",
-    "flow variable properties over interface": "consistent_with_evaporation",
-    "flow do heat transfer": "true",
-    "flow do evaporation": "true"
+    "flow variable properties over interface": "consistent_with_evaporation"
+  },
+  "time stepping": {
+    "start time": "0.0",
+    "end time": "0.0006",
+    "time step size": "0.000001"
+  },
+  "melt pool": {
+    "mp do heat transfer": "true",
+    "mp do evaporation": "true"
   },
   "material": {
     "material first density": "0.01",

--- a/simulations/thermo_capillary_droplet/thermo_capillary_droplet.json
+++ b/simulations/thermo_capillary_droplet/thermo_capillary_droplet.json
@@ -25,11 +25,15 @@
   },
   "flow": {
     "flow surface tension coefficient": "0.01",
-    "flow temperature dependent surface tension coefficient": "0.002",
-    "flow start time": "0.0",
-    "flow end time": "1.0",
-    "flow time step size": "0.0005",
-    "flow do heat transfer": "true"
+    "flow temperature dependent surface tension coefficient": "0.002"
+  },
+  "time stepping": {
+    "start time": "0.0",
+    "end time": "1.0",
+    "time step size": "0.0005"
+  },
+  "melt pool": {
+    "mp do heat transfer": "true"
   },
   "Navier-Stokes": {
     "adaflo": {

--- a/simulations/thermo_capillary_droplet/thermo_capillary_droplet_3D.json
+++ b/simulations/thermo_capillary_droplet/thermo_capillary_droplet_3D.json
@@ -26,13 +26,17 @@
     "material second density": "250",
     "material second viscosity": "0.012"
   },
+  "time stepping": {
+    "start time": "0.0",
+    "end time": "1.0",
+    "time step size": "0.05"
+  },
   "flow": {
     "flow surface tension coefficient": "0.01",
-    "flow temperature dependent surface tension coefficient": "0.002",
-    "flow start time": "0.0",
-    "flow end time": "1.0",
-    "flow time step size": "0.05",
-    "flow do heat transfer": "true"
+    "flow temperature dependent surface tension coefficient": "0.002"
+  },
+  "melt pool": {
+    "mp do heat transfer": "true"
   },
   "Navier-Stokes": {
     "adaflo": {

--- a/simulations/thermo_capillary_two_droplets/thermo_capillary_two_droplets.json
+++ b/simulations/thermo_capillary_two_droplets/thermo_capillary_two_droplets.json
@@ -25,13 +25,17 @@
     "material second density": "250",
     "material second viscosity": "0.012"
   },
+  "time stepping": {
+    "start time": "0.0",
+    "end time": "115.2",
+    "time step size": "0.05"
+  },
   "flow": {
     "flow surface tension coefficient": "0.023040369",
-    "flow temperature dependent surface tension coefficient": "0.002",
-    "flow start time": "0.0",
-    "flow end time": "115.2",
-    "flow time step size": "0.05",
-    "flow do heat transfer": "true"
+    "flow temperature dependent surface tension coefficient": "0.002"
+  },
+  "melt pool": {
+    "mp do heat transfer": "true"
   },
   "Navier-Stokes": {
     "adaflo": {

--- a/source/interface/parameters.cpp
+++ b/source/interface/parameters.cpp
@@ -58,12 +58,12 @@ namespace MeltPoolDG
 
     if (base.problem_name == "melt_pool")
       {
-        if (flow.do_evaporation && !flow.do_heat_transfer)
+        if (mp.do_evaporation && !mp.do_heat_transfer)
           AssertThrow(false,
                       ExcMessage("In case of evaporation both flag >>> do evaporation <<< "
                                  "and >>> do heat transfer <<< have to be set to true."));
 
-        if (flow.do_melt_pool && !flow.do_heat_transfer)
+        if (mp.do_melt_pool && !mp.do_heat_transfer)
           AssertThrow(false,
                       ExcMessage("In case of do melt pool both flag >>> do melt pool <<< "
                                  "and >>> do heat transfer <<< have to be set to true."));
@@ -82,7 +82,7 @@ namespace MeltPoolDG
                       "within the adaflo section, which is ignored by MeltPoolDG. "
                       "Please use the >material: material first density:< section instead. "));
 
-        if (flow.do_evaporation)
+        if (mp.do_evaporation)
           {
             if (evapor.formulation_source_term_continuity != "sharp")
               {
@@ -138,11 +138,11 @@ namespace MeltPoolDG
                                         flow.velocity_n_q_points_1d;
 
         /// synchronize time stepping schemes
-        adaflo_params.params.start_time           = flow.start_time;
-        adaflo_params.params.end_time             = flow.end_time;
-        adaflo_params.params.time_step_size_start = flow.time_step_size;
-        adaflo_params.params.time_step_size_min   = flow.time_step_size;
-        adaflo_params.params.time_step_size_max   = flow.time_step_size;
+        adaflo_params.params.start_time           = time_stepping.start_time;
+        adaflo_params.params.end_time             = time_stepping.end_time;
+        adaflo_params.params.time_step_size_start = time_stepping.time_step_size;
+        adaflo_params.params.time_step_size_min   = time_stepping.time_step_size;
+        adaflo_params.params.time_step_size_max   = time_stepping.time_step_size;
         adaflo_params.params.use_simplex_mesh     = base.do_simplex;
       }
 #endif
@@ -210,6 +210,27 @@ namespace MeltPoolDG
         "verbosity level",
         base.verbosity_level,
         "Sets the maximum verbosity level of the console output. Set this parameter to 0 in case of test files.");
+    }
+    prm.leave_subsection();
+    /*
+     *   time stepping
+     */
+    prm.enter_subsection("time stepping");
+    {
+      prm.add_parameter("start time",
+                        time_stepping.start_time,
+                        "Defines the start time for the solution of the levelset problem");
+      prm.add_parameter("end time",
+                        time_stepping.end_time,
+                        "Sets the end time for the solution of the levelset problem");
+      prm.add_parameter("time step size",
+                        time_stepping.time_step_size,
+                        "Sets the step size for time stepping. For non-uniform "
+                        "time stepping, this parameter determines the size of the first "
+                        "time step.");
+      prm.add_parameter("max n steps",
+                        time_stepping.max_n_steps,
+                        "Sets the maximum number of melt_pool steps");
     }
     prm.leave_subsection();
     /*
@@ -462,38 +483,11 @@ namespace MeltPoolDG
         flow.surface_tension_coefficient_residual_fraction,
         "Define the minimum fraction of the constant surface tension reference value "
         "that can be reached.");
-      prm.add_parameter("flow solver type", flow.solver_type, "solver type of the flow problem");
-      prm.add_parameter("flow start time",
-                        flow.start_time,
-                        "Defines the start time for the solution of the levelset problem");
-      prm.add_parameter("flow end time",
-                        flow.end_time,
-                        "Sets the end time for the solution of the levelset problem");
-      prm.add_parameter("flow time step size",
-                        flow.time_step_size,
-                        "Sets the step size for time stepping. For non-uniform "
-                        "time stepping, this parameter determines the size of the first "
-                        "time step.");
-      prm.add_parameter("flow max n steps",
-                        flow.max_n_steps,
-                        "Sets the maximum number of flow steps");
       prm.add_parameter(
         "flow variable properties over interface",
         flow.variable_properties_over_interface,
         "Set this parameter to interpolate the flow properties over the interface smoothly.",
         Patterns::Selection("false|true|consistent_with_evaporation"));
-      prm.add_parameter(
-        "flow do heat transfer",
-        flow.do_heat_transfer,
-        "Set this parameter to true if you want to consider a coupling with heat transfer.");
-      prm.add_parameter(
-        "flow do evaporation",
-        flow.do_evaporation,
-        "Set this parameter to true if you want to consider a coupling with evaporation.");
-      prm.add_parameter(
-        "flow do melt pool",
-        flow.do_melt_pool,
-        "Set this parameter to true if you want to consider a melt pool simulation including a solid phase.");
     }
     prm.leave_subsection();
     /*
@@ -681,6 +675,18 @@ namespace MeltPoolDG
      */
     prm.enter_subsection("melt pool");
     {
+      prm.add_parameter(
+        "mp do heat transfer",
+        mp.do_heat_transfer,
+        "Set this parameter to true if you want to consider a coupling with heat transfer.");
+      prm.add_parameter(
+        "mp do evaporation",
+        mp.do_evaporation,
+        "Set this parameter to true if you want to consider a coupling with evaporation.");
+      prm.add_parameter(
+        "mp do melt pool",
+        mp.do_melt_pool,
+        "Set this parameter to true if you want to consider a melt pool simulation including a solid phase.");
       prm.add_parameter("mp melt pool center",
                         mp.melt_pool_center,
                         "Center coordinates of the melt pool ellipse/parabola. If no value is "

--- a/source/melt_pool/melt_pool_problem.cpp
+++ b/source/melt_pool/melt_pool_problem.cpp
@@ -110,7 +110,7 @@ namespace MeltPoolDG::Flow
             false /* false means not to zero out the force vector */);
 
         // ... c) temperature-dependent surface tension
-        if (base_in->parameters.flow.do_heat_transfer &&
+        if (base_in->parameters.mp.do_heat_transfer &&
             std::abs(base_in->parameters.flow.temperature_dependent_surface_tension_coefficient) >
               0.0)
           {
@@ -253,11 +253,12 @@ namespace MeltPoolDG::Flow
     /*
      *  initialize the time stepping scheme
      */
-    time_iterator.initialize(TimeIteratorData<double>{base_in->parameters.flow.start_time,
-                                                      base_in->parameters.flow.end_time,
-                                                      base_in->parameters.flow.time_step_size,
-                                                      base_in->parameters.flow.max_n_steps,
-                                                      false /*cfl_condition-->not supported yet*/});
+    time_iterator.initialize(
+      TimeIteratorData<double>{base_in->parameters.time_stepping.start_time,
+                               base_in->parameters.time_stepping.end_time,
+                               base_in->parameters.time_stepping.time_step_size,
+                               base_in->parameters.time_stepping.max_n_steps,
+                               false /*cfl_condition-->not supported yet*/});
     /*
      *    initialize the levelset operation class
      *    and setup initial conditions
@@ -276,7 +277,7 @@ namespace MeltPoolDG::Flow
     /*
      *    initialize the heat operation class
      */
-    if (base_in->parameters.flow.do_heat_transfer)
+    if (base_in->parameters.mp.do_heat_transfer)
       heat_operation = std::make_shared<Heat::HeatTransferOperation<dim>>(
         base_in->get_bc("heat_transfer"),
         *scratch_data,
@@ -292,7 +293,7 @@ namespace MeltPoolDG::Flow
     /*
      *    initialize the evaporation class
      */
-    if (base_in->parameters.flow.do_evaporation)
+    if (base_in->parameters.mp.do_evaporation)
       {
         evaporation_operation = std::make_shared<Evaporation::EvaporationOperation<dim>>(
           scratch_data,
@@ -316,7 +317,7 @@ namespace MeltPoolDG::Flow
     /*
      *    initialize the melt pool operation class
      */
-    if (base_in->parameters.flow.do_melt_pool)
+    if (base_in->parameters.mp.do_melt_pool)
       melt_pool_operation = std::make_shared<MeltPool::MeltPoolOperation<dim>>(
         scratch_data,
         base_in->parameters,
@@ -326,7 +327,7 @@ namespace MeltPoolDG::Flow
         flow_operation->get_dof_handler_idx_velocity(),
         flow_operation->get_quad_idx_velocity(),
         temp_dof_idx,
-        base_in->parameters.flow.start_time);
+        base_in->parameters.time_stepping.start_time);
 
     if (base_in->parameters.heat.solidification)
       AssertThrow(
@@ -359,7 +360,7 @@ namespace MeltPoolDG::Flow
      *  @todo: find a way to plot vectors on the refined mesh, which are only relevant for output
      *  and which must not be transferred to the new mesh everytime refine_mesh() is called.
      */
-    output_results(0, base_in->parameters.flow.start_time, base_in);
+    output_results(0, base_in->parameters.time_stepping.start_time, base_in);
     /*
      *    Do initial refinement steps if requested
      */

--- a/tests/evaporating_droplet.json
+++ b/tests/evaporating_droplet.json
@@ -10,12 +10,16 @@
   },
   "flow": {
     "flow surface tension coefficient": "0.00",
-    "flow start time": "0.0",
-    "flow end time": "0.02",
-    "flow time step size": "0.001",
-    "flow variable properties over interface": "consistent_with_evaporation",
-    "flow do heat transfer": "true",
-    "flow do evaporation": "true"
+    "flow variable properties over interface": "consistent_with_evaporation"
+  },
+  "time stepping": {
+    "start time": "0.0",
+    "end time": "0.02",
+    "time step size": "0.001"
+  },
+  "melt pool": {
+    "mp do heat transfer": "true",
+    "mp do evaporation": "true"
   },
   "material": {
     "material first viscosity": "0.001",

--- a/tests/evaporating_droplet_with_heat.json
+++ b/tests/evaporating_droplet_with_heat.json
@@ -11,12 +11,16 @@
   },
   "flow": {
     "flow surface tension coefficient": "0.1",
-    "flow start time": "0.0",
-    "flow end time": "0.03",
-    "flow time step size": "0.001",
-    "flow variable properties over interface": "consistent_with_evaporation",
-    "flow do evaporation": "true",
-    "flow do heat transfer": "true"
+    "flow variable properties over interface": "consistent_with_evaporation"
+  },
+  "time stepping": {
+    "start time": "0.0",
+    "end time": "0.03",
+    "time step size": "0.001"
+  },
+  "melt pool": {
+    "mp do heat transfer": "true",
+    "mp do evaporation": "true"
   },
   "material": {
     "material first capacity": "200",

--- a/tests/melt_pool_tfi_static_interface_gauss.json
+++ b/tests/melt_pool_tfi_static_interface_gauss.json
@@ -18,7 +18,9 @@
     "max n steps": "5"
   },
   "melt pool": {
-    "mp set velocity to zero in solid": "false"
+    "mp set velocity to zero in solid": "false",
+    "mp do melt pool": "true",
+    "mp do heat transfer": "true"
   },
   "Navier-Stokes": {
     "adaflo": {

--- a/tests/melt_pool_tfi_static_interface_gauss.json
+++ b/tests/melt_pool_tfi_static_interface_gauss.json
@@ -9,13 +9,16 @@
     "verbosity level": "0"
   },
   "flow": {
-    "flow start time": "0.0",
-    "flow time step size": "1e-5",
-    "flow end time": "0.015",
-    "flow max n steps": "5",
-    "flow do melt pool": "true",
-    "flow do heat transfer": "true",
     "flow variable properties over interface": "true"
+  },
+  "time stepping": {
+    "start time": "0.0",
+    "time step size": "1e-5",
+    "end time": "0.015",
+    "max n steps": "5"
+  },
+  "melt pool": {
+    "mp set velocity to zero in solid": "false"
   },
   "Navier-Stokes": {
     "adaflo": {
@@ -53,9 +56,6 @@
     "laser impact type": "interface",
     "laser gauss laser beam radius": "0.06e-3",
     "laser gauss absorptivity": "0.5"
-  },
-  "melt pool": {
-    "mp set velocity to zero in solid": "false"
   },
   "material": {
     "material first capacity": "0",

--- a/tests/melt_pool_tfi_static_interface_gauss_no_solidification.json
+++ b/tests/melt_pool_tfi_static_interface_gauss_no_solidification.json
@@ -8,13 +8,11 @@
     "problem name": "melt_pool",
     "verbosity level": "0"
   },
-  "flow": {
-    "flow start time": "0.0",
-    "flow time step size": "1e-4",
-    "flow end time": "0.015",
-    "flow max n steps": "5",
-    "flow do heat transfer": "true",
-    "flow do melt pool": "true"
+  "time stepping": {
+    "start time": "0.0",
+    "time step size": "1e-4",
+    "end time": "0.015",
+    "max n steps": "5"
   },
   "Navier-Stokes": {
     "adaflo": {
@@ -54,6 +52,8 @@
     "laser gauss absorptivity": "0.5"
   },
   "melt pool": {
+    "mp do heat transfer": "true",
+    "mp do melt pool": "true",
     "mp set velocity to zero in solid": "false"
   },
   "material": {

--- a/tests/recoil_pressure.json
+++ b/tests/recoil_pressure.json
@@ -38,14 +38,14 @@
     "curv damping scale factor": "0.1",
     "curv do matrix free": "true"
   },
+  "time stepping": {
+    "end time": "0.000002",
+    "start time": "0.0",
+    "time step size": "0.000001"
+  },
   "flow": {
-    "flow end time": "0.000002",
-    "flow start time": "0.0",
     "flow surface tension coefficient": "1.8",
-    "flow surface tension reference temperature": "1700",
-    "flow time step size": "0.000001",
-    "flow do melt pool": "true",
-    "flow do heat transfer": "true"
+    "flow surface tension reference temperature": "1700"
   },
   "material": {
     "material first capacity": "0",
@@ -80,6 +80,8 @@
     "laser analytical absorptivity liquid": "0.5"
   },
   "melt pool": {
+    "mp do melt pool": "true",
+    "mp do heat transfer": "true",
     "mp do recoil pressure": "true",
     "mp boiling temperature": "3000.",
     "mp liquid melting point": "1700",

--- a/tests/recoil_pressure_fixed_solid_domain.json
+++ b/tests/recoil_pressure_fixed_solid_domain.json
@@ -39,14 +39,14 @@
     "curv damping scale factor": "0.1",
     "curv do matrix free": "true"
   },
+  "time stepping": {
+    "end time": "0.000005",
+    "start time": "0.0",
+    "time step size": "5.e-7"
+  },
   "flow": {
-    "flow end time": "0.000005",
-    "flow start time": "0.0",
     "flow surface tension coefficient": "1.8",
-    "flow surface tension reference temperature": "1700",
-    "flow time step size": "5.e-7",
-    "flow do heat transfer": "true",
-    "flow do melt pool": "true"
+    "flow surface tension reference temperature": "1700"
   },
   "material": {
     "material first capacity": "0",
@@ -83,6 +83,8 @@
     "laser analytical temperature x to y ratio": "3."
   },
   "melt pool": {
+    "mp do heat transfer": "true",
+    "mp do melt pool": "true",
     "mp do recoil pressure": "true",
     "mp boiling temperature": "3000.",
     "mp domain x max": "0.000100",

--- a/tests/recoil_pressure_simplex.json
+++ b/tests/recoil_pressure_simplex.json
@@ -39,14 +39,14 @@
     "curv damping scale factor": "0.1",
     "curv do matrix free": "true"
   },
+  "time stepping": {
+    "end time": "0.000005",
+    "start time": "0.0",
+    "time step size": "0.000001"
+  },
   "flow": {
-    "flow end time": "0.000005",
-    "flow start time": "0.0",
     "flow surface tension coefficient": "1.8",
-    "flow surface tension reference temperature": "1700",
-    "flow time step size": "0.000001",
-    "flow do heat transfer": "true",
-    "flow do melt pool": "true"
+    "flow surface tension reference temperature": "1700"
   },
   "material": {
     "material first capacity": "0",
@@ -81,6 +81,8 @@
     "laser analytical temperature x to y ratio": "3."
   },
   "melt pool": {
+    "mp do heat transfer": "true",
+    "mp do melt pool": "true",
     "mp do recoil pressure": "true",
     "mp boiling temperature": "3000.",
     "mp liquid melting point": "1700",

--- a/tests/rising_bubble.json
+++ b/tests/rising_bubble.json
@@ -8,11 +8,13 @@
     "degree": "1",
     "gravity": "0.98"
   },
+  "time stepping": {
+    "start time": "0.0",
+    "end time": "0.14",
+    "time step size": "0.02"
+  },
   "flow": {
-    "flow surface tension coefficient": "0.0245",
-    "flow start time": "0.0",
-    "flow end time": "0.14",
-    "flow time step size": "0.02"
+    "flow surface tension coefficient": "0.0245"
   },
   "material": {
     "material first density": "1",

--- a/tests/rising_bubble_amr_mf.json
+++ b/tests/rising_bubble_amr_mf.json
@@ -8,6 +8,11 @@
     "degree": "1",
     "gravity": "0.98"
   },
+  "time stepping": {
+    "start time": "0.0",
+    "end time": "0.10",
+    "time step size": "0.02"
+  },
   "adaptive meshing": {
     "do amr": "true",
     "upper perc to refine": "     0.1",
@@ -16,10 +21,7 @@
     "n initial refinement cycles": "0"
   },
   "flow": {
-    "flow surface tension coefficient": "0.0245",
-    "flow start time": "0.0",
-    "flow end time": "0.10",
-    "flow time step size": "0.02"
+    "flow surface tension coefficient": "0.0245"
   },
   "material": {
     "material first density": "1",

--- a/tests/rising_bubble_amr_mf_mb_reinit.json
+++ b/tests/rising_bubble_amr_mf_mb_reinit.json
@@ -8,6 +8,11 @@
     "degree": "1",
     "gravity": "0.98"
   },
+  "time stepping": {
+    "start time": "0.0",
+    "end time": "0.10",
+    "time step size": "0.02"
+  },
   "adaptive meshing": {
     "do amr": "true",
     "upper perc to refine": "     0.1",
@@ -16,10 +21,7 @@
     "n initial refinement cycles": "0"
   },
   "flow": {
-    "flow surface tension coefficient": "0.0245",
-    "flow start time": "0.0",
-    "flow end time": "0.10",
-    "flow time step size": "0.02"
+    "flow surface tension coefficient": "0.0245"
   },
   "material": {
     "material first density": "1",

--- a/tests/rising_bubble_ls_degree1.json
+++ b/tests/rising_bubble_ls_degree1.json
@@ -8,11 +8,13 @@
     "degree": "1",
     "gravity": " 0.98"
   },
+  "time stepping": {
+    "start time": "0.0",
+    "end time": "0.06",
+    "time step size": "0.02"
+  },
   "flow": {
-    "flow surface tension coefficient": "0.0245",
-    "flow start time": "0.0",
-    "flow end time": "0.06",
-    "flow time step size": "0.02"
+    "flow surface tension coefficient": "0.0245"
   },
   "material": {
     "material first density": "1",

--- a/tests/rising_bubble_simplex.json
+++ b/tests/rising_bubble_simplex.json
@@ -9,11 +9,13 @@
     "degree": "1",
     "gravity": "0.98"
   },
+  "time stepping": {
+    "start time": "0.0",
+    "end time": "0.14",
+    "time step size": "0.02"
+  },
   "flow": {
-    "flow surface tension coefficient": "0.0245",
-    "flow start time": "0.0",
-    "flow end time": "0.14",
-    "flow time step size": "0.02"
+    "flow surface tension coefficient": "0.0245"
   },
   "material": {
     "material first density": "1",

--- a/tests/stefans_problem1_with_flow_and_heat.json
+++ b/tests/stefans_problem1_with_flow_and_heat.json
@@ -9,15 +9,19 @@
     "do print parameters": "false",
     "verbosity level": "0"
   },
+  "time stepping": {
+    "start time": "0.0",
+    "end time": "0.1",
+    "time step size": "5.e-4",
+    "max n steps": "10"
+  },
+  "melt pool": {
+    "mp do heat transfer": "true",
+    "mp do evaporation": "true"
+  },
   "flow": {
     "flow surface tension coefficient": "0.0",
-    "flow start time": "0.0",
-    "flow end time": "0.1",
-    "flow time step size": "5.e-4",
-    "flow max n steps": "10",
-    "flow variable properties over interface": "consistent_with_evaporation",
-    "flow do heat transfer": "true",
-    "flow do evaporation": "true"
+    "flow variable properties over interface": "consistent_with_evaporation"
   },
   "material": {
     "material first density": "1.",

--- a/tests/stefans_problem1_with_flow_and_heat_1d.json
+++ b/tests/stefans_problem1_with_flow_and_heat_1d.json
@@ -9,15 +9,19 @@
     "do print parameters": "false",
     "verbosity level": "0"
   },
+  "time stepping": {
+    "start time": "0.0",
+    "end time": "0.1",
+    "time step size": "5.e-4",
+    "max n steps": "10"
+  },
+  "melt pool": {
+    "mp do heat transfer": "true",
+    "mp do evaporation": "true"
+  },
   "flow": {
     "flow surface tension coefficient": "0.0",
-    "flow start time": "0.0",
-    "flow end time": "0.1",
-    "flow time step size": "5.e-4",
-    "flow max n steps": "10",
-    "flow variable properties over interface": "consistent_with_evaporation",
-    "flow do heat transfer": "true",
-    "flow do evaporation": "true"
+    "flow variable properties over interface": "consistent_with_evaporation"
   },
   "material": {
     "material first density": "1.",

--- a/tests/stefans_problem1_with_flow_and_heat_interface_value.json
+++ b/tests/stefans_problem1_with_flow_and_heat_interface_value.json
@@ -9,15 +9,19 @@
     "do print parameters": "false",
     "verbosity level": "0"
   },
+  "time stepping": {
+    "start time": "0.0",
+    "end time": "0.1",
+    "time step size": "5.e-4",
+    "max n steps": "10"
+  },
+  "melt pool": {
+    "mp do heat transfer": "true",
+    "mp do evaporation": "true"
+  },
   "flow": {
     "flow surface tension coefficient": "0.0",
-    "flow start time": "0.0",
-    "flow end time": "0.1",
-    "flow time step size": "5.e-4",
-    "flow max n steps": "10",
-    "flow variable properties over interface": "consistent_with_evaporation",
-    "flow do heat transfer": "true",
-    "flow do evaporation": "true"
+    "flow variable properties over interface": "consistent_with_evaporation"
   },
   "material": {
     "material first density": "1.",

--- a/tests/stefans_problem1_with_flow_and_heat_line_integral.json
+++ b/tests/stefans_problem1_with_flow_and_heat_line_integral.json
@@ -9,15 +9,19 @@
     "do print parameters": "false",
     "verbosity level": "0"
   },
+  "time stepping": {
+    "start time": "0.0",
+    "end time": "0.1",
+    "time step size": "5.e-4",
+    "max n steps": "10"
+  },
+  "melt pool": {
+    "mp do heat transfer": "true",
+    "mp do evaporation": "true"
+  },
   "flow": {
     "flow surface tension coefficient": "0.0",
-    "flow start time": "0.0",
-    "flow end time": "0.1",
-    "flow time step size": "5.e-4",
-    "flow max n steps": "10",
-    "flow variable properties over interface": "consistent_with_evaporation",
-    "flow do heat transfer": "true",
-    "flow do evaporation": "true"
+    "flow variable properties over interface": "consistent_with_evaporation"
   },
   "material": {
     "material first density": "1.",

--- a/tests/stefans_problem_with_flow_amr.json
+++ b/tests/stefans_problem_with_flow_amr.json
@@ -8,14 +8,18 @@
     "degree": "1",
     "do print parameters": "false"
   },
+  "time stepping": {
+    "start time": "0.0",
+    "end time": "0.002",
+    "time step size": "0.005"
+  },
+  "melt pool": {
+    "mp do heat transfer": "true",
+    "mp do evaporation": "true"
+  },
   "flow": {
     "flow surface tension coefficient": "0.",
-    "flow start time": "0.0",
-    "flow end time": "0.002",
-    "flow time step size": "0.005",
-    "flow variable properties over interface": "consistent_with_evaporation",
-    "flow do heat transfer": "true",
-    "flow do evaporation": "true"
+    "flow variable properties over interface": "consistent_with_evaporation"
   },
   "material": {
     "material first density": "0.01",

--- a/tests/stefans_problem_with_flow_amr_sharp.json
+++ b/tests/stefans_problem_with_flow_amr_sharp.json
@@ -8,13 +8,17 @@
     "degree": "1",
     "do print parameters": "false"
   },
+  "time stepping": {
+    "start time": "0.0",
+    "end time": "0.002",
+    "time step size": "0.0005"
+  },
+  "melt pool": {
+    "mp do heat transfer": "true",
+    "mp do evaporation": "true"
+  },
   "flow": {
-    "flow surface tension coefficient": "0.",
-    "flow start time": "0.0",
-    "flow end time": "0.002",
-    "flow time step size": "0.0005",
-    "flow do heat transfer": "true",
-    "flow do evaporation": "true"
+    "flow surface tension coefficient": "0."
   },
   "material": {
     "material first density": "0.01",

--- a/tests/tests_not_robust/film_boiling.json
+++ b/tests/tests_not_robust/film_boiling.json
@@ -11,12 +11,16 @@
   },
   "flow": {
     "flow surface tension coefficient": "0.1",
-    "flow start time": "0.0",
-    "flow end time": "0.01",
-    "flow time step size": "0.002",
-    "flow variable properties over interface": "consistent_with_evaporation",
-    "flow do heat transfer": "true",
-    "flow do evaporation": "true"
+    "flow variable properties over interface": "consistent_with_evaporation"
+  },
+  "time stepping": {
+    "start time": "0.0",
+    "end time": "0.01",
+    "time step size": "0.002"
+  },
+  "melt pool": {
+    "mp do heat transfer": "true",
+    "mp do evaporation": "true"
   },
   "Navier-Stokes": {
     "adaflo": {

--- a/tests/tests_not_robust/recoil_pressure_amr.json
+++ b/tests/tests_not_robust/recoil_pressure_amr.json
@@ -25,6 +25,11 @@
       }
     }
   },
+  "time stepping": {
+    "end time": "0.000003",
+    "start time": "0.0",
+    "time step size": "0.000001"
+  },
   "base": {
     "application name": "recoil_pressure",
     "degree": "1",
@@ -47,13 +52,8 @@
     "curv do matrix free": "true"
   },
   "flow": {
-    "flow end time": "0.000003",
-    "flow start time": "0.0",
     "flow surface tension coefficient": "1.8",
-    "flow surface tension reference temperature": "1700",
-    "flow time step size": "0.000001",
-    "flow do heat transfer": "true",
-    "flow do melt pool": "true"
+    "flow surface tension reference temperature": "1700"
   },
   "material": {
     "material first capacity": "0",
@@ -88,6 +88,8 @@
     "laser analytical ambient temperature": "500."
   },
   "melt pool": {
+    "mp do heat transfer": "true",
+    "mp do melt pool": "true",
     "mp do recoil pressure": "true",
     "mp boiling temperature": "3000.",
     "mp liquid melting point": "1700",

--- a/tests/tests_not_robust/rising_bubble_amr_mf_adaflo.json
+++ b/tests/tests_not_robust/rising_bubble_amr_mf_adaflo.json
@@ -16,10 +16,12 @@
     "n initial refinement cycles": "0"
   },
   "flow": {
-    "flow surface tension coefficient": "0.0245",
-    "flow start time": "0.0",
-    "flow end time": "0.10",
-    "flow time step size": "0.02"
+    "flow surface tension coefficient": "0.0245"
+  },
+  "time stepping": {
+    "start time": "0.0",
+    "end time": "0.10",
+    "time step size": "0.02"
   },
   "material": {
     "material first density": "1",

--- a/tests/tests_not_robust/stefans_problem2_with_flow_and_heat.json
+++ b/tests/tests_not_robust/stefans_problem2_with_flow_and_heat.json
@@ -9,14 +9,18 @@
     "do print parameters": "false",
     "verbosity level": "0"
   },
+  "time stepping": {
+    "start time": "0.0",
+    "end time": "0.0003",
+    "time step size": "0.0001"
+  },
   "flow": {
     "flow surface tension coefficient": "0.",
-    "flow start time": "0.0",
-    "flow end time": "0.0003",
-    "flow time step size": "0.0001",
-    "flow variable properties over interface": "consistent_with_evaporation",
-    "flow do heat transfer": "true",
-    "flow do evaporation": "true"
+    "flow variable properties over interface": "consistent_with_evaporation"
+  },
+  "melt pool": {
+    "mp do heat transfer": "true",
+    "mp do evaporation": "true"
   },
   "material": {
     "material first density": "0.01",

--- a/tests/thermo_capillary_droplet.json
+++ b/tests/thermo_capillary_droplet.json
@@ -23,13 +23,17 @@
     "material second density": "250",
     "material second viscosity": "0.012"
   },
+  "melt pool": {
+    "mp do heat transfer": "true"
+  },
+  "time stepping": {
+    "start time": "0.0",
+    "end time": "0.002",
+    "time step size": "0.0005"
+  },
   "flow": {
     "flow surface tension coefficient": "0.01",
-    "flow temperature dependent surface tension coefficient": "0.002",
-    "flow start time": "0.0",
-    "flow end time": "0.002",
-    "flow time step size": "0.0005",
-    "flow do heat transfer": "true"
+    "flow temperature dependent surface tension coefficient": "0.002"
   },
   "Navier-Stokes": {
     "adaflo": {

--- a/tests/thermo_capillary_two_droplets.json
+++ b/tests/thermo_capillary_two_droplets.json
@@ -23,13 +23,17 @@
     "material second density": "250",
     "material second viscosity": "0.012"
   },
+  "time stepping": {
+    "start time": "0.0",
+    "end time": "0.25",
+    "time step size": "0.05"
+  },
+  "melt pool": {
+    "mp do heat transfer": "true"
+  },
   "flow": {
     "flow surface tension coefficient": "0.023040369",
-    "flow temperature dependent surface tension coefficient": "0.002",
-    "flow start time": "0.0",
-    "flow end time": "0.25",
-    "flow time step size": "0.05",
-    "flow do heat transfer": "true"
+    "flow temperature dependent surface tension coefficient": "0.002"
   },
   "Navier-Stokes": {
     "adaflo": {


### PR DESCRIPTION
This PR moves the parameters `do_heat_transfer|do_melt_pool|do_evaporation` from the flow section to the melt pool section. Further, I introduced a new `time stepping` parameter category (currently only used within `melt_pool_problem`; the transition of the remaining problems will follow!).

closes #211 

references #170 

@nmuch @peterrum 