### PR TITLE
feature(compressible multiphase): add weakly compressible EoS

### DIFF
--- a/include/meltpooldg/compressible_flow/equation_of_state.hpp
+++ b/include/meltpooldg/compressible_flow/equation_of_state.hpp
@@ -155,6 +155,26 @@ namespace MeltPoolDG::Flow
     };
   };
 
+  /**
+   * Concept defining the specific requirements for a material view to be used with the weakly
+   * compressible equation of state.
+   */
+  template <typename T>
+  concept WeaklyCompressibleIsMaterialView = requires(const T m) {
+    {
+      m.specific_isochoric_heat()
+    };
+    {
+      m.reference_state_sound_speed()
+    };
+    {
+      m.reference_state_density()
+    };
+    {
+      m.reference_state_pressure()
+    };
+  };
+
   struct IdealGasEOS
   {
     /**
@@ -261,7 +281,7 @@ namespace MeltPoolDG::Flow
     }
 
     /**
-     * Compute the specific inner energy from a given flow state and material properties for an
+     * Compute the specific internal energy from a given flow state and material properties for an
      * ideal gas.
      *
      * @param value_view View providing access to the flow state.
@@ -270,7 +290,7 @@ namespace MeltPoolDG::Flow
     template <typename ValueView, IdealGasIsMaterialView MaterialView>
     static inline DEAL_II_ALWAYS_INLINE //
       auto
-      specific_inner_energy(const ValueView &value_view, const MaterialView &material_view)
+      specific_internal_energy(const ValueView &value_view, const MaterialView &material_view)
     {
       return thermodynamic_pressure(value_view, material_view) /
              (value_view.density() * (material_view.heat_capacity_ratio() - 1.));
@@ -435,7 +455,7 @@ namespace MeltPoolDG::Flow
     }
 
     /**
-     * Compute the specific inner energy from a given flow state and material properties for a
+     * Compute the specific internal energy from a given flow state and material properties for a
      * stiffened gas.
      *
      * @param value_view View providing access to the flow state.
@@ -444,7 +464,7 @@ namespace MeltPoolDG::Flow
     template <typename ValueView, StiffenedGasIsMaterialView MaterialView>
     static inline DEAL_II_ALWAYS_INLINE //
       auto
-      specific_inner_energy(const ValueView &value_view, const MaterialView &material_view)
+      specific_internal_energy(const ValueView &value_view, const MaterialView &material_view)
     {
       return (thermodynamic_pressure(value_view, material_view) +
               material_view.heat_capacity_ratio() * material_view.stiffening_pressure()) /
@@ -619,7 +639,7 @@ namespace MeltPoolDG::Flow
     }
 
     /**
-     * Compute the specific inner energy from a given flow state and material properties for a
+     * Compute the specific internal energy from a given flow state and material properties for a
      * Noble-Abel stiffened gas.
      *
      * @param value_view View providing access to the flow state.
@@ -628,7 +648,7 @@ namespace MeltPoolDG::Flow
     template <typename ValueView, NobleAbelStiffenedGasIsMaterialView MaterialView>
     static inline DEAL_II_ALWAYS_INLINE //
       auto
-      specific_inner_energy(const ValueView &value_view, const MaterialView &material_view)
+      specific_internal_energy(const ValueView &value_view, const MaterialView &material_view)
     {
       return (thermodynamic_pressure(value_view, material_view) +
               material_view.heat_capacity_ratio() * material_view.stiffening_pressure()) /
@@ -679,6 +699,175 @@ namespace MeltPoolDG::Flow
          material_view.stiffening_pressure() * (1. / density - material_view.covolume()) +
          material_view.heat_bound() +
          0.5 * scalar_product(primitive_value_view.velocity(), primitive_value_view.velocity()));
+    }
+  };
+
+  struct WeaklyCompressibleEOS
+  {
+    /**
+     * Compute the thermodynamic pressure for a weakly compressible fluid from the given flow
+     * state.
+     *
+     * @param value_view View providing access to the flow state.
+     * @param material_view View providing access to the material properties.
+     *
+     * @return Pressure resulting from the given flow state and material properties.
+     */
+    template <EOSIsConservativeValueView ValueView, WeaklyCompressibleIsMaterialView MaterialView>
+    static inline DEAL_II_ALWAYS_INLINE //
+      auto
+      thermodynamic_pressure(const ValueView &value_view, const MaterialView &material_view)
+    {
+      return material_view.reference_state_sound_speed() *
+               material_view.reference_state_sound_speed() *
+               (value_view.density() - material_view.reference_state_density()) +
+             material_view.reference_state_pressure();
+    }
+
+    /**
+     * Compute the gradient of the temperature for a weakly compressible fluid from the given flow
+     * state and material properties.
+     *
+     * @param value_view View providing access to the flow state.
+     * @param gradient_view View providing access to the gradients of the flow state.
+     * @param material_view View providing access to the material properties.
+     *
+     * @return Gradient of the temperature resulting from the given flow state and material properties.
+     */
+    template <EOSIsConservativeValueView       ValueView,
+              EOSIsGradientView                GradientView,
+              WeaklyCompressibleIsMaterialView MaterialView>
+    static inline DEAL_II_ALWAYS_INLINE //
+      auto
+      grad_temperature(const ValueView    &value_view,
+                       const GradientView &gradient_view,
+                       const MaterialView &material_view)
+    {
+      const auto grad_E =
+        1. / value_view.density() *
+        (gradient_view.grad_total_energy() -
+         value_view.total_energy() / value_view.density() * gradient_view.grad_density());
+
+      return 1. / material_view.specific_isochoric_heat() *
+             (grad_E - matrix_vector_product(gradient_view.grad_velocity(), value_view.velocity()));
+    }
+
+    /**
+     * Compute the speed of sound for a weakly compressible fluid from the given flow state and
+     * material properties.
+     *
+     * @param value_view View providing access to the flow state.
+     * @param material_view View providing access to the material properties.
+     *
+     * @return Speed of sound resulting from the given flow state and material properties.
+     */
+    template <EOSIsConservativeValueView ValueView, WeaklyCompressibleIsMaterialView MaterialView>
+    static inline DEAL_II_ALWAYS_INLINE //
+      auto
+      speed_of_sound(const ValueView &value_view, const MaterialView &material_view)
+    {
+      // return type could be either vectorized or non-vectorized
+      using ReturnType = decltype(value_view.density());
+
+      return ReturnType(material_view.reference_state_sound_speed());
+    }
+
+    /**
+     * Compute the temperature for a weakly compressible fluid from the given flow state and
+     * material properties.
+     *
+     * @param value_view View providing access to the flow state.
+     * @param material_view View providing access to the material properties.
+     *
+     * @return Temperature resulting from the given flow state and material properties.
+     */
+    template <EOSIsConservativeValueView ValueView, WeaklyCompressibleIsMaterialView MaterialView>
+    static inline DEAL_II_ALWAYS_INLINE //
+      auto
+      temperature(const ValueView &value_view, const MaterialView &material_view)
+    {
+      return (value_view.total_energy() / value_view.density() -
+              0.5 * scalar_product(value_view.velocity(), value_view.velocity())) /
+             material_view.specific_isochoric_heat();
+    }
+
+    /**
+     * Compute the inner energy from a given pressure for a weakly compressible fluid with the given
+     * material properties.
+     *
+     * @note This function is not valid for the weakly compressible equation of state. The inner energy
+     * does not depend on pressure, but only on temperature.
+     *
+     * @throw The function call is asserted.
+     */
+    template <typename ValueType,
+              EOSIsConservativeValueView       ValueView,
+              WeaklyCompressibleIsMaterialView MaterialView>
+    static inline DEAL_II_ALWAYS_INLINE //
+      auto
+      inner_energy_from_pressure(const ValueType &, const ValueView &, const MaterialView &)
+    {
+      AssertThrow(
+        false,
+        dealii::ExcMessage(
+          "inner_energy_from_pressure() is not defined for the weakly compressible EOS."));
+
+      return ValueType{};
+    }
+
+    /**
+     * Compute the specific internal energy from a given flow state and material properties for a
+     * weakly compressible fluid.
+     *
+     * @param value_view View providing access to the flow state.
+     */
+    template <typename ValueView, WeaklyCompressibleIsMaterialView MaterialView>
+    static inline DEAL_II_ALWAYS_INLINE //
+      auto
+      specific_internal_energy(const ValueView &value_view, const MaterialView &)
+    {
+      return value_view.total_energy() / value_view.density() -
+             0.5 * scalar_product(value_view.velocity(), value_view.velocity());
+    }
+
+    /**
+     * Compute the set of conserved variables (density, momentum, total energy) from the given state
+     * of primitive variables (pressure, velocity, temperature) for a weakly compressible fluid.
+     *
+     * @param conservative_value_view View providing writable access to the flow state in conservative variables, which is computed.
+     * @param primitive_value_view View providing access to the flow state in primitive variables.
+     * @param material_view View providing access to the material properties.
+     */
+    template <int                                dim,
+              EOSIsWritableConservativeValueView WritableConservativeValueView,
+              EOSIsPrimitiveValueView            PrimitiveValueView,
+              WeaklyCompressibleIsMaterialView   MaterialView>
+    static inline DEAL_II_ALWAYS_INLINE //
+      void
+      conservative_from_primitive(WritableConservativeValueView &conservative_value_view,
+                                  const PrimitiveValueView      &primitive_value_view,
+                                  const MaterialView            &material_view)
+    {
+      const auto pressure    = primitive_value_view.pressure();
+      const auto temperature = primitive_value_view.temperature();
+      const auto velocity    = primitive_value_view.velocity();
+
+      const auto density = (pressure - material_view.reference_state_pressure()) /
+                             (material_view.reference_state_sound_speed() *
+                              material_view.reference_state_sound_speed()) +
+                           material_view.reference_state_density();
+
+      // density
+      conservative_value_view.density() = density;
+
+      // momentum
+      for (unsigned int d = 0; d < dim; ++d)
+        conservative_value_view.momentum(d) = density * velocity[d];
+
+      // total energy
+      conservative_value_view.total_energy() =
+        density * (material_view.specific_isochoric_heat() * temperature +
+                   0.5 * scalar_product(velocity, velocity));
     }
   };
 
@@ -739,6 +928,8 @@ namespace MeltPoolDG::Flow
           if (type == CompressibleFlow::EquationOfState::noble_abel_stiffened_gas)
             return supports_eos<Derived,
                                 CompressibleFlow::EquationOfState::noble_abel_stiffened_gas>();
+          if (type == CompressibleFlow::EquationOfState::weakly_compressible)
+            return supports_eos<Derived, CompressibleFlow::EquationOfState::weakly_compressible>();
           return false;
         }
       return true;
@@ -759,6 +950,11 @@ namespace MeltPoolDG::Flow
         case CompressibleFlow::EquationOfState::noble_abel_stiffened_gas:
           if constexpr (check_support(CompressibleFlow::EquationOfState::noble_abel_stiffened_gas))
             return std::forward<F>(f)(NobleAbelStiffenedGasEOS{});
+          break;
+
+        case CompressibleFlow::EquationOfState::weakly_compressible:
+          if constexpr (check_support(CompressibleFlow::EquationOfState::weakly_compressible))
+            return std::forward<F>(f)(WeaklyCompressibleEOS{});
           break;
 
         default:
@@ -814,10 +1010,10 @@ namespace MeltPoolDG::Flow
     }
 
     decltype(auto)
-    specific_inner_energy() const
+    specific_internal_energy() const
     {
       return dispatch_eos<Derived>(eos_type(), [&](auto eos) -> decltype(auto) {
-        return eos.specific_inner_energy(derived(), derived());
+        return eos.specific_internal_energy(derived(), derived());
       });
     }
 

--- a/include/meltpooldg/compressible_flow/material.hpp
+++ b/include/meltpooldg/compressible_flow/material.hpp
@@ -13,7 +13,12 @@ namespace MeltPoolDG::CompressibleFlow
 {
   /// Enumeration for the currently supported equations of state to model compressible or (nearly)
   /// incompressible fluids
-  BETTER_ENUM(EquationOfState, char, ideal_gas, stiffened_gas, noble_abel_stiffened_gas)
+  BETTER_ENUM(EquationOfState,
+              char,
+              ideal_gas,
+              stiffened_gas,
+              noble_abel_stiffened_gas,
+              weakly_compressible)
 
   /**
    * @brief Collection of parameters related to the equation of state for a compressible or nearly
@@ -35,6 +40,19 @@ namespace MeltPoolDG::CompressibleFlow
     /// hydrogen bondings, latent heat,...
     /// (required for noble_abel_stiffened_gas)
     number heat_bound = std::numeric_limits<number>::min();
+
+    /// Parameters for the weakly compressible equation of state
+    struct WeaklyCompressibleSpecificData
+    {
+      /// Parameter for the pressure at the reference point
+      number reference_state_pressure = std::numeric_limits<number>::max();
+
+      /// Parameter for the density at the reference point
+      number reference_state_density = std::numeric_limits<number>::max();
+
+      /// Parameter for the sound speed at the reference point
+      number reference_state_sound_speed = std::numeric_limits<number>::max();
+    } weakly_compressible;
 
     /**
      * @brief Add EOS-specific material parameters in the parameter handler.
@@ -63,6 +81,9 @@ namespace MeltPoolDG::CompressibleFlow
   {
     /// Specific isobaric heat (SI: J/(kg K))
     number specific_isobaric_heat = 1000.0;
+
+    /// Specific isochoric heat (SI: J/(kg K))
+    number specific_isochoric_heat = 1000.0;
 
     /// Dynamic viscosity (SI: kg/(m s))
     number dynamic_viscosity = 1. / 1600.;
@@ -149,6 +170,7 @@ namespace MeltPoolDG::CompressibleFlow
     /// multi-component materials, they are set to invalid numbers. This is done by the post
     /// function.
     number          specific_isobaric_heat;
+    number          specific_isochoric_heat;
     number          dynamic_viscosity;
     number          gamma;
     number          specific_gas_constant;

--- a/include/meltpooldg/compressible_flow/material_views_mixins.hpp
+++ b/include/meltpooldg/compressible_flow/material_views_mixins.hpp
@@ -42,6 +42,12 @@ namespace MeltPoolDG::CompressibleFlow
     }
 
     decltype(auto)
+    specific_isochoric_heat() const
+    {
+      return this->material().specific_isochoric_heat;
+    }
+
+    decltype(auto)
     stiffening_pressure() const
     {
       return this->material().eos_data.stiffening_pressure;
@@ -57,6 +63,24 @@ namespace MeltPoolDG::CompressibleFlow
     covolume() const
     {
       return this->material().eos_data.covolume;
+    }
+
+    decltype(auto)
+    reference_state_pressure() const
+    {
+      return this->material().eos_data.weakly_compressible.reference_state_pressure;
+    }
+
+    decltype(auto)
+    reference_state_density() const
+    {
+      return this->material().eos_data.weakly_compressible.reference_state_density;
+    }
+
+    decltype(auto)
+    reference_state_sound_speed() const
+    {
+      return this->material().eos_data.weakly_compressible.reference_state_sound_speed;
     }
 
   private:
@@ -122,7 +146,6 @@ namespace MeltPoolDG::CompressibleFlow
     {
       return material().species_data[species_component].specific_gas_constant;
     }
-
 
     ValueType
     specific_isobaric_heat() const

--- a/include/meltpooldg/species_transport/state_views_mixins.hpp
+++ b/include/meltpooldg/species_transport/state_views_mixins.hpp
@@ -156,7 +156,7 @@ namespace MeltPoolDG::SpeciesTransport
     typename ValueType::value_type
     partial_inner_energy(const unsigned species_component) const
     {
-      return derived().specific_inner_energy() * derived().mass_fraction(species_component);
+      return derived().specific_internal_energy() * derived().mass_fraction(species_component);
     }
 
   private:

--- a/source/compressible_flow/material.cpp
+++ b/source/compressible_flow/material.cpp
@@ -40,6 +40,25 @@ MeltPoolDG::CompressibleFlow::EOSData<number>::add_parameters(dealii::ParameterH
       "latent heat,.... The variable is required for the Noble-Abel stiffened gas EOS. The "
       "maximum value is 0.",
       dealii::Patterns::Double(std::numeric_limits<number>::min(), 0.));
+    prm.enter_subsection("weakly compressible");
+    {
+      prm.add_parameter(
+        "reference-state pressure",
+        weakly_compressible.reference_state_pressure,
+        "Numerical EOS parameter for the pressure at the reference point required for the weakly compressible EOS. The minimum value is 0.",
+        dealii::Patterns::Double(0., std::numeric_limits<number>::max()));
+      prm.add_parameter(
+        "reference-state density",
+        weakly_compressible.reference_state_density,
+        "Numerical EOS parameter for the density at the reference point required for the weakly compressible EOS. The minimum value is 0.",
+        dealii::Patterns::Double(0., std::numeric_limits<number>::max()));
+      prm.add_parameter(
+        "reference-state sound speed",
+        weakly_compressible.reference_state_sound_speed,
+        "Numerical EOS parameter for the sound speed at the reference point required for the weakly compressible EOS. The minimum value is 0.",
+        dealii::Patterns::Double(0., std::numeric_limits<number>::max()));
+    }
+    prm.leave_subsection();
   }
   prm.leave_subsection();
 }
@@ -60,6 +79,15 @@ MeltPoolDG::CompressibleFlow::EOSData<number>::post(const EquationOfState eos_ty
                 dealii::ExcMessage(
                   "The parameters stiffening_pressure, covolume and heat_bound are required for "
                   "the Noble-Abel stiffened gas EOS."));
+  else if (eos_type == EquationOfState::weakly_compressible)
+    AssertThrow(
+      weakly_compressible.reference_state_pressure != std::numeric_limits<number>::max() and
+        weakly_compressible.reference_state_density != std::numeric_limits<number>::max() and
+        weakly_compressible.reference_state_sound_speed != std::numeric_limits<number>::max() and
+        weakly_compressible.reference_state_sound_speed > 0.,
+      dealii::ExcMessage(
+        "The parameters reference_state_pressure, reference_state_density and reference_state_sound_speed are required for "
+        "the weakly compressible EOS, and the reference_state_sound_speed must be > 0."));
 }
 
 template <typename number>
@@ -92,6 +120,10 @@ MeltPoolDG::CompressibleFlow::MaterialSpeciesData<number>::add_parameters(
   prm.add_parameter("specific isobaric heat",
                     specific_isobaric_heat,
                     "Specific isobaric heat.",
+                    dealii::Patterns::Double(0., std::numeric_limits<number>::max()));
+  prm.add_parameter("specific isochoric heat",
+                    specific_isochoric_heat,
+                    "Specific isochoric heat.",
                     dealii::Patterns::Double(0., std::numeric_limits<number>::max()));
   prm.add_parameter("dynamic viscosity",
                     dynamic_viscosity,
@@ -132,8 +164,9 @@ MeltPoolDG::CompressibleFlow::MaterialPhaseData<number>::add_parameters(
       "eos type",
       eos_type,
       "Type of equation of state. "
-      "The options are \"ideal_gas\", \"stiffened_gas\" and \"noble_abel_stiffened_gas\".",
-      dealii::Patterns::Selection("ideal_gas|stiffened_gas|noble_abel_stiffened_gas"));
+      "The options are \"ideal_gas\", \"stiffened_gas\", \"noble_abel_stiffened_gas\" and \"weakly_compressible\".",
+      dealii::Patterns::Selection(
+        "ideal_gas|stiffened_gas|noble_abel_stiffened_gas|weakly_compressible"));
     prm.add_parameter("reference density",
                       reference_density,
                       "Reference density for computing the interior penalty factor. "
@@ -254,21 +287,23 @@ MeltPoolDG::CompressibleFlow::MaterialPhaseData<number>::post(const bool is_gas)
   // should be accessed through the species data.
   if (number_of_species == 1)
     {
-      specific_isobaric_heat = species_data[0].specific_isobaric_heat;
-      dynamic_viscosity      = species_data[0].dynamic_viscosity;
-      gamma                  = species_data[0].gamma;
-      specific_gas_constant  = species_data[0].specific_gas_constant;
-      thermal_conductivity   = species_data[0].thermal_conductivity;
-      eos_data               = species_data[0].eos_data;
+      specific_isobaric_heat  = species_data[0].specific_isobaric_heat;
+      specific_isochoric_heat = species_data[0].specific_isochoric_heat;
+      dynamic_viscosity       = species_data[0].dynamic_viscosity;
+      gamma                   = species_data[0].gamma;
+      specific_gas_constant   = species_data[0].specific_gas_constant;
+      thermal_conductivity    = species_data[0].thermal_conductivity;
+      eos_data                = species_data[0].eos_data;
     }
   else
     {
-      specific_isobaric_heat = dealii::numbers::signaling_nan<number>();
-      dynamic_viscosity      = dealii::numbers::signaling_nan<number>();
-      gamma                  = dealii::numbers::signaling_nan<number>();
-      specific_gas_constant  = dealii::numbers::signaling_nan<number>();
-      thermal_conductivity   = dealii::numbers::signaling_nan<number>();
-      eos_data               = EOSData<number>();
+      specific_isobaric_heat  = dealii::numbers::signaling_nan<number>();
+      specific_isochoric_heat = dealii::numbers::signaling_nan<number>();
+      dynamic_viscosity       = dealii::numbers::signaling_nan<number>();
+      gamma                   = dealii::numbers::signaling_nan<number>();
+      specific_gas_constant   = dealii::numbers::signaling_nan<number>();
+      thermal_conductivity    = dealii::numbers::signaling_nan<number>();
+      eos_data                = EOSData<number>();
     }
 }
 

--- a/unit_tests/flow/equation_of_state_01.cpp
+++ b/unit_tests/flow/equation_of_state_01.cpp
@@ -181,6 +181,61 @@ namespace
     }
   };
 
+  struct WeaklyCompressibleValueView
+  {
+    double                         rho = 3500.;
+    dealii::Tensor<1, dim, double> v{{10.1, 1.3}};
+    double                         E = 1.035e10;
+
+    double &
+    density()
+    {
+      return rho;
+    }
+
+    const double &
+    density() const
+    {
+      return rho;
+    }
+
+    auto &
+    velocity()
+    {
+      return v;
+    }
+
+    const auto &
+    velocity() const
+    {
+      return v;
+    }
+
+    double &
+    momentum(const unsigned int d)
+    {
+      return v[d];
+    }
+
+    const double &
+    momentum(const unsigned int d) const
+    {
+      return v[d];
+    }
+
+    double &
+    total_energy()
+    {
+      return E;
+    }
+
+    const double &
+    total_energy() const
+    {
+      return E;
+    }
+  };
+
   struct IdealGasMaterialView
   {
     double gamma = 1.4;
@@ -260,6 +315,38 @@ namespace
     covolume() const
     {
       return b;
+    }
+  };
+
+  struct WeaklyCompressibleMaterialView
+  {
+    double p_0   = 1.e5;
+    double rho_0 = 3500.;
+    double c_0   = 500.;
+    double c_v   = 1000.;
+
+    double
+    reference_state_pressure() const
+    {
+      return p_0;
+    }
+
+    double
+    reference_state_density() const
+    {
+      return rho_0;
+    }
+
+    double
+    reference_state_sound_speed() const
+    {
+      return c_0;
+    }
+
+    double
+    specific_isochoric_heat() const
+    {
+      return c_v;
     }
   };
 
@@ -384,7 +471,7 @@ namespace
 
     const double expected = 180380.10131578948;
 
-    MeltPoolDG::TestUtils::expect_near(IdealGasEOS::specific_inner_energy(value, material),
+    MeltPoolDG::TestUtils::expect_near(IdealGasEOS::specific_internal_energy(value, material),
                                        expected,
                                        1.e-14);
   }
@@ -484,7 +571,7 @@ namespace
 
     const double expected = 1179772.3463625866;
 
-    MeltPoolDG::TestUtils::expect_near(StiffenedGasEOS::specific_inner_energy(value, material),
+    MeltPoolDG::TestUtils::expect_near(StiffenedGasEOS::specific_internal_energy(value, material),
                                        expected,
                                        1.e-14);
   }
@@ -589,7 +676,7 @@ namespace
     const double expected = -2024871.6301347816;
 
     MeltPoolDG::TestUtils::expect_near(
-      NobleAbelStiffenedGasEOS::specific_inner_energy(value, material), expected, 1.e-14);
+      NobleAbelStiffenedGasEOS::specific_internal_energy(value, material), expected, 1.e-14);
   }
 
   TEST(NobleAbelStiffenedGasEOS, GradientTemperature)
@@ -627,6 +714,106 @@ namespace
     MeltPoolDG::TestUtils::expect_near(conservative.total_energy(), expected[3], 1.e-14);
   }
 
+  // Weakly compressible gas
+
+  TEST(WeaklyCompressibleEOS, ThermodynamicPressure)
+  {
+    WeaklyCompressibleValueView value;
+
+    const auto material = WeaklyCompressibleMaterialView{};
+
+    const double expected = 1.e5;
+
+    MeltPoolDG::TestUtils::expect_double_eq(WeaklyCompressibleEOS::thermodynamic_pressure(value,
+                                                                                          material),
+                                            expected);
+  }
+
+  TEST(WeaklyCompressibleEOS, Temperature)
+  {
+    WeaklyCompressibleValueView value;
+
+    const auto material = WeaklyCompressibleMaterialView{};
+
+    const double expected = 2957.0910071428571;
+
+    MeltPoolDG::TestUtils::expect_near(WeaklyCompressibleEOS::temperature(value, material),
+                                       expected,
+                                       1.e-14);
+  }
+
+  TEST(WeaklyCompressibleEOS, SpeedOfSound)
+  {
+    WeaklyCompressibleValueView value;
+
+    const auto material = WeaklyCompressibleMaterialView{};
+
+    const double expected = 500.;
+
+    MeltPoolDG::TestUtils::expect_double_eq(WeaklyCompressibleEOS::speed_of_sound(value, material),
+                                            expected);
+  }
+
+  TEST(WeaklyCompressibleEOS, InnerEnergyFromPressure)
+  {
+    WeaklyCompressibleValueView value;
+
+    const double pressure = 1.e5;
+
+    const auto material = WeaklyCompressibleMaterialView{};
+
+    // For the weakly compressible EoS, the inner energy is independent of the pressure. Thus,
+    // calling this function throws an assert.
+    EXPECT_THROW(WeaklyCompressibleEOS::inner_energy_from_pressure(pressure, value, material),
+                 dealii::ExceptionBase);
+  }
+
+  TEST(WeaklyCompressibleEOS, SpecificInnerEnergy)
+  {
+    WeaklyCompressibleValueView value;
+
+    const auto material = WeaklyCompressibleMaterialView{};
+
+    const double expected = 2957091.0071428572;
+
+    MeltPoolDG::TestUtils::expect_near(
+      WeaklyCompressibleEOS::specific_internal_energy(value, material), expected, 1.e-14);
+  }
+
+  TEST(WeaklyCompressibleEOS, GradientTemperature)
+  {
+    WeaklyCompressibleValueView value;
+
+    const auto material = WeaklyCompressibleMaterialView{};
+    const auto gradient = GradientView();
+
+    const auto result = WeaklyCompressibleEOS::grad_temperature(value, gradient, material);
+
+    const dealii::Tensor<1, dim, double> expected{{-1.061207412244898, -0.66744903673469402}};
+
+    MeltPoolDG::TestUtils::expect_near(result[0], expected[0], 1.e-14);
+    MeltPoolDG::TestUtils::expect_near(result[1], expected[1], 1.e-14);
+  }
+
+  TEST(WeaklyCompressibleEOS, ConservativeFromPrimitive)
+  {
+    PrimitiveVariableView primitive;
+    primitive.v[0] *= 1.e-3;
+    primitive.v[1] *= 1.e-3;
+
+    const auto material = WeaklyCompressibleMaterialView{};
+
+    WeaklyCompressibleValueView conservative;
+    WeaklyCompressibleEOS::conservative_from_primitive<dim>(conservative, primitive, material);
+
+    const dealii::Tensor<1, dim + 2, double> expected{{3500., 35., 7., 1050000000.1819999}};
+
+    MeltPoolDG::TestUtils::expect_double_eq(conservative.density(), expected[0]);
+    MeltPoolDG::TestUtils::expect_double_eq(conservative.momentum(0), expected[1]);
+    MeltPoolDG::TestUtils::expect_double_eq(conservative.momentum(1), expected[2]);
+    MeltPoolDG::TestUtils::expect_near(conservative.total_energy(), expected[3], 1.e-14);
+  }
+
   // supports_eos / dispatch_eos
 
   struct IdealGasDerived
@@ -636,10 +823,11 @@ namespace
 
   struct AllEOSDerived
   {
-    static constexpr std::array<EquationOfState, 3> supported_eos = {
+    static constexpr std::array<EquationOfState, 4> supported_eos = {
       {EquationOfState::ideal_gas,
        EquationOfState::stiffened_gas,
-       EquationOfState::noble_abel_stiffened_gas}};
+       EquationOfState::noble_abel_stiffened_gas,
+       EquationOfState::weakly_compressible}};
   };
 
   TEST(DispatchEOSTest, SupportsEOS)
@@ -647,10 +835,12 @@ namespace
     EXPECT_TRUE((supports_eos<IdealGasDerived, EquationOfState::ideal_gas>()));
     EXPECT_FALSE((supports_eos<IdealGasDerived, EquationOfState::stiffened_gas>()));
     EXPECT_FALSE((supports_eos<IdealGasDerived, EquationOfState::noble_abel_stiffened_gas>()));
+    EXPECT_FALSE((supports_eos<IdealGasDerived, EquationOfState::weakly_compressible>()));
 
     EXPECT_TRUE((supports_eos<AllEOSDerived, EquationOfState::ideal_gas>()));
     EXPECT_TRUE((supports_eos<AllEOSDerived, EquationOfState::stiffened_gas>()));
     EXPECT_TRUE((supports_eos<AllEOSDerived, EquationOfState::noble_abel_stiffened_gas>()));
+    EXPECT_TRUE((supports_eos<AllEOSDerived, EquationOfState::weakly_compressible>()));
   }
 
   TEST(DispatchEOS, DispatchesIdealGas)
@@ -676,6 +866,16 @@ namespace
     const auto result =
       dispatch_eos<AllEOSDerived>(EquationOfState::noble_abel_stiffened_gas, [](auto eos) {
         return std::is_same_v<decltype(eos), NobleAbelStiffenedGasEOS>;
+      });
+
+    EXPECT_TRUE(result);
+  }
+
+  TEST(DispatchEOS, DispatchesWeaklyCompressible)
+  {
+    const auto result =
+      dispatch_eos<AllEOSDerived>(EquationOfState::weakly_compressible, [](auto eos) {
+        return std::is_same_v<decltype(eos), WeaklyCompressibleEOS>;
       });
 
     EXPECT_TRUE(result);

--- a/unit_tests/species_transport/state_views_mixins.cpp
+++ b/unit_tests/species_transport/state_views_mixins.cpp
@@ -69,7 +69,7 @@ namespace
     }
 
     double
-    specific_inner_energy() const
+    specific_internal_energy() const
     {
       return 100.0;
     }


### PR DESCRIPTION
<!-- Please, fill in the description as completely as possible.-->

<!-- Use Conventional Commits format for the commit message:
     <type>(optional scope): <description>

     Available types:
     - feat: introduces a new feature
     - fix: fixes a bug
     - refactor: code change without changing behavior
     - test: adds or updates tests
     - docs: documentation-only changes
     - style: formatting-only changes
     - perf: performance improvements
     - chore: maintenance work
     - bench: adds or updates benchmarks

     Example:
     feat(heat): add apparent capacity method
     - add apparent capacity formulation for latent heat treatment
     - add support for constant, poly4_bell, and qlq apparent-capacity models
     - add temperature derivatives for Newton linearization
-->

# Description
This PR adds the option to use the weakly compressible (or _linearized_ or _barotropic_) equation of state. Some theoretical background and the EOS-specific equations, that are implemented, are summarized in this document:
[weakly_compressible_eos.pdf](https://github.com/user-attachments/files/31941983/weakly_compressible_eos.pdf)



# How has this been tested?
The unit test `equation_of_state_01` was extended to test the new weakly compressible EOS functionalities as well.

# Screenshots (if appropriate)
<!-- Do you have any visual results from simulations that relate to this PR? -->

# Checklist (should be removed by the person who merges this PR)

- [x] The branch is rebased onto main
- [x] Code is formatted with format-all
- [x] Prefer a single commit with a meaningful commit message; if multiple commits are necessary, explain why in the PR description
- [x] Labels are applied
- [x] Co-Pilot review is requested
- [ ] Reviews are requested
- [ ] If this PR closes an issue or is related to a project, it is linked in the "Description" section
- [x] All in-code documentation related to this PR is up to date (Doxygen format)
- [x] Commit has unit test(s) (preferred) or application test(s)
- [ ] If the fix is temporary, an issue is opened where this PR is referenced
- [ ] A changelog entry is added for any notable change
