### PR TITLE
chore(workflows): Add missing install of libmetis to nightly install …

### DIFF
--- a/.github/workflows/nightly_install.yml
+++ b/.github/workflows/nightly_install.yml
@@ -1,6 +1,7 @@
 name: Install MeltPoolDG
 
 on:
+  workflow_dispatch:
   schedule:
   - cron:  '0 0 * * 6' # run every Saturday at 00:00 UTC
 
@@ -16,6 +17,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libmetis-dev
       - name: Compile MeltPoolDG
         run: |
           bash scripts/config/install.sh --nv

--- a/scripts/config/check.sh
+++ b/scripts/config/check.sh
@@ -30,7 +30,7 @@ check_metis() {
   if [[ $(ldconfig -p | grep libmetis) ]]; then
       log "Dependency libmetis found."
   else
-      log "WARNING: Dependency libmetis not found. Make sure to install metis if you want to use the functionalities."
+      log "ERROR: Dependency libmetis not found. Make sure to install metis if you want to use the functionalities."
       exit 1
   fi
 }


### PR DESCRIPTION
<!-- Please, fill in the description as completely as possible.-->

<!-- Use Conventional Commits format for the commit message:
     <type>(optional scope): <description>

     Available types:
     - feat: introduces a new feature
     - fix: fixes a bug
     - refactor: code change without changing behavior
     - test: adds or updates tests
     - docs: documentation-only changes
     - style: formatting-only changes
     - perf: performance improvements
     - chore: maintenance work
     - bench: adds or updates benchmarks

     Example:
     feat(heat): add apparent capacity method
     - add apparent capacity formulation for latent heat treatment
     - add support for constant, poly4_bell, and qlq apparent-capacity models
     - add temperature derivatives for Newton linearization
-->

# Description
Should fix the nightly install workflow.

# How has this been tested?
<!-- Are there changes on current tests? If yes, why?
     Do you introduce new test? Which features do you intend to test?
     How did you ensure that the solution works? -->

# Screenshots (if appropriate)
<!-- Do you have any visual results from simulations that relate to this PR? -->

# Checklist (should be removed by the person who merges this PR)

- [x] The branch is rebased onto master
- [x] Code is formatted with format-all
- [x] Prefer a single commit with a meaningful commit message; if multiple commits are necessary, explain why in the PR description
- [x] Labels are applied
- [ ] Co-Pilot review is requested
- [x] Reviews are requested
- [ ] If this PR closes an issue or is related to a project, it is linked in the "Description" section
- [ ] All in-code documentation related to this PR is up to date (Doxygen format)
- [ ] Commit has unit test(s) (preferred) or application test(s)
- [ ] If the fix is temporary, an issue is opened where this PR is referenced
- [ ] A changelog entry is added for any notable change
