### PR TITLE
refactor(compressible multiphase): use mean velocity for level-set movement

### DIFF
--- a/include/meltpooldg/compressible_flow/multiphase_level_set_advection.hpp
+++ b/include/meltpooldg/compressible_flow/multiphase_level_set_advection.hpp
@@ -10,9 +10,13 @@
 #pragma once
 
 #include <deal.II/base/function.h>
+#include <deal.II/base/mpi.h>
 #include <deal.II/base/point.h>
+#include <deal.II/base/utilities.h>
 
 #include <deal.II/numerics/vector_tools_interpolate.h>
+
+#include <numeric>
 
 namespace MeltPoolDG::Multiphase
 {
@@ -122,8 +126,26 @@ namespace MeltPoolDG::Multiphase
       else if (case_name == "two_phase")
         {
           // one phase boundary
+
+          // TODO: This is a current work-around, since the level-set advection is not yet fully
+          // implemented. The mean value of the interface velocity is used to advect the level-set
+          // field. In the future, a full level-set advection should be implemented, which uses the
+          // full velocity field to advect the level-set field.
+          const number local_sum =
+            std::accumulate(interface_velocity.begin(), interface_velocity.end(), 0.);
+
+          const unsigned int local_size = interface_velocity.size();
+
+          const number global_sum =
+            dealii::Utilities::MPI::sum(local_sum, scratch_data->get_mpi_comm(level_set_dof_idx));
+
+          const unsigned int global_size =
+            dealii::Utilities::MPI::sum(local_size, scratch_data->get_mpi_comm(level_set_dof_idx));
+
+          const number velocity = global_sum / global_size;
+
           for (unsigned int i = 0; i < level_set.size(); i++)
-            level_set[i] += time_step * interface_velocity[0];
+            level_set[i] += time_step * velocity;
         }
       else
         AssertThrow(false,


### PR DESCRIPTION

<!-- Please, fill in the description as completely as possible.-->

<!-- Use Conventional Commits format for the commit message:
     <type>(optional scope): <description>

     Available types:
     - feat: introduces a new feature
     - fix: fixes a bug
     - refactor: code change without changing behavior
     - test: adds or updates tests
     - docs: documentation-only changes
     - style: formatting-only changes
     - perf: performance improvements
     - chore: maintenance work
     - bench: adds or updates benchmarks

     Example:
     feat(heat): add apparent capacity method
     - add apparent capacity formulation for latent heat treatment
     - add support for constant, poly4_bell, and qlq apparent-capacity models
     - add temperature derivatives for Newton linearization
-->

# Description
This PR corresponds to PR https://github.com/tum-sam/applications-dev/pull/8. As a workaround for the first multidimensional two-phase tests, we apply the strategy that the "advection per hand" is performed using the average velocity determined at the interface. This should, of course, be removed when the full level-set coupling is implemented.

# How has this been tested?
Corresponding tests are introduced in PR https://github.com/tum-sam/applications-dev/pull/8.

# Screenshots (if appropriate)
<img width="1100" height="900" alt="density_field" src="https://github.com/user-attachments/assets/d519ff64-2cf1-4af8-b672-7a766826fb98" />

# Checklist (should be removed by the person who merges this PR)

- [x] The branch is rebased onto main
- [x] Code is formatted with format-all
- [x] Prefer a single commit with a meaningful commit message; if multiple commits are necessary, explain why in the PR description
- [x] Labels are applied
- [ ] Co-Pilot review is requested
- [x] Reviews are requested
- [ ] If this PR closes an issue or is related to a project, it is linked in the "Description" section
- [x] All in-code documentation related to this PR is up to date (Doxygen format)
- [ ] Commit has unit test(s) (preferred) or application test(s)
- [ ] If the fix is temporary, an issue is opened where this PR is referenced
- [ ] A changelog entry is added for any notable change
