### PR TITLE
fix(compressible flow): correct temperature calculation in NASG EoS

### DIFF
--- a/include/meltpooldg/compressible_flow/equation_of_state.hpp
+++ b/include/meltpooldg/compressible_flow/equation_of_state.hpp
@@ -449,8 +449,8 @@ namespace MeltPoolDG::Flow
       return (thermodynamic_pressure(value_view, material_view) +
               material_view.stiffening_pressure()) *
              (1. / value_view.density() - material_view.covolume()) *
-             material_view.heat_capacity_ratio() / (material_view.heat_capacity_ratio() - 1.) *
-             material_view.specific_isobaric_heat();
+             material_view.heat_capacity_ratio() /
+             ((material_view.heat_capacity_ratio() - 1.) * material_view.specific_isobaric_heat());
     }
 
     /**


### PR DESCRIPTION
<!-- Please, fill in the description as completely as possible.-->

<!-- Use Conventional Commits format for the commit message:
     <type>(optional scope): <description>

     Available types:
     - feat: introduces a new feature
     - fix: fixes a bug
     - refactor: code change without changing behavior
     - test: adds or updates tests
     - docs: documentation-only changes
     - style: formatting-only changes
     - perf: performance improvements
     - chore: maintenance work
     - bench: adds or updates benchmarks

     Example:
     feat(heat): add apparent capacity method
     - add apparent capacity formulation for latent heat treatment
     - add support for constant, poly4_bell, and qlq apparent-capacity models
     - add temperature derivatives for Newton linearization
-->

# Description
This PR fixes a small bug in the temperature calculation for the Noble-Abel stiffened-gas EoS in our EoS mixins. Note that, as a workaround, the implementation of the EoS-specific computations is currently duplicated (`equation_of_state.hpp` vs. `eos_utils.hpp`). The goal is to rely on our view concept and eliminate the `eos_utils.hpp` in the future. In `eos_utils.hpp`, the implementation was correct.

# How has this been tested?
The implementation in the mixin is currently unused. This is the reason the bug was not detected yet, but will be used in the following PR's. I just encapsulated this fix as a separate fix-PR.

# Screenshots (if appropriate)
<!-- Do you have any visual results from simulations that relate to this PR? -->

# Checklist (should be removed by the person who merges this PR)

- [x] The branch is rebased onto main
- [x] Code is formatted with format-all
- [x] Prefer a single commit with a meaningful commit message; if multiple commits are necessary, explain why in the PR description
- [x] Labels are applied
- [ ] Co-Pilot review is requested
- [x] Reviews are requested
- [ ] If this PR closes an issue or is related to a project, it is linked in the "Description" section
- [x] All in-code documentation related to this PR is up to date (Doxygen format)
- [ ] Commit has unit test(s) (preferred) or application test(s)
- [ ] If the fix is temporary, an issue is opened where this PR is referenced
- [ ] A changelog entry is added for any notable change
