### PR TITLE
Introduce multiplicity in line integral

### DIFF
--- a/include/meltpooldg/evaporation/evaporation_mass_flux_operator_thickness_integration.hpp
+++ b/include/meltpooldg/evaporation/evaporation_mass_flux_operator_thickness_integration.hpp
@@ -37,7 +37,7 @@ namespace MeltPoolDG::Evaporation
     const double constant_epsilon;
     const double eps_scale_factor;
 
-    const unsigned int ls_dof_idx;
+    const unsigned int ls_hanging_nodes_dof_idx;
     const unsigned int normal_dof_idx;
     const unsigned int temp_dof_idx;
 
@@ -53,7 +53,7 @@ namespace MeltPoolDG::Evaporation
                                                     const BlockVectorType &normal_vector,
                                                     const double           constant_epsilon,
                                                     const double           eps_scale_factor,
-                                                    const unsigned int     ls_dof_idx,
+                                                    const unsigned int     ls_hanging_nodes_dof_idx,
                                                     const unsigned int     normal_dof_idx,
                                                     const unsigned int     temp_dof_idx,
                                                     const unsigned int     n_subdivisions_per_side,

--- a/include/meltpooldg/utilities/utility_functions.hpp
+++ b/include/meltpooldg/utilities/utility_functions.hpp
@@ -483,6 +483,10 @@ namespace MeltPoolDG
 
       global_points_normal_to_interface_pointer = {0};
 
+      const auto bounding_box = GridTools::compute_bounding_box(dof_handler_ls.get_triangulation());
+      const auto boundary_points = bounding_box.get_boundary_points();
+
+
       const auto collect_points_along_normal = [&](const auto &                 cell,
                                                    const auto &                 real_points,
                                                    const auto &                 unit_points,
@@ -548,7 +552,22 @@ namespace MeltPoolDG
                                               max_distance_per_side,
                                               n_inc_per_side,
                                               bidirectional);
-
+            // check if point is outside domain and if so then project it back to
+            // the domain
+            //
+            // @todo: compute intersection between normal and bounding box and use
+            // this point
+            for (unsigned int d = 0; d < dim; ++d)
+              {
+                for (unsigned int counter = 0; counter < points_normal_to_interface.size();
+                     counter++)
+                  {
+                    if (points_normal_to_interface[counter][d] < boundary_points.first[d])
+                      points_normal_to_interface[counter][d] = boundary_points.first[d];
+                    else if (points_normal_to_interface[counter][d] > boundary_points.second[d])
+                      points_normal_to_interface[counter][d] = boundary_points.second[d];
+                  }
+              }
 
             global_points_normal_to_interface.insert(global_points_normal_to_interface.end(),
                                                      points_normal_to_interface.begin(),

--- a/include/meltpooldg/utilities/utility_functions.hpp
+++ b/include/meltpooldg/utilities/utility_functions.hpp
@@ -563,9 +563,14 @@ namespace MeltPoolDG
                      counter++)
                   {
                     if (points_normal_to_interface[counter][d] < boundary_points.first[d])
-                      points_normal_to_interface[counter][d] = boundary_points.first[d];
+                      {
+                        points_normal_to_interface.erase(points_normal_to_interface.begin() +
+                                                         counter);
+                        continue;
+                      }
                     else if (points_normal_to_interface[counter][d] > boundary_points.second[d])
-                      points_normal_to_interface[counter][d] = boundary_points.second[d];
+                      points_normal_to_interface.erase(points_normal_to_interface.begin() +
+                                                       counter);
                   }
               }
 

--- a/source/evaporation/evaporation_mass_flux_operator_thickness_integration.cpp
+++ b/source/evaporation/evaporation_mass_flux_operator_thickness_integration.cpp
@@ -242,16 +242,12 @@ namespace MeltPoolDG::Evaporation
         evaporative_mass_flux.compress(VectorOperation::add);
         vector_multiplicity.compress(VectorOperation::add);
 
-        vector_multiplicity.update_ghost_values();
-        evaporative_mass_flux.update_ghost_values();
-
         for (unsigned int i = 0; i < vector_multiplicity.locally_owned_size(); ++i)
           if (vector_multiplicity.local_element(i) > 1.0)
             evaporative_mass_flux.local_element(i) /= vector_multiplicity.local_element(i);
 
-        scratch_data.get_constraint(ls_hanging_nodes_dof_idx).distribute(evaporative_mass_flux);
         evaporative_mass_flux.update_ghost_values();
-
+        scratch_data.get_constraint(ls_hanging_nodes_dof_idx).distribute(evaporative_mass_flux);
         temperature.zero_out_ghost_values();
         level_set_as_heaviside.zero_out_ghost_values();
       }

--- a/source/evaporation/evaporation_mass_flux_operator_thickness_integration.cpp
+++ b/source/evaporation/evaporation_mass_flux_operator_thickness_integration.cpp
@@ -249,6 +249,7 @@ namespace MeltPoolDG::Evaporation
           if (vector_multiplicity.local_element(i) > 1.0)
             evaporative_mass_flux.local_element(i) /= vector_multiplicity.local_element(i);
 
+        scratch_data.get_constraint(ls_hanging_nodes_dof_idx).distribute(evaporative_mass_flux);
         evaporative_mass_flux.update_ghost_values();
 
         temperature.zero_out_ghost_values();

--- a/source/evaporation/evaporation_mass_flux_operator_thickness_integration.cpp
+++ b/source/evaporation/evaporation_mass_flux_operator_thickness_integration.cpp
@@ -25,7 +25,7 @@ namespace MeltPoolDG::Evaporation
                                                     const BlockVectorType &normal_vector,
                                                     const double           constant_epsilon,
                                                     const double           eps_scale_factor,
-                                                    const unsigned int     ls_dof_idx,
+                                                    const unsigned int     ls_hanging_nodes_dof_idx,
                                                     const unsigned int     normal_dof_idx,
                                                     const unsigned int     temp_dof_idx,
                                                     const unsigned int     n_subdivisions_per_side,
@@ -36,7 +36,7 @@ namespace MeltPoolDG::Evaporation
     , normal_vector(normal_vector)
     , constant_epsilon(constant_epsilon)
     , eps_scale_factor(eps_scale_factor)
-    , ls_dof_idx(ls_dof_idx)
+    , ls_hanging_nodes_dof_idx(ls_hanging_nodes_dof_idx)
     , normal_dof_idx(normal_dof_idx)
     , temp_dof_idx(temp_dof_idx)
     , fe_dim(FE_Q<dim>(scratch_data.get_degree(normal_dof_idx)), dim)
@@ -54,7 +54,7 @@ namespace MeltPoolDG::Evaporation
 
     if constexpr (dim > 1)
       {
-        scratch_data.initialize_dof_vector(evaporative_mass_flux, ls_dof_idx);
+        scratch_data.initialize_dof_vector(evaporative_mass_flux, ls_hanging_nodes_dof_idx);
         /*
          * generate point cloud normal to interface
          */
@@ -71,7 +71,7 @@ namespace MeltPoolDG::Evaporation
         UtilityFunctions::generate_points_along_normal<dim>(
           global_points_normal_to_interface,
           global_points_normal_to_interface_pointer,
-          scratch_data.get_dof_handler(ls_dof_idx),
+          scratch_data.get_dof_handler(ls_hanging_nodes_dof_idx),
           fe_dim,
           scratch_data.get_mapping(),
           level_set_as_heaviside,
@@ -82,7 +82,11 @@ namespace MeltPoolDG::Evaporation
           /* contour_value */ 0.5,
           n_subdivisions_MCA);
 
-        if (true)
+        temperature.update_ghost_values();
+        level_set_as_heaviside.update_ghost_values();
+
+
+        if (false)
           {
             /*
              * debug
@@ -121,6 +125,7 @@ namespace MeltPoolDG::Evaporation
                                        scratch_data.get_triangulation(),
                                        scratch_data.get_mapping());
 
+
         const auto temperature_evaluation_values =
           dealii::VectorTools::point_values<1>(remote_point_evaluation,
                                                scratch_data.get_dof_handler(temp_dof_idx),
@@ -128,7 +133,8 @@ namespace MeltPoolDG::Evaporation
 
         const std::vector<Tensor<1, dim, double>> level_set_gradient_values =
           dealii::VectorTools::point_gradients<1>(remote_point_evaluation,
-                                                  scratch_data.get_dof_handler(ls_dof_idx),
+                                                  scratch_data.get_dof_handler(
+                                                    ls_hanging_nodes_dof_idx),
                                                   level_set_as_heaviside);
         /*
          * evaluate line integral
@@ -178,7 +184,7 @@ namespace MeltPoolDG::Evaporation
          * too sensitive with respect to the inherent distance parameter.
          */
         VectorType vector_multiplicity;
-        vector_multiplicity.reinit(temperature);
+        vector_multiplicity.reinit(evaporative_mass_flux);
 
         const auto broadcast_function = [&](const auto &values, const auto &cell_data) {
           // loop over all cells where points along normal are interior
@@ -188,7 +194,7 @@ namespace MeltPoolDG::Evaporation
                 &remote_point_evaluation.get_triangulation(),
                 cell_data.cells[i].first,
                 cell_data.cells[i].second,
-                &scratch_data.get_dof_handler(ls_dof_idx)};
+                &scratch_data.get_dof_handler(ls_hanging_nodes_dof_idx)};
 
               // values at the points along normal in reference coordinates
               const ArrayView<const double> temp_vals(values.data() +
@@ -213,13 +219,15 @@ namespace MeltPoolDG::Evaporation
               for (auto &n : nodal_values)
                 n = average;
 
-              cell->set_dof_values(nodal_values, evaporative_mass_flux);
+              scratch_data.get_constraint(ls_hanging_nodes_dof_idx)
+                .distribute_local_to_global(nodal_values, local_dof_indices, evaporative_mass_flux);
 
               // count the number of written values (multiplicity)
               for (auto &val : nodal_values)
                 val = 1.0;
 
-              cell->set_dof_values(nodal_values, vector_multiplicity);
+              scratch_data.get_constraint(ls_hanging_nodes_dof_idx)
+                .distribute_local_to_global(nodal_values, local_dof_indices, vector_multiplicity);
             }
         };
 
@@ -229,6 +237,22 @@ namespace MeltPoolDG::Evaporation
         remote_point_evaluation.template process_and_evaluate<double>(mass_flux_val,
                                                                       buffer,
                                                                       broadcast_function);
+
+        // take care dofs shared by multiple geometric entities
+        evaporative_mass_flux.compress(VectorOperation::add);
+        vector_multiplicity.compress(VectorOperation::add);
+
+        vector_multiplicity.update_ghost_values();
+        evaporative_mass_flux.update_ghost_values();
+
+        for (unsigned int i = 0; i < vector_multiplicity.locally_owned_size(); ++i)
+          if (vector_multiplicity.local_element(i) > 1.0)
+            evaporative_mass_flux.local_element(i) /= vector_multiplicity.local_element(i);
+
+        evaporative_mass_flux.update_ghost_values();
+
+        temperature.zero_out_ghost_values();
+        level_set_as_heaviside.zero_out_ghost_values();
       }
   }
 


### PR DESCRIPTION
This PR:

- computes multiplicity to evaluate the evaporative mass flux via thickness integration
- adds the check if a point is outside the bounding box within `generate_points_along_normal_vector`.

In the following picture we see the resulting evaporative mass flux. In this example periodic BC are applied between the right and the left face. This would mean that the values should be the same on the two faces, however they are not (on the right face they are exactly zero).

![image](https://user-images.githubusercontent.com/70260016/122092457-3c347e00-ce0a-11eb-9495-c202cd68d30e.png)
