### PR TITLE
Enable time-dependent update of zero velocity constraints

### DIFF
--- a/include/meltpooldg/melt_pool/melt_pool_operation.hpp
+++ b/include/meltpooldg/melt_pool/melt_pool_operation.hpp
@@ -51,6 +51,7 @@ namespace MeltPoolDG
       const unsigned int ls_dof_idx;
       const unsigned int reinit_dof_idx;
       const unsigned int flow_vel_dof_idx;
+      const unsigned int flow_vel_no_solid_dof_idx;
       const unsigned int flow_vel_quad_idx;
       const unsigned int temp_dof_idx;
       VectorType *       temperature;
@@ -68,6 +69,7 @@ namespace MeltPoolDG
                         VectorType *                             temperature,
                         const unsigned int                       reinit_dof_idx_in,
                         const unsigned int                       flow_vel_dof_idx_in,
+                        const unsigned int                       flow_vel_no_solid_dof_idx_in,
                         const unsigned int                       flow_vel_quad_idx_in,
                         const unsigned int                       temp_dof_idx_in,
                         const double                             start_time_in);
@@ -126,8 +128,10 @@ namespace MeltPoolDG
        *  regions.
        */
       void
-      set_flow_field_in_solid_regions_to_zero(const DoFHandler<dim> &    flow_dof_handler,
-                                              AffineConstraints<double> &flow_constraints);
+      set_flow_field_in_solid_regions_to_zero(
+        const DoFHandler<dim> &          flow_dof_handler,
+        const AffineConstraints<double> &flow_constraints_no_solid,
+        AffineConstraints<double> &      flow_constraints);
 
       /**
        *  The level set constraints are modified such that they are zero in solid

--- a/include/meltpooldg/melt_pool/melt_pool_problem.hpp
+++ b/include/meltpooldg/melt_pool/melt_pool_problem.hpp
@@ -107,6 +107,7 @@ namespace MeltPoolDG::Flow
     AffineConstraints<double> ls_hanging_node_constraints;
     AffineConstraints<double> reinit_constraints_dirichlet;
     AffineConstraints<double> temp_constraints_dirichlet;
+    AffineConstraints<double> flow_velocity_constraints_no_solid;
 
     VectorType vel_force_rhs;
     VectorType mass_balance_rhs;
@@ -126,6 +127,7 @@ namespace MeltPoolDG::Flow
 
     unsigned int vel_dof_idx;
     unsigned int pressure_dof_idx;
+    unsigned int flow_vel_no_solid_dof_idx;
 
     std::shared_ptr<ScratchData<dim>>                       scratch_data;
     std::shared_ptr<FlowBase<dim>>                          flow_operation;

--- a/simulations/recoil_pressure/recoil_pressure.hpp
+++ b/simulations/recoil_pressure/recoil_pressure.hpp
@@ -22,6 +22,8 @@ namespace MeltPoolDG
   {
     namespace RecoilPressure
     {
+      const double T_initial = 500.;
+
       using namespace dealii;
 
       template <int dim>
@@ -157,12 +159,17 @@ namespace MeltPoolDG
         void
         set_boundary_conditions() override
         {
+          types::boundary_id lower_bc = 0;
+          types::boundary_id upper_bc = 0;
+          types::boundary_id left_bc  = 0;
+          types::boundary_id right_bc = 0;
+
           if (this->parameters.mp.do_evaporation)
             {
-              const types::boundary_id lower_bc = 1;
-              const types::boundary_id upper_bc = 2;
-              const types::boundary_id left_bc  = 3;
-              const types::boundary_id right_bc = 4;
+              lower_bc = 1;
+              upper_bc = 2;
+              left_bc  = 3;
+              right_bc = 4;
 
               if constexpr (dim == 2)
                 {
@@ -190,35 +197,11 @@ namespace MeltPoolDG
 
               this->attach_dirichlet_boundary_condition(
                 upper_bc, std::make_shared<Functions::ConstantFunction<dim>>(-1.0), "level_set");
-              if (this->parameters.laser.heat_source_model != "Analytical")
-                {
-                  this->attach_dirichlet_boundary_condition(
-                    lower_bc,
-                    std::make_shared<Functions::ConstantFunction<dim>>(500),
-                    "heat_transfer");
-                  this->attach_dirichlet_boundary_condition(
-                    upper_bc,
-                    std::make_shared<Functions::ConstantFunction<dim>>(500),
-                    "heat_transfer");
-                  this->attach_dirichlet_boundary_condition(
-                    left_bc,
-                    std::make_shared<Functions::ConstantFunction<dim>>(500),
-                    "heat_transfer");
-                  this->attach_dirichlet_boundary_condition(
-                    right_bc,
-                    std::make_shared<Functions::ConstantFunction<dim>>(500),
-                    "heat_transfer");
-                }
             }
           else if (this->parameters.base.problem_name == "melt_pool")
             {
               this->attach_no_slip_boundary_condition(0, "navier_stokes_u");
               this->attach_fix_pressure_constant_condition(0, "navier_stokes_p");
-              if (this->parameters.laser.heat_source_model != "Analytical")
-                {
-                  this->attach_dirichlet_boundary_condition(
-                    0, std::make_shared<Functions::ConstantFunction<dim>>(500), "heat_transfer");
-                }
             }
           else
             AssertThrow(false, ExcNotImplemented());
@@ -226,7 +209,25 @@ namespace MeltPoolDG
           /*
            * BC for heat transfer
            */
-          // old bc
+          if (this->parameters.laser.heat_source_model != "Analytical")
+            {
+              this->attach_dirichlet_boundary_condition(
+                lower_bc,
+                std::make_shared<Functions::ConstantFunction<dim>>(T_initial),
+                "heat_transfer");
+              this->attach_dirichlet_boundary_condition(
+                upper_bc,
+                std::make_shared<Functions::ConstantFunction<dim>>(T_initial),
+                "heat_transfer");
+              this->attach_dirichlet_boundary_condition(
+                left_bc,
+                std::make_shared<Functions::ConstantFunction<dim>>(T_initial),
+                "heat_transfer");
+              this->attach_dirichlet_boundary_condition(
+                right_bc,
+                std::make_shared<Functions::ConstantFunction<dim>>(T_initial),
+                "heat_transfer");
+            }
         }
 
         void
@@ -242,8 +243,8 @@ namespace MeltPoolDG
                                            new Functions::ZeroFunction<dim>(dim)),
                                          "navier_stokes_u");
           if (this->parameters.laser.heat_source_model != "Analytical")
-            this->attach_initial_condition(std::make_shared<Functions::ConstantFunction<dim>>(500),
-                                           "heat_transfer");
+            this->attach_initial_condition(
+              std::make_shared<Functions::ConstantFunction<dim>>(T_initial), "heat_transfer");
         }
       };
 

--- a/simulations/recoil_pressure/recoil_pressure.hpp
+++ b/simulations/recoil_pressure/recoil_pressure.hpp
@@ -159,17 +159,12 @@ namespace MeltPoolDG
         void
         set_boundary_conditions() override
         {
-          types::boundary_id lower_bc = 0;
-          types::boundary_id upper_bc = 0;
-          types::boundary_id left_bc  = 0;
-          types::boundary_id right_bc = 0;
-
           if (this->parameters.mp.do_evaporation)
             {
-              lower_bc = 1;
-              upper_bc = 2;
-              left_bc  = 3;
-              right_bc = 4;
+              const types::boundary_id lower_bc = 1;
+              const types::boundary_id upper_bc = 2;
+              const types::boundary_id left_bc  = 3;
+              const types::boundary_id right_bc = 4;
 
               if constexpr (dim == 2)
                 {
@@ -197,37 +192,46 @@ namespace MeltPoolDG
 
               this->attach_dirichlet_boundary_condition(
                 upper_bc, std::make_shared<Functions::ConstantFunction<dim>>(-1.0), "level_set");
+              /*
+               * BC for heat transfer
+               */
+              if (this->parameters.laser.heat_source_model != "Analytical")
+                {
+                  this->attach_dirichlet_boundary_condition(
+                    lower_bc,
+                    std::make_shared<Functions::ConstantFunction<dim>>(T_initial),
+                    "heat_transfer");
+                  this->attach_dirichlet_boundary_condition(
+                    upper_bc,
+                    std::make_shared<Functions::ConstantFunction<dim>>(T_initial),
+                    "heat_transfer");
+                  this->attach_dirichlet_boundary_condition(
+                    left_bc,
+                    std::make_shared<Functions::ConstantFunction<dim>>(T_initial),
+                    "heat_transfer");
+                  this->attach_dirichlet_boundary_condition(
+                    right_bc,
+                    std::make_shared<Functions::ConstantFunction<dim>>(T_initial),
+                    "heat_transfer");
+                }
             }
           else if (this->parameters.base.problem_name == "melt_pool")
             {
               this->attach_no_slip_boundary_condition(0, "navier_stokes_u");
               this->attach_fix_pressure_constant_condition(0, "navier_stokes_p");
+              /*
+               * BC for heat transfer
+               */
+              if (this->parameters.laser.heat_source_model != "Analytical")
+                {
+                  this->attach_dirichlet_boundary_condition(
+                    0,
+                    std::make_shared<Functions::ConstantFunction<dim>>(T_initial),
+                    "heat_transfer");
+                }
             }
           else
             AssertThrow(false, ExcNotImplemented());
-
-          /*
-           * BC for heat transfer
-           */
-          if (this->parameters.laser.heat_source_model != "Analytical")
-            {
-              this->attach_dirichlet_boundary_condition(
-                lower_bc,
-                std::make_shared<Functions::ConstantFunction<dim>>(T_initial),
-                "heat_transfer");
-              this->attach_dirichlet_boundary_condition(
-                upper_bc,
-                std::make_shared<Functions::ConstantFunction<dim>>(T_initial),
-                "heat_transfer");
-              this->attach_dirichlet_boundary_condition(
-                left_bc,
-                std::make_shared<Functions::ConstantFunction<dim>>(T_initial),
-                "heat_transfer");
-              this->attach_dirichlet_boundary_condition(
-                right_bc,
-                std::make_shared<Functions::ConstantFunction<dim>>(T_initial),
-                "heat_transfer");
-            }
         }
 
         void

--- a/simulations/recoil_pressure/recoil_pressure.hpp
+++ b/simulations/recoil_pressure/recoil_pressure.hpp
@@ -190,14 +190,42 @@ namespace MeltPoolDG
 
               this->attach_dirichlet_boundary_condition(
                 upper_bc, std::make_shared<Functions::ConstantFunction<dim>>(-1.0), "level_set");
+              if (this->parameters.laser.heat_source_model != "Analytical")
+                {
+                  this->attach_dirichlet_boundary_condition(
+                    lower_bc,
+                    std::make_shared<Functions::ConstantFunction<dim>>(500),
+                    "heat_transfer");
+                  this->attach_dirichlet_boundary_condition(
+                    upper_bc,
+                    std::make_shared<Functions::ConstantFunction<dim>>(500),
+                    "heat_transfer");
+                  this->attach_dirichlet_boundary_condition(
+                    left_bc,
+                    std::make_shared<Functions::ConstantFunction<dim>>(500),
+                    "heat_transfer");
+                  this->attach_dirichlet_boundary_condition(
+                    right_bc,
+                    std::make_shared<Functions::ConstantFunction<dim>>(500),
+                    "heat_transfer");
+                }
             }
           else if (this->parameters.base.problem_name == "melt_pool")
             {
               this->attach_no_slip_boundary_condition(0, "navier_stokes_u");
               this->attach_fix_pressure_constant_condition(0, "navier_stokes_p");
+              if (this->parameters.laser.heat_source_model != "Analytical")
+                {
+                  this->attach_dirichlet_boundary_condition(
+                    0, std::make_shared<Functions::ConstantFunction<dim>>(500), "heat_transfer");
+                }
             }
           else
             AssertThrow(false, ExcNotImplemented());
+
+          /*
+           * BC for heat transfer
+           */
           // old bc
         }
 
@@ -213,6 +241,9 @@ namespace MeltPoolDG
           this->attach_initial_condition(std::shared_ptr<Function<dim>>(
                                            new Functions::ZeroFunction<dim>(dim)),
                                          "navier_stokes_u");
+          if (this->parameters.laser.heat_source_model != "Analytical")
+            this->attach_initial_condition(std::make_shared<Functions::ConstantFunction<dim>>(500),
+                                           "heat_transfer");
         }
       };
 

--- a/simulations/recoil_pressure/recoil_pressure_with_laser_fixed_solid_domain.json
+++ b/simulations/recoil_pressure/recoil_pressure_with_laser_fixed_solid_domain.json
@@ -1,0 +1,135 @@
+{
+  "base": {
+    "problem name": "melt_pool",
+    "application name": "recoil_pressure",
+    "global refinements": "8",
+    "dimension": "2",
+    "degree": "1",
+    "gravity": "0.0",
+    "do print parameters": "true",
+    "verbosity level": "3"
+  },
+  "time stepping": {
+    "start time": "0.0",
+    "end time": "0.0001",
+    "time step size": "1.e-7"
+  },
+  "flow": {
+    "flow surface tension coefficient": "1.8",
+    "flow variable properties over interface": "true"
+  },
+  "material": {
+    "material first capacity": "965",
+    "material first conductivity": "35.95",
+    "material first density": "74.30",
+    "material first viscosity": "0.0006",
+    "material second capacity": "965",
+    "material second conductivity": "35.95",
+    "material second density": "7430",
+    "material second viscosity": "0.006",
+    "material solid conductivity": "35.95",
+    "material solid capacity": "965",
+    "material solid density": "7430.0",
+    "material solid viscosity": "1.0",
+    "material solidus temperature": "1400.0",
+    "material liquidus temperature": "1700.0"
+  },
+  "recoil pressure": {
+    "recoil pressure constant": "10000.",
+    "recoil temperature constant": "10000."
+  },
+  "laser": {
+    "laser power": "113.",
+    "laser center": "0.0,0.00004",
+    "laser scan speed": "0.003",
+    "laser do move": "false",
+    "laser heat source model": "Gauss",
+    "laser impact type": "interface",
+    "laser gauss laser beam radius": "30.e-6",
+    "laser gauss absorptivity": "0.5"
+  },
+  "melt pool": {
+    "mp do melt pool": "true",
+    "mp do heat transfer": "true",
+    "mp boiling temperature": "3500.",
+    "mp do recoil pressure": "true",
+    "mp set level set to zero in solid": "false",
+    "mp set velocity to zero in solid": "true"
+  },
+  "simulation specific domain": {
+    "domain x min": "-0.0002",
+    "domain x max": "0.0002",
+    "domain y min": "-0.0001",
+    "domain y max": "0.0002"
+  },
+  "levelset": {
+    "ls do reinitialization": "true",
+    "ls artificial diffusivity": "0.0",
+    "ls time integration scheme": "crank_nicolson",
+    "ls do matrix free": "true"
+  },
+  "reinitialization": {
+    "reinit max n steps": "5",
+    "reinit modeltype": "olsson2007",
+    "reinit do matrix free": "true",
+    "reinit constant epsilon": "1e-6",
+    "reinit preconditioner type": "AMG"
+  },
+  "normal vector": {
+    "normal vec damping scale factor": "0.5",
+    "normal vec do matrix free": "true"
+  },
+  "curvature": {
+    "curv do matrix free": "true",
+    "curv damping scale factor": "4",
+    "curv implementation": "adaflo"
+  },
+  "heat": {
+    "heat solidification": "true",
+    "heat solver rel tolerance": "1e-12",
+    "heat solver preconditioner type": "ILU",
+    "heat nlsolve residual tolerance": "1e-7",
+    "heat nlsolve field correction tolerance": "1e-7"
+  },
+  "paraview": {
+    "paraview do output": "true",
+    "paraview write frequency": "1",
+    "paraview directory": "output_recoil_pressure_fixed_solid_domain_eps1e-6_refine8_variable_props",
+    "paraview filename": "solution_recoil_pressure_temperature_dependent"
+  },
+  "adaptive meshing": {
+    "do amr": "false",
+    "upper perc to refine": "     0.1",
+    "lower perc to coarsen": "0.1",
+    "max grid refinement level": "9",
+    "n initial refinement cycles": "2"
+  },
+  "Navier-Stokes": {
+    "adaflo": {
+      "Navier-Stokes": {
+        "physical type": "incompressible",
+        "dimension": "2",
+        "global refinements": "0",
+        "velocity degree": "2",
+        "Solver": {
+          "linearization scheme": "coupled implicit Newton",
+          "NL max iterations": "10",
+          "NL tolerance": "1.e-9",
+          "lin max iterations": "30",
+          "lin tolerance": "1.e-4",
+          "lin relative tolerance": "1",
+          "lin velocity preconditioner": "ilu scalar",
+          "lin pressure mass preconditioner": "ilu",
+          "lin its before inner solvers": "50"
+        }
+      },
+      "Time stepping": {
+        "scheme": "bdf_2"
+      },
+      "Output options": {
+        "output verbosity": "2",
+        "output walltimes": "0"
+      }
+    }
+  }
+}

--- a/source/melt_pool/melt_pool_operation.cpp
+++ b/source/melt_pool/melt_pool_operation.cpp
@@ -15,6 +15,7 @@ namespace MeltPoolDG::MeltPool
     VectorType *                             temperature,
     const unsigned int                       reinit_dof_idx_in,
     const unsigned int                       flow_vel_dof_idx_in,
+    const unsigned int                       flow_vel_no_solid_dof_idx_in,
     const unsigned int                       flow_vel_quad_idx_in,
     const unsigned int                       temp_dof_idx_in,
     const double                             start_time_in)
@@ -24,6 +25,7 @@ namespace MeltPoolDG::MeltPool
     , ls_dof_idx(ls_dof_idx_in)
     , reinit_dof_idx(reinit_dof_idx_in)
     , flow_vel_dof_idx(flow_vel_dof_idx_in)
+    , flow_vel_no_solid_dof_idx(flow_vel_no_solid_dof_idx_in)
     , flow_vel_quad_idx(flow_vel_quad_idx_in)
     , temp_dof_idx(temp_dof_idx_in)
     , temperature(temperature)
@@ -109,6 +111,9 @@ namespace MeltPoolDG::MeltPool
      *  Constraint the solid domain if requested
      */
     make_constraints_in_spatially_fixed_solid_domain();
+    /*
+     * distribute the constraints for the level set in the solid region
+     */
     scratch_data->get_constraint(ls_dof_idx).distribute(level_set);
   }
 
@@ -174,8 +179,14 @@ namespace MeltPoolDG::MeltPool
         // 1) update phases
         compute_solid_and_liquid_phases(level_set_as_heaviside);
 
+
         // 2) update the constraints such that the solid domain is spatially fixed
         make_constraints_in_spatially_fixed_solid_domain();
+        /*
+         * distribute the constraints for the level set in the solid region
+         */
+        //@todo:
+        // scratch_data->get_constraint(ls_dof_idx).distribute(level_set);
       }
   }
 
@@ -269,6 +280,8 @@ namespace MeltPoolDG::MeltPool
 
     if (mp_data.set_velocity_to_zero_in_solid)
       set_flow_field_in_solid_regions_to_zero(scratch_data->get_dof_handler(flow_vel_dof_idx),
+                                              scratch_data->get_constraint(
+                                                flow_vel_no_solid_dof_idx),
                                               scratch_data->get_constraint(flow_vel_dof_idx));
   }
 
@@ -316,10 +329,13 @@ namespace MeltPoolDG::MeltPool
   template <int dim>
   void
   MeltPoolOperation<dim>::set_flow_field_in_solid_regions_to_zero(
-    const DoFHandler<dim> &    flow_dof_handler,
-    AffineConstraints<double> &flow_constraints)
+    const DoFHandler<dim> &          flow_dof_handler,
+    const AffineConstraints<double> &flow_constraints_no_solid,
+    AffineConstraints<double> &      flow_constraints)
   {
     solid.update_ghost_values();
+
+    flow_constraints.copy_from(flow_constraints_no_solid);
 
     IndexSet flow_locally_relevant_dofs;
     DoFTools::extract_locally_relevant_dofs(flow_dof_handler, flow_locally_relevant_dofs);
@@ -420,6 +436,8 @@ namespace MeltPoolDG::MeltPool
     level_set_constraints.close();
 
     UtilityFunctions::check_constraints(level_set_dof_handler, level_set_constraints);
+
+
 
     solid.zero_out_ghost_values();
   }

--- a/source/melt_pool/melt_pool_operation.cpp
+++ b/source/melt_pool/melt_pool_operation.cpp
@@ -437,8 +437,6 @@ namespace MeltPoolDG::MeltPool
 
     UtilityFunctions::check_constraints(level_set_dof_handler, level_set_constraints);
 
-
-
     solid.zero_out_ghost_values();
   }
 

--- a/source/melt_pool/melt_pool_problem.cpp
+++ b/source/melt_pool/melt_pool_problem.cpp
@@ -25,7 +25,9 @@ namespace MeltPoolDG::Flow
         //
         // @todo: alternative (better performing) solution?
         if (base_in->parameters.mp.set_velocity_to_zero_in_solid)
-          scratch_data->build();
+          {
+            scratch_data->build();
+          }
 
         const auto dt = time_iterator.get_next_time_increment();
         const auto n  = time_iterator.get_current_time_step_number();
@@ -246,6 +248,9 @@ namespace MeltPoolDG::Flow
 
 #ifdef MELT_POOL_DG_WITH_ADAFLO
     flow_operation = std::make_shared<AdafloWrapper<dim>>(*scratch_data, base_in);
+    flow_vel_no_solid_dof_idx =
+      scratch_data->attach_constraint_matrix(flow_velocity_constraints_no_solid);
+    scratch_data->attach_dof_handler(flow_operation->get_dof_handler_velocity());
 #else
     AssertThrow(false, ExcNotImplemented());
 #endif
@@ -332,6 +337,7 @@ namespace MeltPoolDG::Flow
         &heat_operation->get_temperature(),
         reinit_dof_idx,
         flow_operation->get_dof_handler_idx_velocity(),
+        flow_vel_no_solid_dof_idx,
         flow_operation->get_quad_idx_velocity(),
         temp_dof_idx,
         base_in->parameters.time_stepping.start_time);
@@ -448,6 +454,7 @@ namespace MeltPoolDG::Flow
        */
 #ifdef MELT_POOL_DG_WITH_ADAFLO
     dynamic_cast<AdafloWrapper<dim> *>(flow_operation.get())->reinit_1();
+    flow_velocity_constraints_no_solid.copy_from(flow_operation->get_constraints_velocity());
 #else
     AssertThrow(false, ExcNotImplemented());
 #endif

--- a/source/melt_pool/melt_pool_problem.cpp
+++ b/source/melt_pool/melt_pool_problem.cpp
@@ -25,9 +25,7 @@ namespace MeltPoolDG::Flow
         //
         // @todo: alternative (better performing) solution?
         if (base_in->parameters.mp.set_velocity_to_zero_in_solid)
-          {
-            scratch_data->build();
-          }
+          scratch_data->build();
 
         const auto dt = time_iterator.get_next_time_increment();
         const auto n  = time_iterator.get_current_time_step_number();


### PR DESCRIPTION
This PR enables 

- `heat_transfer` BC in the recoil pressure example.
- the time-dependent update of zero velocity constraints in the solid phase. This can be enabled by setting 
```json
    "mp set velocity to zero in solid": "true"
```
in the parameter file. The results looks now as follows for the coupled thermo-two-phase-flow melt pool problem (blue line marks the liquid domain):

@nmuch FYI

![image](https://user-images.githubusercontent.com/70260016/122381456-3dc88800-cf69-11eb-9322-bde7d5f0fe87.png)
