### PR TITLE
Adapt profiling output to journal style

### DIFF
--- a/include/meltpooldg/utilities/cell_monitor.hpp
+++ b/include/meltpooldg/utilities/cell_monitor.hpp
@@ -1,7 +1,8 @@
 #pragma once
 
-#include <deal.II/base/convergence_table.h>
 #include <deal.II/base/table_handler.h>
+
+#include <meltpooldg/utilities/journal.hpp>
 
 #include <algorithm>
 #include <map>
@@ -67,9 +68,9 @@ namespace MeltPoolDG
 
     template <typename StreamType>
     static void
-    print(StreamType &ss)
+    print(StreamType &ss, const std::string &title)
     {
-      dealii::ConvergenceTable table;
+      dealii::TableHandler table;
 
       for (const auto &entry : stat_cells)
         {
@@ -82,12 +83,12 @@ namespace MeltPoolDG
 
           table.add_value("cell size min", entry.second.cell_size_min);
           table.add_value("cell size max", entry.second.cell_size_max);
-          table.set_scientific("cell size min", 4);
-          table.set_scientific("cell size max", 4);
+          table.set_scientific("cell size min", true);
+          table.set_scientific("cell size max", true);
         }
 
       if (ss.is_active())
-        table.write_text(ss.get_stream(), dealii::TableHandler::TextOutputFormat::org_mode_table);
+        Journal::print_table(ss, title, table);
     }
 
     static CellStatistics
@@ -105,6 +106,12 @@ namespace MeltPoolDG
     clear()
     {
       stat_cells.clear();
+    }
+
+    static bool
+    has_statistics()
+    {
+      return not stat_cells.empty();
     }
 
   private:

--- a/include/meltpooldg/utilities/dof_monitor.hpp
+++ b/include/meltpooldg/utilities/dof_monitor.hpp
@@ -1,6 +1,8 @@
 #pragma once
 
-#include <deal.II/base/convergence_table.h>
+#include <deal.II/base/table_handler.h>
+
+#include <meltpooldg/utilities/journal.hpp>
 
 namespace MeltPoolDG
 {
@@ -44,9 +46,9 @@ namespace MeltPoolDG
 
     template <typename StreamType>
     static void
-    print(StreamType &ss)
+    print(StreamType &ss, const std::string &title)
     {
-      dealii::ConvergenceTable table;
+      dealii::TableHandler table;
 
       for (const auto &entry : stat_dofs)
         {
@@ -61,7 +63,13 @@ namespace MeltPoolDG
         }
 
       if (ss.is_active())
-        table.write_text(ss.get_stream(), dealii::TableHandler::TextOutputFormat::org_mode_table);
+        Journal::print_table(ss, title, table);
+    }
+
+    static bool
+    has_statistics()
+    {
+      return not stat_dofs.empty();
     }
 
 

--- a/include/meltpooldg/utilities/iteration_monitor.hpp
+++ b/include/meltpooldg/utilities/iteration_monitor.hpp
@@ -1,6 +1,10 @@
 #pragma once
 
-#include <deal.II/base/convergence_table.h>
+#include <deal.II/base/table_handler.h>
+
+#include <meltpooldg/utilities/journal.hpp>
+
+#include <sstream>
 
 namespace MeltPoolDG
 {
@@ -44,9 +48,9 @@ namespace MeltPoolDG
 
     template <typename StreamType>
     static void
-    print(StreamType &ss)
+    print(StreamType &ss, const std::string &title)
     {
-      dealii::ConvergenceTable table;
+      dealii::TableHandler table;
 
       for (const auto &entry : stat_linear)
         {
@@ -61,9 +65,14 @@ namespace MeltPoolDG
         }
 
       if (ss.is_active())
-        table.write_text(ss.get_stream(), dealii::TableHandler::TextOutputFormat::org_mode_table);
+        Journal::print_table(ss, title, table);
     }
 
+    static bool
+    has_statistics()
+    {
+      return not stat_linear.empty();
+    }
 
   private:
     inline static std::map<std::string, LinearIterationStatistics> stat_linear;

--- a/include/meltpooldg/utilities/journal.hpp
+++ b/include/meltpooldg/utilities/journal.hpp
@@ -1,4 +1,6 @@
 #pragma once
+#include <deal.II/base/table_handler.h>
+
 #include <meltpooldg/utilities/conditional_ostream.hpp>
 
 #include <functional>
@@ -48,6 +50,40 @@ namespace MeltPoolDG::Journal
                              const std::string        &text           = "",
                              const std::string        &operation_name = "",
                              const unsigned int        extra_size     = 0);
+
+  /**
+   * @brief Print a multi-line preconfigured table inside a single bordered box with a title row.
+   *
+   * The box width grows to fit the widest table row, but never shrinks below max_text_width, so
+   * short tables still line up with the rest of the decorated output.
+   *
+   * The function requires a preconfigured dealii::TableHandler object, which is printed inside the
+   * box. From the table handler object the labels as well as the corresponding values are
+   * extracted. The title is printed in the top row, left-aligned, and the table is printed below
+   * it. An example output is shown below:
+   *
+   * @verbatim
+   * +-----------------------------------------------------------------------+
+   * | Cell statistics                                                       |
+   * |                                                                       |
+   * | label           | no. calls | n_cells avg | n_cells min | n_cells max |
+   * +-----------------+-----------+-------------+-------------+-------------+
+   * | flow_field      | 747       | 73.74       | 26          | 112         |
+   * | level_set       | 380       | 37.47       | 21          | 42          |
+   * +-----------------+-----------+-------------+-------------+-------------+
+   * @endverbatim
+   *
+   * @note The function does not provide a separate interface for labels of row. If desired, the
+   *       labels can be added to the table handler object before calling this function.
+   *
+   * @param pcout ConditionalOStream to print the text.
+   * @param title Title of the table, printed left-aligned in the top row.
+   * @param table The configured table which is printed inside the box.
+   */
+  void
+  print_table(const ConditionalOStream   &pcout,
+              const std::string          &title,
+              const dealii::TableHandler &table);
 
   /**
    * @brief Prints a formatted header consisting of a centered text surrounded

--- a/include/meltpooldg/utilities/profiling_monitor.hpp
+++ b/include/meltpooldg/utilities/profiling_monitor.hpp
@@ -19,18 +19,37 @@ namespace MeltPoolDG::Profiling
     ProfilingMonitor(const ProfilingData<number>                 &data,
                      const TimeIntegration::TimeIterator<number> &time);
 
+    /**
+     * Returns true if according to the data set in the profiling data struct, profiling outout
+     * should be performed. Otherwise, returns false.
+     */
     bool
     now() const;
 
+    /**
+     * Print profiling summary as obtained by the TimerOutput class and statistics summary of all
+     * available monitors.
+     *
+     * @param pcout ConditionalOStream to print the text.
+     * @param timer TimerOutput object which contains the profiling information.
+     * @param mpi_communicator MPI communicator relevant for the timer.
+     */
     void
     print(const ConditionalOStream  &pcout,
           const dealii::TimerOutput &timer,
           const MPI_Comm            &mpi_communicator) const;
 
   private:
-    const ProfilingData<number>                       &data;
-    const TimeIntegration::TimeIterator<number>       &time;
-    mutable number                                     last_written_time = 0.0;
+    /// The profiling data struct which contains the relevant information for profiling.
+    const ProfilingData<number> &data;
+
+    /// The time iterator which is used to compute the current time.
+    const TimeIntegration::TimeIterator<number> &time;
+
+    /// The time at which the last profiling output was written.
+    mutable number last_written_time = 0.0;
+
+    /// Real time at object construction
     std::chrono::time_point<std::chrono::system_clock> real_time_start;
 
     number

--- a/source/utilities/journal.cpp
+++ b/source/utilities/journal.cpp
@@ -1,5 +1,15 @@
+#include <deal.II/base/table_handler.h>
+
 #include <meltpooldg/utilities/conditional_ostream.hpp>
 #include <meltpooldg/utilities/journal.hpp>
+
+#include <algorithm>
+#include <iomanip>
+#include <ios>
+#include <ostream>
+#include <sstream>
+#include <string>
+#include <vector>
 
 
 namespace MeltPoolDG::Journal
@@ -33,6 +43,75 @@ namespace MeltPoolDG::Journal
           << std::setw(max_text_width - text.length() - end_line_symbol.length() + extra_size)
           << str.str() << std::endl;
     print_decoration_line(pcout);
+  }
+
+  void
+  print_table(const ConditionalOStream   &pcout,
+              const std::string          &title,
+              const dealii::TableHandler &table_handler)
+  {
+    // get the string representation of the table
+    std::ostringstream oss;
+    table_handler.write_text(oss, dealii::TableHandler::TextOutputFormat::org_mode_table);
+    const std::string table_text = oss.str();
+
+    // collect the table rows, dropping any trailing whitespace so their length reflects the
+    // position of the closing '|'
+    std::vector<std::string> rows;
+    {
+      std::istringstream iss(table_text);
+      std::string        row;
+      while (std::getline(iss, row))
+        {
+          while (not row.empty() and row.back() == ' ')
+            row.pop_back();
+          if (not row.empty())
+            rows.push_back(row);
+        }
+    }
+
+    unsigned int table_width = max_text_width;
+    for (const auto &row : rows)
+      table_width = std::max<unsigned int>(table_width, row.size());
+
+    const auto print_rule = [&]() {
+      pcout << "+" << std::string(table_width - 2, '-') << "+" << std::endl;
+    };
+
+    // rules bordering the tabular grid get a '+' wherever a column boundary ('|') occurs in the
+    // column-header row
+    const auto print_table_rule = [&]() {
+      std::string rule(table_width, '-');
+      rule[0]               = '+';
+      rule[table_width - 1] = '+';
+      if (not rows.empty())
+        for (std::size_t p = 0; p < rows.front().size(); ++p)
+          if (rows.front()[p] == '|')
+            rule[p] = '+';
+      pcout << rule << std::endl;
+    };
+
+    print_rule();
+
+    pcout << start_line_symbol << title << std::right
+          << std::setw(table_width - title.length() - end_line_symbol.length()) << end_line_symbol
+          << std::endl;
+
+    // blank line between the title and the column-header row
+    pcout << "|" << std::string(table_width - 2, ' ') << "|" << std::endl;
+
+    for (unsigned int i = 0; i < rows.size(); ++i)
+      {
+        auto row = rows[i];
+        row.pop_back(); // drop the trailing '|', it is re-added after padding
+        pcout << row << std::string(table_width - row.size() - 1, ' ') << "|" << std::endl;
+
+        // separate the column-header row from the data rows
+        if (i == 0 and rows.size() > 1)
+          print_table_rule();
+      }
+
+    print_table_rule();
   }
 
   template <typename number>

--- a/source/utilities/profiling_monitor.cpp
+++ b/source/utilities/profiling_monitor.cpp
@@ -43,22 +43,45 @@ namespace MeltPoolDG::Profiling
                                   const dealii::TimerOutput &timer,
                                   const MPI_Comm            &mpi_communicator) const
   {
+    // print profiling summary as obtained by the TimerOutput class
+    pcout << std::endl;
+    Journal::print_header(pcout, "Profiling summary");
+
     timer.print_wall_time_statistics(mpi_communicator);
-    pcout << std::endl;
 
-    Journal::print_decoration_line(pcout);
-    Journal::print_line(pcout, "Iteration statistics", "iteration_monitor");
-    IterationMonitor<number>::print(pcout);
-    pcout << std::endl;
+    timer.print_summary();
 
-    Journal::print_decoration_line(pcout);
-    Journal::print_line(pcout, "DoF statistics", "dof_monitor");
-    DoFMonitor<number>::print(pcout);
-    pcout << std::endl;
+    Journal::print_header(pcout, "End of profiling summary");
+    pcout << std::endl << std::endl;
 
-    Journal::print_decoration_line(pcout);
-    Journal::print_line(pcout, "Cell statistics", "cell_monitor");
-    CellMonitor<number>::print(pcout);
+    // print statistics summary of all available monitors
+    Journal::print_header(pcout, "Statistics summary");
+    pcout << std::endl;
+    int section_number = 1;
+    if (IterationMonitor<number>::has_statistics())
+      {
+        IterationMonitor<number>::print(pcout,
+                                        std::to_string(section_number) + ". Iteration statistics");
+        pcout << std::endl;
+        ++section_number;
+      }
+
+    if (DoFMonitor<number>::has_statistics())
+      {
+        DoFMonitor<number>::print(pcout, std::to_string(section_number) + ". DoF statistics");
+        pcout << std::endl;
+        ++section_number;
+      }
+
+    if (CellMonitor<number>::has_statistics())
+      {
+        CellMonitor<number>::print(pcout, std::to_string(section_number) + ". Cell statistics");
+        pcout << std::endl;
+        ++section_number;
+      }
+
+    Journal::print_header(pcout, "End of statistics summary");
+    pcout << std::endl;
   }
 
   template <typename number>


### PR DESCRIPTION
<!-- Please, fill in the description as completely as possible.-->

<!-- Use Conventional Commits format for the commit message:
     <type>(optional scope): <description>

     Available types:
     - feat: introduces a new feature
     - fix: fixes a bug
     - refactor: code change without changing behavior
     - test: adds or updates tests
     - docs: documentation-only changes
     - style: formatting-only changes
     - perf: performance improvements
     - chore: maintenance work
     - bench: adds or updates benchmarks

     Example:
     feat(heat): add apparent capacity method
     - add apparent capacity formulation for latent heat treatment
     - add support for constant, poly4_bell, and qlq apparent-capacity models
     - add temperature derivatives for Newton linearization
-->

# Description
This PR aims to adapt the profiling console output to the journal style used throughout MeltPoolDG. In my opinion, the output now looks cleaner, especially the tables for the different monitors. Below is a screenshot of the before-and-after. I am open to any other changes :-) The current style is just a suggestion.

In addition, the profiling output now also prints the deal.II timer summary. This gives a bit more detail on how much time was spent in specific sections.

# How has this been tested?
<!-- Are there changes on current tests? If yes, why?
     Do you introduce new test? Which features do you intend to test?
     How did you ensure that the solution works? -->

# Screenshots (if appropriate)
The old output:
<img width="1966" height="848" alt="old_profiling_output" src="https://github.com/user-attachments/assets/5262d326-d9c2-49a1-aa7a-7c551cc4247c" />

The new output:
<img width="1909" height="1525" alt="new_profiling_output" src="https://github.com/user-attachments/assets/df2a7a47-1868-4b41-9984-f01f784b4268" />


# Checklist (should be removed by the person who merges this PR)

- [x] The branch is rebased onto main
- [x] Code is formatted with format-all
- [x] Prefer a single commit with a meaningful commit message; if multiple commits are necessary, explain why in the PR description
- [x] Labels are applied
- [ ] Co-Pilot review is requested
- [x] Reviews are requested
- [ ] If this PR closes an issue or is related to a project, it is linked in the "Description" section
- [x] All in-code documentation related to this PR is up to date (Doxygen format)
- [ ] Commit has unit test(s) (preferred) or application test(s)
- [ ] If the fix is temporary, an issue is opened where this PR is referenced
- [ ] A changelog entry is added for any notable change
