### PR TITLE
fix(reinit): elliptic fully supports time iteration

### DIFF
--- a/applications/mp-reinit/cases/reinit_circle/tests/reinit_circle_elliptic_signed_distance.json
+++ b/applications/mp-reinit/cases/reinit_circle/tests/reinit_circle_elliptic_signed_distance.json
@@ -8,7 +8,7 @@
     "fe": {
       "degree": 1
     },
-    "verbosity level": 2
+    "verbosity level": 1
   },
   "case specific": {
     "center point": "0., 0.",
@@ -36,7 +36,7 @@
     "elliptic": {
       "penalty parameter": 1000.0,
       "fixed point iteration": {
-        "max n steps": 10,
+        "max n steps": 3,
         "tolerance": 1e-05
       }
     }
@@ -44,7 +44,7 @@
   "time stepping": {
     "start time": 0.0,
     "time step size": 1.0,
-    "end time": 1000.0,
+    "end time": 5.0,
     "max n steps": 5,
     "time step size function": "0.0*t"
   }

--- a/applications/mp-reinit/cases/reinit_circle/tests/reinit_circle_elliptic_signed_distance.mpirun=4.output
+++ b/applications/mp-reinit/cases/reinit_circle/tests/reinit_circle_elliptic_signed_distance.mpirun=4.output
@@ -1,33 +1,28 @@
 +--------------------------------------------------------------------------------------------------+
-|  Time increment # 0      t = 0.0000e+00 to 0.0000e+00 ( dt = 1.0000e+00 )          time_iterator |
-+--------------------------------------------------------------------------------------------------+
-| || ψ^(n+1) ||L2  = 7.47275218e-01                                               reinitialization |
-| || |Δψ|/|ψ^n| ||L2  = 2.00020530e-01                                           reinitialization |
-| LinearSolver completed in 9 iterations.                                         reinitialization |
-+--------------------------------------------------------------------------------------------------+
 |  Time increment # 1      t = 0.0000e+00 to 1.0000e+00 ( dt = 1.0000e+00 )          time_iterator |
 +--------------------------------------------------------------------------------------------------+
-| || ψ^(n+1) ||L2  = 7.77172983e-01                                               reinitialization |
-| || |Δψ|/|ψ^n| ||L2  = 4.00090852e-02                                           reinitialization |
-| LinearSolver completed in 9 iterations.                                         reinitialization |
+| || |Δψ|/|ψ^n| ||L2  = 1.60331026e-03                                           reinitialization |
+| Reinitialization completed in 3 iterations.                                     reinitialization |
 +--------------------------------------------------------------------------------------------------+
 |  Time increment # 2      t = 1.0000e+00 to 2.0000e+00 ( dt = 1.0000e+00 )          time_iterator |
 +--------------------------------------------------------------------------------------------------+
-| || ψ^(n+1) ||L2  = 7.78419018e-01                                               reinitialization |
-| || |Δψ|/|ψ^n| ||L2  = 1.60331019e-03                                           reinitialization |
-| LinearSolver completed in 9 iterations.                                         reinitialization |
+| || |Δψ|/|ψ^n| ||L2  = 8.92537506e-06                                           reinitialization |
+| Reinitialization completed in 2 iterations.                                     reinitialization |
 +--------------------------------------------------------------------------------------------------+
 |  Time increment # 3      t = 2.0000e+00 to 3.0000e+00 ( dt = 1.0000e+00 )          time_iterator |
 +--------------------------------------------------------------------------------------------------+
-| || ψ^(n+1) ||L2  = 7.78423369e-01                                               reinitialization |
-| || |Δψ|/|ψ^n| ||L2  = 1.04495818e-05                                           reinitialization |
-| LinearSolver completed in 8 iterations.                                         reinitialization |
+| || |Δψ|/|ψ^n| ||L2  = 9.04428627e-06                                           reinitialization |
+| Reinitialization completed in 1 iterations.                                     reinitialization |
 +--------------------------------------------------------------------------------------------------+
 |  Time increment # 4      t = 3.0000e+00 to 4.0000e+00 ( dt = 1.0000e+00 )          time_iterator |
 +--------------------------------------------------------------------------------------------------+
-| || ψ^(n+1) ||L2  = 7.78424084e-01                                               reinitialization |
-| || |Δψ|/|ψ^n| ||L2  = 8.91918454e-06                                           reinitialization |
-| LinearSolver completed in 8 iterations.                                         reinitialization |
+| || |Δψ|/|ψ^n| ||L2  = 9.19160441e-06                                           reinitialization |
+| Reinitialization completed in 1 iterations.                                     reinitialization |
++--------------------------------------------------------------------------------------------------+
+|  Time increment # 5      t = 4.0000e+00 to 5.0000e+00 ( dt = 1.0000e+00 )          time_iterator |
++--------------------------------------------------------------------------------------------------+
+| || |Δψ|/|ψ^n| ||L2  = 9.34434374e-06                                           reinitialization |
+| Reinitialization completed in 1 iterations.                                     reinitialization |
 +--------------------------------------------------------------------------------------------------+
 |  end of simulation                                                                               |
 +--------------------------------------------------------------------------------------------------+

--- a/applications/mp-reinit/reinitialization_application.cpp
+++ b/applications/mp-reinit/reinitialization_application.cpp
@@ -111,16 +111,12 @@ namespace MeltPoolDG::LevelSet
       {
         auto *elliptic_reinit =
           dynamic_cast<ReinitializationEllipticOperation<dim, number> *>(reinit_operation.get());
-        time_iterator->reset_max_n_time_steps(
-          param.reinit.elliptic.fix_point_iteration.max_n_steps);
 
-        while (elliptic_reinit->get_relative_change_level_set() >
-                 param.reinit.elliptic.fix_point_iteration.tolerance and
-               !time_iterator->is_finished())
+        while (!time_iterator->is_finished())
           {
-            time_iterator->print_me(scratch_data->get_pcout(1));
-            elliptic_reinit->solve_one_iter();
             time_iterator->compute_next_time_increment();
+            time_iterator->print_me(scratch_data->get_pcout(1));
+            elliptic_reinit->solve();
 
             output_results(time_iterator->get_current_time_step_number(),
                            time_iterator->get_current_time());

--- a/source/level_set/reinitialization_elliptic_operation.cpp
+++ b/source/level_set/reinitialization_elliptic_operation.cpp
@@ -36,6 +36,11 @@ namespace MeltPoolDG::LevelSet
     const unsigned int max_iterations = reinit_data.elliptic.fix_point_iteration.max_n_steps;
     number             tolerance      = reinit_data.elliptic.fix_point_iteration.tolerance;
     unsigned int       iter           = 0;
+    relative_change_level_set         = std::numeric_limits<number>::max();
+
+    // necessary here for mp-reinit
+    mesh_classifier->reclassify();
+    compute_intersected_quadrature();
 
     while (iter < max_iterations && relative_change_level_set > tolerance)
       {
@@ -157,8 +162,6 @@ namespace MeltPoolDG::LevelSet
 
     reinit_operator->reinit();
     preconditioner.reinit();
-
-    relative_change_level_set = std::numeric_limits<number>::max();
   }
 
   template <int dim, typename number>


### PR DESCRIPTION
The conflict between fixed point and time iterations for the elliptic reinit in mp-reinit is resolved. 
It is now possible to define both: fixed point iterations refine solution within one time step, and time steps call a mesh classifier update. 
This procedure corresponds to a static simulation with physical time steps.

The test files are updated accordingly. 