### PR TITLE
fix: missing else branch in evaporative cooling if activation temperature was set

### DIFF
--- a/applications/mp-heat-transfer/cases/fixed_melt_pool_geometry/tests/fixed_melt_pool_diffuse_CE.mpirun=4.output
+++ b/applications/mp-heat-transfer/cases/fixed_melt_pool_geometry/tests/fixed_melt_pool_diffuse_CE.mpirun=4.output
@@ -5,31 +5,31 @@
 +--------------------------------------------------------------------------------------------------+
 | current laser position: 0 0                                                                laser |
 | current laser intensity: 1                                                                 laser |
-| Newton Raphson solver converged: ||solution|| = 1.12263e-01                newton_raphson_solver |
+| Newton Raphson solver converged: ||solution|| = 1.12448e-01                newton_raphson_solver |
 +--------------------------------------------------------------------------------------------------+
 |  Time increment # 2      t = 2.0000e-06 to 4.0000e-06 ( dt = 2.0000e-06 )          time_iterator |
 +--------------------------------------------------------------------------------------------------+
 | current laser position: 0 0                                                                laser |
 | current laser intensity: 1                                                                 laser |
-| Newton Raphson solver converged: ||solution|| = 1.28176e-01                newton_raphson_solver |
+| Newton Raphson solver converged: ||solution|| = 1.28690e-01                newton_raphson_solver |
 +--------------------------------------------------------------------------------------------------+
 |  Time increment # 3      t = 4.0000e-06 to 6.0000e-06 ( dt = 2.0000e-06 )          time_iterator |
 +--------------------------------------------------------------------------------------------------+
 | current laser position: 0 0                                                                laser |
 | current laser intensity: 1                                                                 laser |
-| Newton Raphson solver converged: ||solution|| = 1.44676e-01                newton_raphson_solver |
+| Newton Raphson solver converged: ||solution|| = 1.45608e-01                newton_raphson_solver |
 +--------------------------------------------------------------------------------------------------+
 |  Time increment # 4      t = 6.0000e-06 to 8.0000e-06 ( dt = 2.0000e-06 )          time_iterator |
 +--------------------------------------------------------------------------------------------------+
 | current laser position: 0 0                                                                laser |
 | current laser intensity: 1                                                                 laser |
-| Newton Raphson solver converged: ||solution|| = 1.60415e-01                newton_raphson_solver |
+| Newton Raphson solver converged: ||solution|| = 1.61815e-01                newton_raphson_solver |
 +--------------------------------------------------------------------------------------------------+
 |  Time increment # 5      t = 8.0000e-06 to 1.0000e-05 ( dt = 2.0000e-06 )          time_iterator |
 +--------------------------------------------------------------------------------------------------+
 | current laser position: 0 0                                                                laser |
 | current laser intensity: 1                                                                 laser |
-| Newton Raphson solver converged: ||solution|| = 1.74997e-01                newton_raphson_solver |
+| Newton Raphson solver converged: ||solution|| = 1.76890e-01                newton_raphson_solver |
 +--------------------------------------------------------------------------------------------------+
 |  end of simulation                                                                               |
 +--------------------------------------------------------------------------------------------------+

--- a/applications/mp-heat-transfer/cases/fixed_melt_pool_geometry/tests/fixed_melt_pool_one_phase_cut.mpirun=4.output
+++ b/applications/mp-heat-transfer/cases/fixed_melt_pool_geometry/tests/fixed_melt_pool_one_phase_cut.mpirun=4.output
@@ -5,31 +5,31 @@
 +--------------------------------------------------------------------------------------------------+
 | current laser position: 0 0                                                                laser |
 | current laser intensity: 1                                                                 laser |
-| Newton Raphson solver converged: ||solution|| = 7.02610e-02                newton_raphson_solver |
+| Newton Raphson solver converged: ||solution|| = 7.03641e-02                newton_raphson_solver |
 +--------------------------------------------------------------------------------------------------+
 |  Time increment # 2      t = 2.0000e-06 to 4.0000e-06 ( dt = 2.0000e-06 )          time_iterator |
 +--------------------------------------------------------------------------------------------------+
 | current laser position: 0 0                                                                laser |
 | current laser intensity: 1                                                                 laser |
-| Newton Raphson solver converged: ||solution|| = 7.56561e-02                newton_raphson_solver |
+| Newton Raphson solver converged: ||solution|| = 7.59326e-02                newton_raphson_solver |
 +--------------------------------------------------------------------------------------------------+
 |  Time increment # 3      t = 4.0000e-06 to 6.0000e-06 ( dt = 2.0000e-06 )          time_iterator |
 +--------------------------------------------------------------------------------------------------+
 | current laser position: 0 0                                                                laser |
 | current laser intensity: 1                                                                 laser |
-| Newton Raphson solver converged: ||solution|| = 8.13771e-02                newton_raphson_solver |
+| Newton Raphson solver converged: ||solution|| = 8.18552e-02                newton_raphson_solver |
 +--------------------------------------------------------------------------------------------------+
 |  Time increment # 4      t = 6.0000e-06 to 8.0000e-06 ( dt = 2.0000e-06 )          time_iterator |
 +--------------------------------------------------------------------------------------------------+
 | current laser position: 0 0                                                                laser |
 | current laser intensity: 1                                                                 laser |
-| Newton Raphson solver converged: ||solution|| = 8.70383e-02                newton_raphson_solver |
+| Newton Raphson solver converged: ||solution|| = 8.76791e-02                newton_raphson_solver |
 +--------------------------------------------------------------------------------------------------+
 |  Time increment # 5      t = 8.0000e-06 to 1.0000e-05 ( dt = 2.0000e-06 )          time_iterator |
 +--------------------------------------------------------------------------------------------------+
 | current laser position: 0 0                                                                laser |
 | current laser intensity: 1                                                                 laser |
-| Newton Raphson solver converged: ||solution|| = 9.24963e-02                newton_raphson_solver |
+| Newton Raphson solver converged: ||solution|| = 9.32352e-02                newton_raphson_solver |
 +--------------------------------------------------------------------------------------------------+
 |  end of simulation                                                                               |
 +--------------------------------------------------------------------------------------------------+

--- a/include/meltpooldg/phase_change/evaporative_cooling.templates.hpp
+++ b/include/meltpooldg/phase_change/evaporative_cooling.templates.hpp
@@ -72,6 +72,10 @@ namespace MeltPoolDG::Evaporation
                 compute_evaporative_cooling_derivative_with_temperature_dependent_mass_flux(
                   material_data.boiling_temperature);
           }
+        else
+          {
+            activation_temperature = evapor_data.evaporative_cooling.activation_temperature;
+          }
 
         if (ramp_enabled)
           {

--- a/unit_tests/phase_change/evaporative_cooling_01.cc
+++ b/unit_tests/phase_change/evaporative_cooling_01.cc
@@ -41,7 +41,7 @@ main()
 
     std::cout << "With activation ramp" << std::endl;
 
-    for (const auto T : {T_ac - 10.0, T_ac, 0.5 * (T_ac + T_v), T_v, T_v + 10.0})
+    for (const auto T : {T_ac - 10.0, T_ac + 0.01, 0.5 * (T_ac + T_v), T_v, T_v + 10.0})
       std::cout << "T = " << T
                 << ", evaporative cooling = " << evaporative_cooling.compute_evaporative_cooling(T)
                 << ", derivative = "
@@ -57,7 +57,7 @@ main()
 
     std::cout << "\nWithout activation ramp" << std::endl;
 
-    for (const auto T : {T_ac - 10.0, T_ac, 0.5 * (T_ac + T_v), T_v, T_v + 10.0})
+    for (const auto T : {T_ac - 10.0, T_ac + 0.01, 0.5 * (T_ac + T_v), T_v, T_v + 10.0})
       std::cout << "T = " << T << ", evaporative cooling = "
                 << evaporative_cooling_no_ramp.compute_evaporative_cooling(T) << ", derivative = "
                 << evaporative_cooling_no_ramp

--- a/unit_tests/phase_change/evaporative_cooling_01.output
+++ b/unit_tests/phase_change/evaporative_cooling_01.output
@@ -1,13 +1,13 @@
 With activation ramp
-T = 1890, evaporative cooling = -2.36317e+08, derivative = -125035
-T = 1900, evaporative cooling = -2.37567e+08, derivative = -125035
-T = 2516.5, evaporative cooling = -3.14651e+08, derivative = -125035
+T = 1890, evaporative cooling = 0, derivative = 0
+T = 1900.01, evaporative cooling = -3177.09, derivative = -317709
+T = 2516.5, evaporative cooling = -1.95868e+08, derivative = -317709
 T = 3133, evaporative cooling = -3.91735e+08, derivative = -222.366
 T = 3143, evaporative cooling = -4.11827e+08, derivative = -232.262
 
 Without activation ramp
-T = 1890, evaporative cooling = -11737.1, derivative = -0.0185387
-T = 1900, evaporative cooling = -13485.9, derivative = -0.0210751
+T = 1890, evaporative cooling = 0, derivative = 0
+T = 1900.01, evaporative cooling = -13487.7, derivative = -0.0210778
 T = 2516.5, evaporative cooling = -8.21699e+06, derivative = -7.27486
 T = 3133, evaporative cooling = -3.91735e+08, derivative = -222.366
 T = 3143, evaporative cooling = -4.11827e+08, derivative = -232.262


### PR DESCRIPTION
<!-- Please, fill in the description as completely as possible.-->

<!-- Use Conventional Commits format for the commit message:
     <type>(optional scope): <description>

     Available types:
     - feat: introduces a new feature
     - fix: fixes a bug
     - refactor: code change without changing behavior
     - test: adds or updates tests
     - docs: documentation-only changes
     - style: formatting-only changes
     - perf: performance improvements
     - chore: maintenance work
     - bench: adds or updates benchmarks

     Example:
     feat(heat): add apparent capacity method
     - add apparent capacity formulation for latent heat treatment
     - add support for constant, poly4_bell, and qlq apparent-capacity models
     - add temperature derivatives for Newton linearization
-->

# Description
<!-- Please include a summary of the changes and the related issue.
     Please also include relevant motivation and context.
     List any dependencies that are required for this change. -->

This PR sets the class member `activation_temperature` within EvaporativeCooling if it is explicitly set in the input file. In addition, the evaporative_cooling_01 test was made more robust.

# How has this been tested?
<!-- Are there changes on current tests? If yes, why?
     Do you introduce new test? Which features do you intend to test?
     How did you ensure that the solution works? -->

# Screenshots (if appropriate)
<!-- Do you have any visual results from simulations that relate to this PR? -->

# Checklist (should be removed by the person who merges this PR)

- [x] The branch is rebased onto master
- [x] Code is formatted with format-all
- [x] Prefer a single commit with a meaningful commit message; if multiple commits are necessary, explain why in the PR description
- [ ] Labels are applied
- [x] Co-Pilot review is requested
- [x] Reviews are requested
- [ ] If this PR closes an issue or is related to a project, it is linked in the "Description" section
- [ ] All in-code documentation related to this PR is up to date (Doxygen format)
- [x] Commit has unit test(s) (preferred) or application test(s)
- [ ] If the fix is temporary, an issue is opened where this PR is referenced
- [ ] A changelog entry is added for any notable change
