### PR TITLE
refactor: separate darcy damping model and operation

### DIFF
--- a/include/meltpooldg/compressible_flow/multiphase_operator.hpp
+++ b/include/meltpooldg/compressible_flow/multiphase_operator.hpp
@@ -7,6 +7,7 @@
 #include <meltpooldg/compressible_flow/kernels.hpp>
 #include <meltpooldg/compressible_flow/multiphase_level_set_advection.hpp>
 #include <meltpooldg/cut/util.hpp>
+#include <meltpooldg/flow/darcy_damping_model.hpp>
 #include <meltpooldg/phase_change/evaporation_model_knight.hpp>
 #include <meltpooldg/utilities/dg_generic_convection_diffusion_worker.hpp>
 #include <meltpooldg/utilities/vector_tools.hpp>
@@ -238,6 +239,9 @@ namespace MeltPoolDG::Multiphase
 
     /// Pointer to the object for the evaluation of the Knight evaporation model
     std::unique_ptr<Evaporation::EvaporationModelKnight<number>> evaporation_model_knight;
+
+    /// Darcy damping model for the computation of the damping coefficient
+    Flow::DarcyDampingModel<number> darcy_damping_model;
 
     /**
      * @brief Wrapper for the generation of a FECellIntegrator object.

--- a/include/meltpooldg/flow/darcy_damping_model.hpp
+++ b/include/meltpooldg/flow/darcy_damping_model.hpp
@@ -1,0 +1,57 @@
+#pragma once
+
+#include <deal.II/base/vectorization.h>
+
+#include <meltpooldg/flow/darcy_damping_data.hpp>
+
+
+namespace MeltPoolDG::Flow
+{
+  /**
+   * @brief This class computes the Darcy damping coefficient \f$ K \f$ given by the Kozeny-Carman equation:
+   *
+   * \f$ K= -C \frac{f_s^2}{(1-f_s)^3 + b} \f$
+   *
+   * with the solid fraction \f$ f_s \in [0, 1] \f$, the morphology of the mushy zone \f$ C \f$ and
+   * the parameter \f$ b \f$ to avoid division by zero.
+   *
+   * @note The regularization constant \f$ b \f$ must be greater than zero.
+   *
+   * Voller, V. R., & Prakash, C. (1987). A fixed grid numerical modelling methodology for
+   * convection-diffusion mushy region phase-change problems. International Journal of Heat and Mass
+   * Transfer, 30(8), 1709–1719. https://doi.org/10.1016/0017-9310(87)90317-6
+   *
+   * @tparam number Floating-point type
+   */
+  template <typename number>
+  class DarcyDampingModel
+  {
+  public:
+    /**
+     * @brief Constructor.
+     *
+     * @param data_in Input parameters related to darcy damping.
+     */
+    explicit DarcyDampingModel(const DarcyDampingData<number> &data_in);
+
+    /**
+     * @brief Compute the Darcy damping coefficient based on a given @p solid_fraction.
+     *
+     * @tparam number2 Enables both scalar and vectorized computations.
+     *
+     * @param solid_fraction Volume fraction of solid phase between 0 and 1.
+     *
+     * @return Darcy damping coefficient.
+     */
+    template <typename number2>
+    [[nodiscard]] number2
+    compute_darcy_damping_coefficient(const number2 &solid_fraction) const;
+
+  private:
+    /// Morphological constant C.
+    const number mushy_zone_morphology;
+
+    /// Small constant b to avoid division by zero.
+    const number avoid_div_zero_constant;
+  };
+} // namespace MeltPoolDG::Flow

--- a/include/meltpooldg/flow/darcy_damping_operation.hpp
+++ b/include/meltpooldg/flow/darcy_damping_operation.hpp
@@ -10,29 +10,23 @@
 #include <meltpooldg/core/material.hpp>
 #include <meltpooldg/core/scratch_data.hpp>
 #include <meltpooldg/flow/darcy_damping_data.hpp>
+#include <meltpooldg/flow/darcy_damping_model.hpp>
 #include <meltpooldg/post_processing/generic_data_out.hpp>
 
 
 namespace MeltPoolDG::Flow
 {
   /**
-   * @brief This class computes the Darcy damping force (or Darcy source term).
+   * @brief This class computes the Darcy damping force (or Darcy source term)
    *
-   *         /              \
-   *  f_d =  | N_a, K N_b u |
-   *         \              /
-   *                         Ω
+   * \f$ f_d = \left( N_a, K N_b u \right)_\Omega \f$
    *
-   * with the isotropic permeability of the mushy zone K given by the Kozeny-Carman equation:
+   * with the isotropic permeability of the mushy zone \f$ K \f$ given by the Kozeny-Carman equation
    *
-   *                 fs²
-   *  K = - C ----------------
-   *           ( 1- fs )³ + b
+   * \f$ K= -C \frac{f_s^2}{(1-f_s)^3 + b} \f$
    *
-   * with the solid fraction fs \in [0, 1], the morphology of the mushy zone C and the parameter b
-   * to avoid division by zero.
-   *
-   * @note The regularization constant b must be greater than zero.
+   * with the solid fraction \f$ f_s \in [0, 1] \f$, the morphology of the mushy zone \f$ C \f$ and
+   * the parameter \f$ b \f$ to avoid division by zero.
    *
    * Voller, V. R., & Prakash, C. (1987). A fixed grid numerical modelling methodology for
    * convection-diffusion mushy region phase-change problems. International Journal of Heat and Mass
@@ -157,12 +151,6 @@ namespace MeltPoolDG::Flow
     get_damping(const unsigned int cell, const unsigned int q) const;
 
   private:
-    /// Morphological constant C.
-    const number mushy_zone_morphology;
-
-    /// Small constant b to avoid division by zero.
-    const number avoid_div_zero_constant;
-
     /// Reference to scratch data used for assembling.
     const ScratchData<dim, dim, number> &scratch_data;
 
@@ -181,15 +169,8 @@ namespace MeltPoolDG::Flow
     /// Element-wise output vector of damping coefficient.
     mutable dealii::Vector<number> damping_output;
 
-    /**
-     * @brief Compute the Darcy damping coefficient based on a given @p solid_fraction.
-     *
-     * @param solid_fraction Volume fraction of solid phase between 0 and 1.
-     *
-     * @return Darcy damping coefficient.
-     */
-    dealii::VectorizedArray<number>
-    compute_darcy_damping_coefficient(const dealii::VectorizedArray<number> &solid_fraction) const;
+    /// Darcy damping model for the computation of the damping coefficient
+    DarcyDampingModel<number> darcy_damping_model;
 
     /**
      * @brief Getter function for the vector of damping coefficients, holding the values at each cell and

--- a/source/compressible_flow/multiphase_operator.cpp
+++ b/source/compressible_flow/multiphase_operator.cpp
@@ -34,6 +34,7 @@ namespace MeltPoolDG::Multiphase
     , fe_point_temp(FE_DGQ<dim>(multiphase_scratch_data.flow_data.fe.degree),
                     CompressibleFlow::n_conserved_variables<dim>)
     , n_dofs_per_cell(fe_point_temp.dofs_per_cell)
+    , darcy_damping_model(multiphase_scratch_data.darcy_damping)
   {
     const auto &l     = multiphase_scratch_data.material_liquid.data;
     const auto &g     = multiphase_scratch_data.material_gas.data;
@@ -179,22 +180,17 @@ namespace MeltPoolDG::Multiphase
               const VectorizedArray<number> T_solidus_vec(
                 multiphase_scratch_data.phase_change.solid_liquid.solidus_temperature);
 
-              VectorizedArray<number> liquid_fraction =
-                (temperature - T_solidus_vec) / (T_liquidus_vec - T_solidus_vec);
+              VectorizedArray<number> solid_fraction =
+                (T_liquidus_vec - temperature) / (T_liquidus_vec - T_solidus_vec);
 
-              // liquid fraction is bounded [0;1]
-              liquid_fraction =
-                std::min(std::max(liquid_fraction,
+              // solid fraction is bounded [0;1]
+              solid_fraction =
+                std::min(std::max(solid_fraction,
                                   dealii::make_vectorized_array<VectorizedArray<number>>(0.)),
                          dealii::make_vectorized_array<VectorizedArray<number>>(1.));
 
-              const VectorizedArray<number> solid_fraction = 1. - liquid_fraction;
-
               const VectorizedArray<number> darcy_damping_coefficient =
-                -multiphase_scratch_data.darcy_damping.mushy_zone_morphology * solid_fraction *
-                solid_fraction /
-                (liquid_fraction * liquid_fraction * liquid_fraction +
-                 multiphase_scratch_data.darcy_damping.avoid_div_zero_constant);
+                darcy_damping_model.compute_darcy_damping_coefficient(solid_fraction);
 
               // contribution to momentum equation
               darcy_damping[1] = darcy_damping_coefficient * velocity[0];

--- a/source/flow/darcy_damping_model.cpp
+++ b/source/flow/darcy_damping_model.cpp
@@ -1,0 +1,42 @@
+#include <deal.II/base/exception_macros.h>
+#include <deal.II/base/exceptions.h>
+
+#include <meltpooldg/flow/darcy_damping_model.hpp>
+
+namespace MeltPoolDG::Flow
+{
+  template <typename number>
+  DarcyDampingModel<number>::DarcyDampingModel(const DarcyDampingData<number> &data_in)
+    : mushy_zone_morphology(data_in.mushy_zone_morphology)
+    , avoid_div_zero_constant(data_in.avoid_div_zero_constant)
+  {
+    AssertThrow(mushy_zone_morphology == 0. or avoid_div_zero_constant > 0.,
+                dealii::ExcMessage(
+                  "When computing the Darcy damping coefficient, the parameter \"mp solid "
+                  "darcy damping avoid div zero constant\" must be greater than zero! Abort.."));
+  }
+
+  template <typename number>
+  template <typename number2>
+  number2
+  DarcyDampingModel<number>::compute_darcy_damping_coefficient(const number2 &solid_fraction) const
+  {
+    // K = -C * fs² / ( (1-fs)³ + b )
+    // K := permeability = Darcy damping coefficient
+    // C := morphology
+    // b := avoid div zero constant
+    // fs := solid fraction
+    const auto liquid_fraction = 1.0 - solid_fraction;
+    return -mushy_zone_morphology * solid_fraction * solid_fraction /
+           (liquid_fraction * liquid_fraction * liquid_fraction + avoid_div_zero_constant);
+  }
+
+  template class DarcyDampingModel<double>;
+
+  template double
+  DarcyDampingModel<double>::compute_darcy_damping_coefficient<double>(const double &) const;
+
+  template dealii::VectorizedArray<double>
+  DarcyDampingModel<double>::compute_darcy_damping_coefficient<dealii::VectorizedArray<double>>(
+    const dealii::VectorizedArray<double> &) const;
+} // namespace MeltPoolDG::Flow

--- a/source/flow/darcy_damping_operation.cpp
+++ b/source/flow/darcy_damping_operation.cpp
@@ -23,17 +23,11 @@ namespace MeltPoolDG::Flow
     const ScratchData<dim, dim, number> &scratch_data,
     const unsigned int                   flow_vel_hanging_nodes_dof_idx,
     const unsigned int                   flow_quad_idx)
-    : mushy_zone_morphology(data_in.mushy_zone_morphology)
-    , avoid_div_zero_constant(data_in.avoid_div_zero_constant)
-    , scratch_data(scratch_data)
+    : scratch_data(scratch_data)
     , flow_vel_hanging_nodes_dof_idx(flow_vel_hanging_nodes_dof_idx)
     , flow_quad_idx(flow_quad_idx)
-  {
-    AssertThrow(mushy_zone_morphology == 0.0 or avoid_div_zero_constant > 0.0,
-                dealii::ExcMessage(
-                  "When using the Darcy damping force, the parameter \"mp solid "
-                  "darcy damping avoid div zero constant\" must be greater than zero! Abort.."));
-  }
+    , darcy_damping_model(data_in)
+  {}
 
   template <int dim, typename number>
   void
@@ -213,25 +207,13 @@ namespace MeltPoolDG::Flow
                           .solid_fraction;
                     }
                 }
-                get_damping(cell, q) = compute_darcy_damping_coefficient(solid_fraction);
+                get_damping(cell, q) =
+                  darcy_damping_model.compute_darcy_damping_coefficient(solid_fraction);
               }
           }
       },
       dummy,
       ls_as_heaviside);
-  }
-
-  template <int dim, typename number>
-  dealii::VectorizedArray<number>
-  DarcyDampingOperation<dim, number>::compute_darcy_damping_coefficient(
-    const dealii::VectorizedArray<number> &solid_fraction) const
-  {
-    // K = -C * fs² / ( (1-fs)³ + b )
-    // K := permeability,  C := morphology
-    // b := avoid div zero constant, fs := solid fraction
-    const auto non_solid = 1.0 - solid_fraction;
-    return -mushy_zone_morphology * solid_fraction * solid_fraction /
-           (non_solid * non_solid * non_solid + avoid_div_zero_constant);
   }
 
   template <int dim, typename number>

--- a/unit_tests/flow/CMakeLists.txt
+++ b/unit_tests/flow/CMakeLists.txt
@@ -1,4 +1,5 @@
 mpdg_setup_serial_unit_tests(
     TEST_SOURCE_FILES
     compressible_flow_kernels.cpp
+    darcy_damping_model.cpp
 )

--- a/unit_tests/flow/darcy_damping_model.cpp
+++ b/unit_tests/flow/darcy_damping_model.cpp
@@ -1,0 +1,107 @@
+#include <gtest/gtest.h>
+
+#include <deal.II/base/vectorization.h>
+
+#include <meltpooldg/flow/darcy_damping_data.hpp>
+#include <meltpooldg/flow/darcy_damping_model.hpp>
+
+namespace
+{
+  using namespace MeltPoolDG::Flow;
+
+  TEST(DarcyDampingModel, ComputesDarcyDampingCoefficientForScalar)
+  {
+    DarcyDampingData<double> data;
+    data.mushy_zone_morphology   = 1.e11;
+    data.avoid_div_zero_constant = 1.;
+
+    const DarcyDampingModel<double> model(data);
+
+    constexpr double solid_fraction = 0.5;
+
+    const auto coefficient = model.compute_darcy_damping_coefficient(solid_fraction);
+
+    const double expected =
+      -data.mushy_zone_morphology * solid_fraction * solid_fraction /
+      ((1.0 - solid_fraction) * (1.0 - solid_fraction) * (1.0 - solid_fraction) +
+       data.avoid_div_zero_constant);
+
+    EXPECT_NEAR(coefficient, expected, 1.e-12);
+  }
+
+  TEST(DarcyDampingModel, ComputesDarcyDampingCoefficientForAllLanes)
+  {
+    DarcyDampingData<double> data;
+    data.mushy_zone_morphology   = 1.e11;
+    data.avoid_div_zero_constant = 1.;
+
+    const DarcyDampingModel<double> model(data);
+
+    dealii::VectorizedArray<double> solid_fraction;
+    for (unsigned int lane = 0; lane < solid_fraction.size(); ++lane)
+      solid_fraction[lane] = 0.1 * (lane + 1);
+
+    const auto coefficient = model.compute_darcy_damping_coefficient(solid_fraction);
+
+    for (unsigned int lane = 0; lane < solid_fraction.size(); ++lane)
+      {
+        const double fs = solid_fraction[lane];
+
+        const double expected =
+          -data.mushy_zone_morphology * fs * fs /
+          ((1.0 - fs) * (1.0 - fs) * (1.0 - fs) + data.avoid_div_zero_constant);
+
+        EXPECT_NEAR(coefficient[lane], expected, 1.e-12);
+      }
+  }
+
+  TEST(DarcyDampingModel, HandlesFullySolidMaterial)
+  {
+    DarcyDampingData<double> data;
+    data.mushy_zone_morphology   = 1.e11;
+    data.avoid_div_zero_constant = 1.;
+
+    const DarcyDampingModel<double> model(data);
+
+    const dealii::VectorizedArray<double> solid_fraction = 1.;
+
+    const auto coefficient = model.compute_darcy_damping_coefficient(solid_fraction);
+
+    const double expected = -data.mushy_zone_morphology / data.avoid_div_zero_constant;
+
+    EXPECT_NEAR(coefficient[0], expected, 1.e-12);
+  }
+
+  TEST(DarcyDampingModel, ZeroMorphologyGivesZeroCoefficient)
+  {
+    DarcyDampingData<double> data;
+    data.mushy_zone_morphology   = 0.;
+    data.avoid_div_zero_constant = 0.;
+
+    const DarcyDampingModel<double> model(data);
+
+    const dealii::VectorizedArray<double> solid_fraction = 0.5;
+
+    const auto coefficient = model.compute_darcy_damping_coefficient(solid_fraction);
+
+    EXPECT_DOUBLE_EQ(coefficient[0], 0.0);
+  }
+
+  TEST(DarcyDampingModel, ConstructorRejectsZeroAvoidDivZeroConstant)
+  {
+    DarcyDampingData<double> data;
+    data.mushy_zone_morphology   = 1.e11;
+    data.avoid_div_zero_constant = 0.;
+
+    EXPECT_THROW(DarcyDampingModel<double> model(data), dealii::ExceptionBase);
+  }
+
+  TEST(DarcyDampingModel, ConstructorRejectsNegativeAvoidDivZeroConstant)
+  {
+    DarcyDampingData<double> data;
+    data.mushy_zone_morphology   = 1.e11;
+    data.avoid_div_zero_constant = -1.e-6;
+
+    EXPECT_THROW(DarcyDampingModel<double> model(data), dealii::ExceptionBase);
+  }
+} // namespace


### PR DESCRIPTION
<!-- Please, fill in the description as completely as possible.-->

<!-- Use Conventional Commits format for the commit message:
     <type>(optional scope): <description>

     Available types:
     - feat: introduces a new feature
     - fix: fixes a bug
     - refactor: code change without changing behavior
     - test: adds or updates tests
     - docs: documentation-only changes
     - style: formatting-only changes
     - perf: performance improvements
     - chore: maintenance work
     - bench: adds or updates benchmarks

     Example:
     feat(heat): add apparent capacity method
     - add apparent capacity formulation for latent heat treatment
     - add support for constant, poly4_bell, and qlq apparent-capacity models
     - add temperature derivatives for Newton linearization
-->

# Description
This PR refactors the `darcy_damping_operation` to make the damping coefficient computation reusable in the `multiphase_operator`.
To achieve this, a new `darcy_damping_model` class is introduced to encapsulate the functionality to compute the damping coefficient. This allows the same implementation to be reused across both incompressible and compressible solvers and eliminates the current code duplication in the compressible `multiphase_operator`.

# How has this been tested?
A unit test for the `darcy_damping_model` was added.

# Screenshots (if appropriate)
<!-- Do you have any visual results from simulations that relate to this PR? -->

# Checklist (should be removed by the person who merges this PR)

- [x] The branch is rebased onto main
- [x] Code is formatted with format-all
- [x] Prefer a single commit with a meaningful commit message; if multiple commits are necessary, explain why in the PR description
- [x] Labels are applied
- [ ] Co-Pilot review is requested
- [ ] Reviews are requested
- [ ] If this PR closes an issue or is related to a project, it is linked in the "Description" section
- [x] All in-code documentation related to this PR is up to date (Doxygen format)
- [x] Commit has unit test(s) (preferred) or application test(s)
- [ ] If the fix is temporary, an issue is opened where this PR is referenced
- [ ] A changelog entry is added for any notable change
