### PR TITLE
Add simulation specific parameters

### DIFF
--- a/include/meltpooldg/interface/parameters.hpp
+++ b/include/meltpooldg/interface/parameters.hpp
@@ -201,10 +201,6 @@ namespace MeltPoolDG
     bool        set_velocity_to_zero_in_solid  = false;
     bool        set_level_set_to_zero_in_solid = false;
     bool        do_recoil_pressure             = false;
-    number      domain_x_min                   = 0.0;
-    number      domain_y_min                   = 0.0;
-    number      domain_x_max                   = 0.0;
-    number      domain_y_max                   = 0.0;
     number      boiling_temperature            = 0.0;
 
     struct Liquid
@@ -330,6 +326,8 @@ namespace MeltPoolDG
     add_parameters();
 
     ParameterHandler prm;
+
+    bool parameters_read = false;
 
     BaseData<number>               base;
     TimeSteppingData<number>       time_stepping;

--- a/include/meltpooldg/interface/simulation_base.hpp
+++ b/include/meltpooldg/interface/simulation_base.hpp
@@ -1,6 +1,7 @@
 #pragma once
 // dealii
 #include <deal.II/base/exceptions.h>
+#include <deal.II/base/parameter_handler.h>
 
 #include <deal.II/distributed/tria.h>
 
@@ -32,9 +33,23 @@ namespace MeltPoolDG
 
     virtual ~SimulationBase() = default;
 
+    /**
+     * add simulation-specific parameters to the parameter handler
+     * @note: they will be available after create() has been
+     * called.
+     */
+    virtual void
+    add_simulation_specific_parameters(dealii::ParameterHandler &)
+    {
+      // default: do nothing
+    }
+
     virtual void
     set_parameters()
     {
+      /*
+       * read parameters defined in parameters.hpp
+       */
       this->parameters.process_parameters_file(this->parameter_file);
     }
 
@@ -50,6 +65,7 @@ namespace MeltPoolDG
     virtual void
     create()
     {
+      set_simulation_specific_parameters();
       create_spatial_discretization();
       AssertThrow(
         this->triangulation,
@@ -73,6 +89,28 @@ namespace MeltPoolDG
     {
       (void)generic_data_out;
       // do nothing default
+    }
+
+    /**
+     * Read the simulation specific parameters
+     */
+    void
+    set_simulation_specific_parameters()
+    {
+      /*
+       * read user-defined parameters
+       */
+      add_simulation_specific_parameters(prm_simulation_specific);
+
+      std::ifstream file;
+      file.open(parameter_file);
+
+      if (parameter_file.substr(parameter_file.find_last_of(".") + 1) == "json")
+        prm_simulation_specific.parse_input_from_json(file, true);
+      else if (parameter_file.substr(parameter_file.find_last_of(".") + 1) == "prm")
+        prm_simulation_specific.parse_input(parameter_file);
+      else
+        AssertThrow(false, ExcMessage("Parameterhandler cannot handle current file ending"));
     }
 
     /**
@@ -418,6 +456,7 @@ namespace MeltPoolDG
     const MPI_Comm                                mpi_communicator;
     Parameters<double>                            parameters;
     std::shared_ptr<Triangulation<dim, spacedim>> triangulation;
+    ParameterHandler                              prm_simulation_specific;
 
   private:
     std::map<std::string, std::shared_ptr<FieldConditions<dim>>>    field_conditions_map;

--- a/simulations/advection_diffusion/advection_diffusion.hpp
+++ b/simulations/advection_diffusion/advection_diffusion.hpp
@@ -114,9 +114,7 @@ namespace MeltPoolDG
       public:
         SimulationAdvec(std::string parameter_file, const MPI_Comm mpi_communicator)
           : SimulationBase<dim>(parameter_file, mpi_communicator)
-        {
-          this->set_parameters();
-        }
+        {}
 
         void
         create_spatial_discretization()

--- a/simulations/advection_diffusion/advection_diffusion_user_output.hpp
+++ b/simulations/advection_diffusion/advection_diffusion_user_output.hpp
@@ -34,9 +34,7 @@ namespace MeltPoolDG::Simulation::AdvectionDiffusion
     SimulationAdvectionDiffusionUserOutput(std::string    parameter_file,
                                            const MPI_Comm mpi_communicator)
       : SimulationBase<dim>(parameter_file, mpi_communicator)
-    {
-      this->set_parameters();
-    }
+    {}
 
     void
     create_spatial_discretization()

--- a/simulations/evaporating_droplet/evaporating_droplet.hpp
+++ b/simulations/evaporating_droplet/evaporating_droplet.hpp
@@ -55,9 +55,7 @@ namespace MeltPoolDG
       public:
         SimulationEvaporatingDroplet(std::string parameter_file, const MPI_Comm mpi_communicator)
           : SimulationBase<dim>(parameter_file, mpi_communicator)
-        {
-          this->set_parameters();
-        }
+        {}
 
         void
         create_spatial_discretization() override

--- a/simulations/evaporating_droplet/evaporating_droplet_with_heat.hpp
+++ b/simulations/evaporating_droplet/evaporating_droplet_with_heat.hpp
@@ -58,9 +58,7 @@ namespace MeltPoolDG
                  std::sqrt(3. * this->parameters.flow.surface_tension_coefficient /
                            (9.81 * (this->parameters.material.second.density -
                                     this->parameters.material.first.density))))
-      {
-        this->set_parameters();
-      }
+      {}
 
       void
       create_spatial_discretization() override

--- a/simulations/film_boiling/film_boiling.hpp
+++ b/simulations/film_boiling/film_boiling.hpp
@@ -127,9 +127,7 @@ namespace MeltPoolDG::Simulation::FilmBoiling
       , x_max(lambda0 / 2.)
       , y_max(lambda0)
       , x_min(-x_max)
-    {
-      this->set_parameters();
-    }
+    {}
 
     void
     create_spatial_discretization() override

--- a/simulations/flow_past_cylinder/flow_past_cylinder.hpp
+++ b/simulations/flow_past_cylinder/flow_past_cylinder.hpp
@@ -105,9 +105,7 @@ namespace MeltPoolDG
       public:
         SimulationFlowPastCylinder(std::string parameter_file, const MPI_Comm mpi_communicator)
           : SimulationBase<dim>(parameter_file, mpi_communicator)
-        {
-          this->set_parameters();
-        }
+        {}
 
         void
         create_spatial_discretization()

--- a/simulations/melt_front_propagation/melt_front_propagation.hpp
+++ b/simulations/melt_front_propagation/melt_front_propagation.hpp
@@ -92,9 +92,7 @@ namespace MeltPoolDG::Simulation::MeltFrontPropagation
   public:
     SimulationMeltFrontPropagation(std::string parameter_file, const MPI_Comm mpi_communicator)
       : SimulationBase<dim>(parameter_file, mpi_communicator)
-    {
-      this->set_parameters();
-    }
+    {}
 
     void
     create_spatial_discretization() override

--- a/simulations/recoil_pressure/recoil_pressure.hpp
+++ b/simulations/recoil_pressure/recoil_pressure.hpp
@@ -60,11 +60,36 @@ namespace MeltPoolDG
       template <int dim>
       class SimulationRecoilPressure : public SimulationBase<dim>
       {
+      private:
+        double domain_x_min = 0;
+        double domain_x_max = 0;
+        double domain_y_min = 0;
+        double domain_y_max = 0;
+
       public:
         SimulationRecoilPressure(std::string parameter_file, const MPI_Comm mpi_communicator)
           : SimulationBase<dim>(parameter_file, mpi_communicator)
+        {}
+
+        void
+        add_simulation_specific_parameters(dealii::ParameterHandler &prm) override
         {
-          this->set_parameters();
+          prm.enter_subsection("simulation specific domain");
+          {
+            prm.add_parameter("domain x min",
+                              domain_x_min,
+                              "minimum x coordinate of simulation domain");
+            prm.add_parameter("domain y min",
+                              domain_y_min,
+                              "minimum y coordinate of simulation domain");
+            prm.add_parameter("domain x max",
+                              domain_x_max,
+                              "maximum x coordinate of simulation domain");
+            prm.add_parameter("domain y max",
+                              domain_y_max,
+                              "maximum y coordinate of simulation domain");
+          }
+          prm.leave_subsection();
         }
 
         void
@@ -92,10 +117,10 @@ namespace MeltPoolDG
                 std::make_shared<parallel::distributed::Triangulation<dim>>(this->mpi_communicator);
             }
 
-          const double &x_min = this->parameters.mp.domain_x_min;
-          const double &x_max = this->parameters.mp.domain_x_max;
-          const double &y_min = this->parameters.mp.domain_y_min;
-          const double &y_max = this->parameters.mp.domain_y_max;
+          const double &x_min = domain_x_min;
+          const double &x_max = domain_x_max;
+          const double &y_min = domain_y_min;
+          const double &y_max = domain_y_max;
 
           if constexpr ((dim == 2) || (dim == 3))
             {
@@ -145,13 +170,13 @@ namespace MeltPoolDG
                     for (const auto &face : cell->face_iterators())
                       if ((face->at_boundary()))
                         {
-                          if (face->center()[1] == this->parameters.mp.domain_y_min)
+                          if (face->center()[1] == domain_y_min)
                             face->set_boundary_id(lower_bc);
-                          else if (face->center()[1] == this->parameters.mp.domain_y_max)
+                          else if (face->center()[1] == domain_y_max)
                             face->set_boundary_id(upper_bc);
-                          else if (face->center()[0] == this->parameters.mp.domain_x_min)
+                          else if (face->center()[0] == domain_x_min)
                             face->set_boundary_id(left_bc);
-                          else if (face->center()[0] == this->parameters.mp.domain_x_max)
+                          else if (face->center()[0] == domain_x_max)
                             face->set_boundary_id(right_bc);
                         }
                 }
@@ -182,10 +207,8 @@ namespace MeltPoolDG
           auto laser_center = MeltPoolDG::UtilityFunctions::convert_string_coords_to_point<dim>(
             this->parameters.laser.center);
           this->attach_initial_condition(
-            std::make_shared<InitialValuesLS<dim>>(this->parameters.mp.domain_x_min,
-                                                   this->parameters.mp.domain_x_max,
-                                                   this->parameters.mp.domain_y_min,
-                                                   laser_center[dim - 1]),
+            std::make_shared<InitialValuesLS<dim>>(
+              domain_x_min, domain_x_max, domain_y_min, laser_center[dim - 1]),
             "level_set");
           this->attach_initial_condition(std::shared_ptr<Function<dim>>(
                                            new Functions::ZeroFunction<dim>(dim)),

--- a/simulations/recoil_pressure/recoil_pressure.json
+++ b/simulations/recoil_pressure/recoil_pressure.json
@@ -43,11 +43,13 @@
   "melt pool": {
     "mp do melt pool": "true",
     "mp do heat transfer": "true",
-    "mp domain x min": "-0.0002",
-    "mp domain x max": "0.0002",
-    "mp domain y min": "-0.0001",
-    "mp domain y max": "0.0002",
     "mp boiling temperature": "3000."
+  },
+  "simulation specific domain": {
+    "domain x min": "-0.0002",
+    "domain x max": "0.0002",
+    "domain y min": "-0.0001",
+    "domain y max": "0.0002"
   },
   "levelset": {
     "ls do reinitialization": "true",

--- a/simulations/recoil_pressure/recoil_pressure_3d.json
+++ b/simulations/recoil_pressure/recoil_pressure_3d.json
@@ -41,13 +41,15 @@
     "laser analytical ambient temperature": "500."
   },
   "melt pool": {
-    "mp domain x min": "-0.0002",
-    "mp domain x max": "0.0002",
-    "mp domain y min": "-0.0001",
-    "mp domain y max": "0.0002",
     "mp boiling temperature": "3000.",
     "mp do melt pool": "true",
     "mp do heat transfer": "true"
+  },
+  "simulation specific domain": {
+    "domain x min": "-0.0002",
+    "domain x max": "0.0002",
+    "domain y min": "-0.0001",
+    "domain y max": "0.0002"
   },
   "levelset": {
     "ls do reinitialization": "true",

--- a/simulations/reinit_circle/reinit_circle.hpp
+++ b/simulations/reinit_circle/reinit_circle.hpp
@@ -82,9 +82,7 @@ namespace MeltPoolDG
       public:
         SimulationReinit(std::string parameter_file, const MPI_Comm mpi_communicator)
           : SimulationBase<dim>(parameter_file, mpi_communicator)
-        {
-          this->set_parameters();
-        }
+        {}
 
         void
         create_spatial_discretization()

--- a/simulations/rising_bubble/rising_bubble.hpp
+++ b/simulations/rising_bubble/rising_bubble.hpp
@@ -52,9 +52,7 @@ namespace MeltPoolDG
       public:
         SimulationRisingBubble(std::string parameter_file, const MPI_Comm mpi_communicator)
           : SimulationBase<dim>(parameter_file, mpi_communicator)
-        {
-          this->set_parameters();
-        }
+        {}
 
         void
         create_spatial_discretization() override

--- a/simulations/rotating_bubble/rotating_bubble.hpp
+++ b/simulations/rotating_bubble/rotating_bubble.hpp
@@ -139,9 +139,7 @@ namespace MeltPoolDG
       public:
         SimulationRotatingBubble(std::string parameter_file, const MPI_Comm mpi_communicator)
           : SimulationBase<dim>(parameter_file, mpi_communicator)
-        {
-          this->set_parameters();
-        }
+        {}
 
         void
         create_spatial_discretization()

--- a/simulations/slotted_disc/slotted_disc.hpp
+++ b/simulations/slotted_disc/slotted_disc.hpp
@@ -273,9 +273,7 @@ namespace MeltPoolDG
       public:
         SimulationSlottedDisc(std::string parameter_file, const MPI_Comm mpi_communicator)
           : SimulationBase<dim>(parameter_file, mpi_communicator)
-        {
-          this->set_parameters();
-        }
+        {}
 
         void
         create_spatial_discretization()

--- a/simulations/solidification_slab/solidification_slab.hpp
+++ b/simulations/solidification_slab/solidification_slab.hpp
@@ -42,9 +42,7 @@ namespace MeltPoolDG::Simulation::SolidificationSlab
   public:
     SimulationSolidificationSlab(std::string parameter_file, const MPI_Comm mpi_communicator)
       : SimulationBase<dim>(parameter_file, mpi_communicator)
-    {
-      this->set_parameters();
-    }
+    {}
 
     void
     create_spatial_discretization() override

--- a/simulations/spurious_currents/spurious_currents.hpp
+++ b/simulations/spurious_currents/spurious_currents.hpp
@@ -63,9 +63,7 @@ namespace MeltPoolDG
       public:
         SimulationSpuriousCurrents(std::string parameter_file, const MPI_Comm mpi_communicator)
           : SimulationBase<dim>(parameter_file, mpi_communicator)
-        {
-          this->set_parameters();
-        }
+        {}
 
 
         void

--- a/simulations/stefans_problem/stefans_problem.hpp
+++ b/simulations/stefans_problem/stefans_problem.hpp
@@ -91,9 +91,7 @@ namespace MeltPoolDG::Simulation::StefansProblem
   public:
     SimulationStefansProblem(std::string parameter_file, const MPI_Comm mpi_communicator)
       : SimulationBase<dim>(parameter_file, mpi_communicator)
-    {
-      this->set_parameters();
-    }
+    {}
 
     void
     create_spatial_discretization() override

--- a/simulations/stefans_problem/stefans_problem1_with_flow_and_heat.hpp
+++ b/simulations/stefans_problem/stefans_problem1_with_flow_and_heat.hpp
@@ -143,7 +143,6 @@ namespace MeltPoolDG::Simulation::StefansProblem1WithFlowAndHeat
       , x_max(y_max / std::pow(dim, this->parameters.base.global_refinements))
 
     {
-      this->set_parameters();
       if (Utilities::MPI::this_mpi_process(mpi_communicator) == 0)
         file_level_set_contour.open(this->parameters.paraview.directory + "/" +
                                     this->parameters.paraview.filename +

--- a/simulations/stefans_problem/stefans_problem2_with_flow_and_heat.hpp
+++ b/simulations/stefans_problem/stefans_problem2_with_flow_and_heat.hpp
@@ -94,9 +94,7 @@ namespace MeltPoolDG::Simulation::StefansProblem2WithFlowAndHeat
     SimulationStefansProblem2WithFlowAndHeat(std::string    parameter_file,
                                              const MPI_Comm mpi_communicator)
       : SimulationBase<dim>(parameter_file, mpi_communicator)
-    {
-      this->set_parameters();
-    }
+    {}
 
     void
     create_spatial_discretization() override

--- a/simulations/stefans_problem/stefans_problem_with_flow.hpp
+++ b/simulations/stefans_problem/stefans_problem_with_flow.hpp
@@ -74,9 +74,7 @@ namespace MeltPoolDG::Simulation::StefansProblemWithFlow
   public:
     SimulationStefansProblemWithFlow(std::string parameter_file, const MPI_Comm mpi_communicator)
       : SimulationBase<dim>(parameter_file, mpi_communicator)
-    {
-      this->set_parameters();
-    }
+    {}
 
     void
     create_spatial_discretization() override

--- a/simulations/thermo_capillary_droplet/thermo_capillary_droplet.hpp
+++ b/simulations/thermo_capillary_droplet/thermo_capillary_droplet.hpp
@@ -114,9 +114,7 @@ namespace MeltPoolDG::Simulation::ThermoCapillaryDroplet
   public:
     SimulationThermoCapillaryDroplet(std::string parameter_file, const MPI_Comm mpi_communicator)
       : SimulationBase<dim>(parameter_file, mpi_communicator)
-    {
-      this->set_parameters();
-    }
+    {}
 
     void
     create_spatial_discretization() override

--- a/simulations/thermo_capillary_two_droplets/thermo_capillary_two_droplets.hpp
+++ b/simulations/thermo_capillary_two_droplets/thermo_capillary_two_droplets.hpp
@@ -157,9 +157,7 @@ namespace MeltPoolDG::Simulation::ThermoCapillaryTwoDroplets
     SimulationThermoCapillaryTwoDroplets(std::string    parameter_file,
                                          const MPI_Comm mpi_communicator)
       : SimulationBase<dim>(parameter_file, mpi_communicator)
-    {
-      this->set_parameters();
-    }
+    {}
 
     void
     create_spatial_discretization() override

--- a/simulations/unidirectional_heat_transfer/unidirectional_heat_transfer.hpp
+++ b/simulations/unidirectional_heat_transfer/unidirectional_heat_transfer.hpp
@@ -159,9 +159,7 @@ namespace MeltPoolDG::Simulation::UnidirectionalHeatTransfer
     SimulationUnidirectionalHeatTransfer(std::string    parameter_file,
                                          const MPI_Comm mpi_communicator)
       : SimulationBase<dim>(parameter_file, mpi_communicator)
-    {
-      this->set_parameters();
-    }
+    {}
 
     void
     create_spatial_discretization() override

--- a/simulations/vortex_bubble/vortex_bubble.hpp
+++ b/simulations/vortex_bubble/vortex_bubble.hpp
@@ -124,9 +124,7 @@ namespace MeltPoolDG
       public:
         SimulationVortexBubble(std::string parameter_file, const MPI_Comm mpi_communicator)
           : SimulationBase<dim>(parameter_file, mpi_communicator)
-        {
-          this->set_parameters();
-        }
+        {}
 
         void
         create_spatial_discretization()

--- a/source/interface/parameters.cpp
+++ b/source/interface/parameters.cpp
@@ -6,7 +6,8 @@ namespace MeltPoolDG
   void
   Parameters<number>::process_parameters_file(const std::string &parameter_filename)
   {
-    add_parameters();
+    AssertThrow(!parameters_read, ExcMessage("The parameters are already read once."))
+      add_parameters();
 
     check_for_file(parameter_filename);
 
@@ -51,13 +52,37 @@ namespace MeltPoolDG
     if (evapor.ls_value_liquid == evapor.ls_value_gas)
       AssertThrow(
         false, ExcMessage("Parameterhandler: ls value liquid must not be equal to ls value gas."));
+
+
+    if (heat.solidification)
+      {
+        AssertThrow(
+          material.solidus_temperature < material.liquidus_temperature,
+          ExcMessage(
+            "The liquidus temperature must be greater than the solidus temperature! Abort..."));
+        material.inv_mushy_interval =
+          1.0 / (material.liquidus_temperature - material.solidus_temperature);
+      }
       /*
        *  parameters for adaflo
        */
 #ifdef MELT_POOL_DG_WITH_ADAFLO
-
     if (base.problem_name == "melt_pool")
       {
+        if (flow.variable_properties_over_interface == "false")
+          material.two_phase_properties_transition_type =
+            MaterialData<number>::TwoPhasePropertiesTransitionType::sharp;
+        else if (flow.variable_properties_over_interface == "true")
+          material.two_phase_properties_transition_type =
+            MaterialData<number>::TwoPhasePropertiesTransitionType::smooth;
+        else if (flow.variable_properties_over_interface == "consistent_with_evaporation")
+          material.two_phase_properties_transition_type =
+            MaterialData<number>::TwoPhasePropertiesTransitionType::evaporation;
+        else
+          AssertThrow(false,
+                      ExcMessage("Unknown variable properties over interface type \"" +
+                                 flow.variable_properties_over_interface + "\"! Abort..."));
+
         if (mp.do_evaporation && !mp.do_heat_transfer)
           AssertThrow(false,
                       ExcMessage("In case of evaporation both flag >>> do evaporation <<< "
@@ -146,6 +171,7 @@ namespace MeltPoolDG
         adaflo_params.params.use_simplex_mesh     = base.do_simplex;
       }
 #endif
+    parameters_read = true;
   }
 
   template <typename number>
@@ -652,18 +678,6 @@ namespace MeltPoolDG
                         mp.melt_pool_center,
                         "Center coordinates of the melt pool ellipse/parabola. If no value is "
                         "provided it will be set equally to the laser center");
-      prm.add_parameter("mp domain x min",
-                        mp.domain_x_min,
-                        "minimum x coordinate of simulation domain");
-      prm.add_parameter("mp domain y min",
-                        mp.domain_y_min,
-                        "minimum y coordinate of simulation domain");
-      prm.add_parameter("mp domain x max",
-                        mp.domain_x_max,
-                        "maximum x coordinate of simulation domain");
-      prm.add_parameter("mp domain y max",
-                        mp.domain_y_max,
-                        "maximum y coordinate of simulation domain");
       prm.add_parameter(
         "mp set velocity to zero in solid",
         mp.set_velocity_to_zero_in_solid,
@@ -800,28 +814,6 @@ namespace MeltPoolDG
       prm.add_parameter("material liquidus temperature",
                         material.liquidus_temperature,
                         "Liquidus temperature");
-      if (heat.solidification)
-        {
-          AssertThrow(
-            material.solidus_temperature < material.liquidus_temperature,
-            ExcMessage(
-              "The liquidus temperature must be greater than the solidus temperature! Abort..."));
-          material.inv_mushy_interval =
-            1.0 / (material.liquidus_temperature - material.solidus_temperature);
-        }
-      if (flow.variable_properties_over_interface == "false")
-        material.two_phase_properties_transition_type =
-          MaterialData<number>::TwoPhasePropertiesTransitionType::sharp;
-      else if (flow.variable_properties_over_interface == "true")
-        material.two_phase_properties_transition_type =
-          MaterialData<number>::TwoPhasePropertiesTransitionType::smooth;
-      else if (flow.variable_properties_over_interface == "consistent_with_evaporation")
-        material.two_phase_properties_transition_type =
-          MaterialData<number>::TwoPhasePropertiesTransitionType::evaporation;
-      else
-        AssertThrow(false,
-                    ExcMessage("Unknown variable properties over interface type \"" +
-                               flow.variable_properties_over_interface + "\"! Abort..."));
     }
     prm.leave_subsection();
     /*

--- a/tests/recoil_pressure.json
+++ b/tests/recoil_pressure.json
@@ -84,11 +84,13 @@
     "mp do heat transfer": "true",
     "mp do recoil pressure": "true",
     "mp boiling temperature": "3000.",
-    "mp liquid melting point": "1700",
-    "mp domain x min": "-0.0002",
-    "mp domain x max": "0.0002",
-    "mp domain y min": "-0.0001",
-    "mp domain y max": "0.0002"
+    "mp liquid melting point": "1700"
+  },
+  "simulation specific domain": {
+    "domain x min": "-0.0002",
+    "domain x max": "0.0002",
+    "domain y min": "-0.0001",
+    "domain y max": "0.0002"
   },
   "normal vector": {
     "normal vec damping scale factor": "2.",

--- a/tests/recoil_pressure_fixed_solid_domain.json
+++ b/tests/recoil_pressure_fixed_solid_domain.json
@@ -87,13 +87,15 @@
     "mp do melt pool": "true",
     "mp do recoil pressure": "true",
     "mp boiling temperature": "3000.",
-    "mp domain x max": "0.000100",
-    "mp domain x min": "-0.000100",
-    "mp domain y max": "0.0001",
-    "mp domain y min": "-0.000075",
     "mp liquid melting point": "1700",
     "mp set level set to zero in solid": "true",
     "mp set velocity to zero in solid": "true"
+  },
+  "simulation specific domain": {
+    "domain x max": "0.000100",
+    "domain x min": "-0.000100",
+    "domain y max": "0.0001",
+    "domain y min": "-0.000075"
   },
   "normal vector": {
     "normal vec damping scale factor": "4.",

--- a/tests/recoil_pressure_simplex.json
+++ b/tests/recoil_pressure_simplex.json
@@ -85,11 +85,13 @@
     "mp do melt pool": "true",
     "mp do recoil pressure": "true",
     "mp boiling temperature": "3000.",
-    "mp liquid melting point": "1700",
-    "mp domain x min": "-0.0002",
-    "mp domain x max": "0.0002",
-    "mp domain y min": "-0.0001",
-    "mp domain y max": "0.0002"
+    "mp liquid melting point": "1700"
+  },
+  "simulation specific domain": {
+    "domain x min": "-0.0002",
+    "domain x max": "0.0002",
+    "domain y min": "-0.0001",
+    "domain y max": "0.0002"
   },
   "normal vector": {
     "normal vec damping scale factor": "2.",

--- a/tests/tests_not_robust/recoil_pressure_amr.json
+++ b/tests/tests_not_robust/recoil_pressure_amr.json
@@ -92,11 +92,13 @@
     "mp do melt pool": "true",
     "mp do recoil pressure": "true",
     "mp boiling temperature": "3000.",
-    "mp liquid melting point": "1700",
-    "mp domain x min": "-0.0002",
-    "mp domain x max": "0.0002",
-    "mp domain y min": "-0.0001",
-    "mp domain y max": "0.0002"
+    "mp liquid melting point": "1700"
+  },
+  "simulation specific domain": {
+    "domain x min": "-0.0002",
+    "domain x max": "0.0002",
+    "domain y min": "-0.0001",
+    "domain y max": "0.0002"
   },
   "normal vector": {
     "normal vec damping scale factor": "4.",


### PR DESCRIPTION
This PR introduces a particular function to declare simulation specific parameters `domain_x_min` (see `recoil_pressure.hpp`). I did not want to read the base parameters twice (note: child function cannot be executed from the base class constructor) to avoid potential conflicting behavior, so I declared a separate `ParameterHandler` for the user-specific parameters.

@nmuch: Could you please adapt #259 to this concept?